### PR TITLE
Switch from python -m venv to virtualenvwrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,20 @@ To install the CRAM architecture, follow these steps:
 Setup the Python venvironment:
 
 ```bash
-python3 -m venv cram-env
-source cram-env/bin/activate
+sudo apt install -y virtualenv virtualenvwrapper && \
+grep -qxF 'export WORKON_HOME=$HOME/.virtualenvs' ~/.bashrc || echo 'export WORKON_HOME=$HOME/.virtualenvs' >> ~/.bashrc && \
+grep -qxF 'export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3' ~/.bashrc || echo 'export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3' >> ~/.bashrc && \
+grep -qxF 'source /usr/share/virtualenvwrapper/virtualenvwrapper.sh' ~/.bashrc || echo 'source /usr/share/virtualenvwrapper/virtualenvwrapper.sh' >> ~/.bashrc && \
+source ~/.bashrc && \
+mkvirtualenv cram-env
 ```
+Activate / deactivate
+
+```
+workon cram-env
+deactivate
+```
+
 
 We use poetry to manage dependencies. Install poetry if you haven't already:
 


### PR DESCRIPTION
The environment setup is migrated from a manually activated venv to virtualenvwrapper.
This change standardizes environment handling, improves usability, and avoids repeated shell-specific activation steps.
