### PR TITLE
[LMMTM] Fix flaky tests for good

### DIFF
--- a/semantic_digital_twin/requirements.txt
+++ b/semantic_digital_twin/requirements.txt
@@ -32,4 +32,4 @@ pymysql
 pyglet == 1.5.31
 pycollada
 mujoco==3.3.5
-multiverse-simulators>=0.0.8
+multiverse-simulators>=0.0.9


### PR DESCRIPTION
I found out the bug, it turns out the function `mj_step` was called twice eventually in two threads concurrently, causing simulation to crash. That was from [multiverse_simulators](https://github.com/Multiverse-Framework/Multiverse-Simulators-Connector) and was fixed.