### PR TITLE
added specific room annotations

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/procthor/procthor_parser.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/procthor/procthor_parser.py
@@ -28,6 +28,10 @@ from ...semantic_annotations.semantic_annotations import (
     Hinge,
     DoubleDoor,
     Wall,
+    Kitchen,
+    Bedroom,
+    Bathroom,
+    LivingRoom,
 )
 from ...spatial_types.spatial_types import (
     HomogeneousTransformationMatrix,
@@ -503,7 +507,17 @@ class ProcthorRoom:
                 floor_polytope=self.centered_polytope,
                 world_root_T_self=self.world_T_room,
             )
-        room = Room(name=self.name, floor=floor)
+        if "Bedroom" in self.name.name:
+            room = Bedroom(name=self.name, floor=floor)
+        elif "LivingRoom" in self.name.name:
+            room = LivingRoom(name=self.name, floor=floor)
+        elif "Kitchen" in self.name.name:
+            room = Kitchen(name=self.name, floor=floor)
+        elif "Bathroom" in self.name.name:
+            room = Bathroom(name=self.name, floor=floor)
+        else:
+            assert_never(self.name.name)
+
         with world.modify_world():
             world.add_semantic_annotation(room)
 

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -1561,6 +1561,44 @@ class RevoluteConnectionDAO(
     }
 
 
+class DiffDriveDAO(
+    ActiveConnectionDAO,
+    DataAccessObject[semantic_digital_twin.world_description.connections.DiffDrive],
+):
+
+    __tablename__ = "DiffDriveDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(ActiveConnectionDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    x_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+    y_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+    roll_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+    pitch_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+    yaw_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+    x_velocity_id: Mapped[uuid.UUID] = mapped_column(
+        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "DiffDriveDAO",
+        "inherit_condition": database_id == ActiveConnectionDAO.database_id,
+    }
+
+
 class OmniDriveDAO(
     ActiveConnectionDAO,
     DataAccessObject[semantic_digital_twin.world_description.connections.OmniDrive],
@@ -4175,6 +4213,82 @@ class RoomDAO(
     __mapper_args__ = {
         "polymorphic_identity": "RoomDAO",
         "inherit_condition": database_id == SemanticAnnotationDAO.database_id,
+    }
+
+
+class BathroomDAO(
+    RoomDAO,
+    DataAccessObject[
+        semantic_digital_twin.semantic_annotations.semantic_annotations.Bathroom
+    ],
+):
+
+    __tablename__ = "BathroomDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(RoomDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "BathroomDAO",
+        "inherit_condition": database_id == RoomDAO.database_id,
+    }
+
+
+class BedroomDAO(
+    RoomDAO,
+    DataAccessObject[
+        semantic_digital_twin.semantic_annotations.semantic_annotations.Bedroom
+    ],
+):
+
+    __tablename__ = "BedroomDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(RoomDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "BedroomDAO",
+        "inherit_condition": database_id == RoomDAO.database_id,
+    }
+
+
+class KitchenDAO(
+    RoomDAO,
+    DataAccessObject[
+        semantic_digital_twin.semantic_annotations.semantic_annotations.Kitchen
+    ],
+):
+
+    __tablename__ = "KitchenDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(RoomDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "KitchenDAO",
+        "inherit_condition": database_id == RoomDAO.database_id,
+    }
+
+
+class LivingRoomDAO(
+    RoomDAO,
+    DataAccessObject[
+        semantic_digital_twin.semantic_annotations.semantic_annotations.LivingRoom
+    ],
+):
+
+    __tablename__ = "LivingRoomDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(RoomDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "LivingRoomDAO",
+        "inherit_condition": database_id == RoomDAO.database_id,
     }
 
 

--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/semantic_annotations.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/semantic_annotations.py
@@ -444,6 +444,22 @@ class Room(SemanticAnnotation):
 
 
 @dataclass(eq=False)
+class Kitchen(Room): ...
+
+
+@dataclass(eq=False)
+class Bedroom(Room): ...
+
+
+@dataclass(eq=False)
+class Bathroom(Room): ...
+
+
+@dataclass(eq=False)
+class LivingRoom(Room): ...
+
+
+@dataclass(eq=False)
 class Wall(HasApertures):
     """
     A wall is a physical entity that separates two spaces and can contain apertures. Doors are a computed property.

--- a/test/semantic_digital_twin_test/test_procthor/test_procthor.py
+++ b/test/semantic_digital_twin_test/test_procthor/test_procthor.py
@@ -364,7 +364,7 @@ class ProcTHORTestCase(unittest.TestCase):
                 resource_filename("semantic_digital_twin", "../../"),
                 "resources",
                 "procthor_json",
-                "house_987654321.json",
+                "house_0.json",
             )
         ).parse()
 


### PR DESCRIPTION
This pull request introduces semantic differentiation of room types in the ProcTHOR parser and extends the ORM and annotation layers to support specific room subclasses (Kitchen, Bedroom, Bathroom, LivingRoom).

**Semantic Room Type Support:**

* Added new semantic annotation classes: `Kitchen`, `Bedroom`, `Bathroom`, and `LivingRoom`, each inheriting from `Room` in `semantic_annotations.py`.
* Updated the ProcTHOR parser to instantiate the correct room subclass (`Kitchen`, `Bedroom`, `Bathroom`, `LivingRoom`) based on the room name, instead of always using the generic `Room` class. [[1]](diffhunk://#diff-390f571c8ba0114a4d1a2db188c8173e882808b50044b8199129b055bf244572R31-R34) [[2]](diffhunk://#diff-390f571c8ba0114a4d1a2db188c8173e882808b50044b8199129b055bf244572L506-R520)

**Testing:**

* Updated the test fixture in `test_procthor.py` to use `house_0.json` instead of `house_987654321.json`.