### PR TITLE
[Giskard] added @dataclass for EmptyMotionStatechartError

### DIFF
--- a/giskardpy/src/giskardpy/motion_statechart/exceptions.py
+++ b/giskardpy/src/giskardpy/motion_statechart/exceptions.py
@@ -31,6 +31,7 @@ class NodeInitializationError(MotionStatechartError):
         super().__post_init__()
 
 
+@dataclass
 class EmptyMotionStatechartError(MotionStatechartError):
     reason: str = field(default="MotionStatechart is empty.", init=False)
 


### PR DESCRIPTION
added missing `@dataclass` to EmptyMotionStatechartError.
Fixes an issue in giskardpy_ros tests.