### PR TITLE
[EQL] order by not evalualted variable, needed by suturo.

### DIFF
--- a/krrood/src/krrood/entity_query_language/symbolic.py
+++ b/krrood/src/krrood/entity_query_language/symbolic.py
@@ -915,7 +915,7 @@ class QueryObjectDescriptor(SymbolicExpression[T], ABC):
 
     def order_by(
         self,
-        variable: Selectable,
+        variable: TypingUnion[Selectable[T], Any],
         descending: bool = False,
         key: Optional[Callable] = None,
     ) -> Self:
@@ -940,7 +940,11 @@ class QueryObjectDescriptor(SymbolicExpression[T], ABC):
         """
 
         def key(result: OperationResult) -> Any:
-            variable_value = result.bindings[self._order_by.variable._var_._id_]
+            var = self._order_by.variable
+            var_id = var._var_._id_
+            if var_id not in result:
+                result[var_id] = next(var._evaluate__(result.bindings, self)).value
+            variable_value = result.bindings[var_id]
             if self._order_by.key:
                 return self._order_by.key(variable_value)
             else:

--- a/test/krrood_test/test_eql/test_core/test_queries.py
+++ b/test/krrood_test/test_eql/test_core/test_queries.py
@@ -1007,3 +1007,9 @@ def test_multiple_dependent_selectables(handles_and_containers_world):
         (res[cabinet], res[cabinet_drawers])
         for res in cabinet_drawer_pairs_query.evaluate()
     } == set(cabinet_drawer_pairs_expected)
+
+
+def test_order_by_not_evaluated_variable(handles_and_containers_world):
+    body = variable(Body, domain=handles_and_containers_world.bodies)
+    query = an(entity(body).order_by(variable=body.name, descending=False))
+    assert list(query.evaluate()) == sorted(handles_and_containers_world.bodies, key=lambda b: b.name, reverse=False)


### PR DESCRIPTION
This pull request improves the `order_by` functionality in the symbolic query language by allowing ordering on variables that have not yet been evaluated and adds a corresponding test to ensure this behavior works correctly. The changes enhance flexibility and robustness in query ordering.

Enhancements to `order_by` functionality:

* Updated the `order_by` method in `symbolic.py` to accept variables of any type, not just `Selectable`, allowing for more flexible ordering criteria.
* Modified the `_order` method to evaluate and cache a variable's value if it hasn't been computed yet before using it for ordering, ensuring correct ordering even for unevaluated variables.

Testing improvements:

* Added a new test `test_order_by_not_evaluated_variable` to verify that queries can order by variables that have not yet been evaluated, increasing test coverage for this scenario.