### PR TITLE
[SemDT] added index to Body to_json/from_json

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
@@ -476,6 +476,7 @@ class Body(KinematicStructureEntity):
         result["collision"] = self.collision.to_json()
         result["visual"] = self.visual.to_json()
         result["collision_config"] = to_json(self.collision_config)
+        result["index"] = to_json(self.index)
         return result
 
     @classmethod
@@ -484,6 +485,8 @@ class Body(KinematicStructureEntity):
             name=PrefixedName.from_json(data["name"], **kwargs),
             id=from_json(data["id"]),
         )
+        result.index = from_json(data["index"])
+
         result._track_object_in_from_json(kwargs)
 
         collision = ShapeCollection.from_json(data["collision"], **kwargs)

--- a/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
@@ -33,6 +33,7 @@ from semantic_digital_twin.world_description.world_entity import Body
 
 
 def test_body_json_serialization():
+    world = World()
     body = Body(name=PrefixedName("body"))
     collision = [
         Box(origin=HomogeneousTransformationMatrix.from_xyz_rpy(0, 1, 0, 0, 0, 1, body))
@@ -43,8 +44,14 @@ def test_body_json_serialization():
     body.collision_config.buffer_zone_distance = 1.227
     body.collision_config.violated_distance = 0.23
 
+    with world.modify_world():
+        world.add_kinematic_structure_entity(body)
+    body_index = body.index
+
     json_data = body.to_json()
     body2 = Body.from_json(json_data)
+
+    assert body_index == body2.index
 
     for c1 in body.collision:
         for c2 in body2.collision:


### PR DESCRIPTION
Adjusted test_body_json_serialization to reflect faulty behavior with index, where the index of the Body gets lost in JSON.

The index becomes None after loading it from json.
For example `_compute_chain_of_kinematic_structure_entities_indexes` requires the index to be not None, otherwise it fails.