### PR TITLE
added ros-jazzy-rclpy-message-converter  to dockerfile

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /opt/ros
 RUN apt update  \
-    && apt install python3.12-venv ros-jazzy-xacro python3-vcstool git ros-dev-tools default-jre graphviz graphviz-dev pip -y  \
+    && apt install python3.12-venv ros-jazzy-xacro python3-vcstool git ros-dev-tools default-jre graphviz graphviz-dev ros-jazzy-rclpy-message-converter pip -y  \
     && apt-get clean  \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We need to update the dockerfile to make https://github.com/cram2/cognitive_robot_abstract_machine/pull/112 work.
You can see it work on my fork: https://github.com/ichumuh/cognitive_robot_abstract_machine/actions/runs/20877119731

Unfortunately, this lib cannot be installed via pip and we are not a ros package with a package.xml. so i don't know what the best way is to tell ppl that they need to install it.
just put it in a readme?