### PR TITLE
Fix surface samples

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
@@ -702,8 +702,14 @@ class HasSupportingSurface(HasStorageSpace, ABC):
             ),
             points_3d=points_3d,
         )
+
+        supporting_surface_z_position = self.root.collision.scale.z / 2
         self_C_supporting_surface = FixedConnection(
-            parent=self.root, child=supporting_surface
+            parent=self.root,
+            child=supporting_surface,
+            parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(
+                z=supporting_surface_z_position, reference_frame=self.root
+            ),
         )
         self._world.add_region(supporting_surface)
         self._world.add_connection(self_C_supporting_surface)
@@ -766,7 +772,7 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         samples = surface_circuit.sample(amount)
         samples = samples[np.argsort(surface_circuit.log_likelihood(samples))[::-1]]
         samples = np.concatenate((samples, z_coordinate), axis=1)
-        return [Point3(*s, reference_frame=self.root) for s in samples]
+        return [Point3(*s, reference_frame=self.supporting_surface) for s in samples]
 
     def _build_surface_sampler(
         self,

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
@@ -535,6 +535,34 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(len(world.regions), 1)
         self.assertTrue(len(surface.area.combined_mesh.vertices) > 0)
 
+    def test_supporting_surface_position_on_top_of_table(self):
+        world = World()
+        root = Body(name=PrefixedName("root"))
+        with world.modify_world():
+            world.add_body(root)
+        with world.modify_world():
+            table = Table.create_with_new_body_in_world(
+                name=PrefixedName("table"),
+                world=world,
+                world_root_T_self=HomogeneousTransformationMatrix.from_xyz_rpy(z=1.5),
+            )
+        table_scale = Scale(1.0, 1.0, 0.5)
+        table.root.collision = BoundingBoxCollection.from_event(
+            table.root, table_scale.to_simple_event().as_composite_set()
+        ).as_shapes()
+        table.root.visual = table.root.collision
+
+        with world.modify_world():
+            surface = table.calculate_supporting_surface()
+
+        _, max_point = table.min_max_points
+        # supporting surface should be at the height of the table's global z + the max z of the table's bounding box (since the table's origin is at its center)
+        expected_z = table.root.global_pose.z + max_point.z
+
+        self.assertIsNotNone(surface)
+        self.assertEqual(surface, table.supporting_surface)
+        self.assertEqual(expected_z, surface.global_pose.z)
+
     def test_sample_points_from_surface(self):
         world = World()
         root = Body(name=PrefixedName("root"))

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
@@ -609,7 +609,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(len(points), 10)
 
         min_point, max_point = table.min_max_points
-        assert all(p.reference_frame == table.root for p in points)
+        assert all(p.reference_frame == table.supporting_surface for p in points)
         assert all(p.x >= min_point.x for p in points)
         assert all(p.x <= max_point.x for p in points)
         assert all(p.y >= min_point.y for p in points)
@@ -653,7 +653,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(len(points), 10)
 
         min_point, max_point = table.min_max_points
-        assert all(p.reference_frame == table.root for p in points)
+        assert all(p.reference_frame == table.supporting_surface for p in points)
         assert all(p.x >= min_point.x for p in points)
         assert all(p.x <= max_point.x for p in points)
         assert all(p.y >= min_point.y for p in points)
@@ -698,7 +698,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(len(points), 10)
 
         min_point, max_point = table.min_max_points
-        assert all(p.reference_frame == table.root for p in points)
+        assert all(p.reference_frame == table.supporting_surface for p in points)
         assert all(p.x >= min_point.x for p in points)
         assert all(p.x <= max_point.x for p in points)
         assert all(p.y >= min_point.y for p in points)

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_factories.py
@@ -571,7 +571,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(len(points), 10)
 
         min_point, max_point = table.min_max_points
-        assert all(p.reference_frame == table.root for p in points)
+        assert all(p.reference_frame == table.supporting_surface for p in points)
         assert all(p.x >= min_point.x for p in points)
         assert all(p.x <= max_point.x for p in points)
         assert all(p.y >= min_point.y for p in points)


### PR DESCRIPTION
The supporting surface was spawned at the origin of its parent body instead of on its surface.
As a result, the sampled points did not match expectations, since the supporting surface they were sampled from was not positioned correctly.

This fix spawns the supporting surface on the surface of its parent body. It also assigns the proper reference frame, as the sampling points are taken from the supporting surface rather than from the root of the parent body.