### PR TITLE
[EQL] fix doc mistakes and fix a bug in the refinement rule evaluation.

### DIFF
--- a/krrood/doc/eql/user/eql_for_sql_experts.md
+++ b/krrood/doc/eql/user/eql_for_sql_experts.md
@@ -43,8 +43,7 @@ query = entity(r.parts.name).where(
 
 ## Filter Early, Filter Late
 
-In SQL, all filtering happens in the `WHERE` or `HAVING` clause. EQL maintains this distinction but applies it to
-object grouping.
+In SQL, all filtering happens in the `WHERE` or `HAVING` clause. EQL also maintains this distinction.
 
 | SQL Clause | EQL Method      | Purpose                                        |
 |:-----------|:----------------|:-----------------------------------------------|

--- a/krrood/doc/eql/user/match.md
+++ b/krrood/doc/eql/user/match.md
@@ -56,7 +56,7 @@ fixed_connection = match_variable(FixedConnection, domain=world.connections)(
 
 ```{note}
 `match_variable` is syntactic sugar. Under the hood, it creates a {py:func}`~krrood.entity_query_language.factories.variable`,
- selects it using {py:meth}`~krrood.entity_query_language.factories.entity` and automatically adds the corresponding {py:meth}`~krrood.entity_query_language.query.query.Query.where` clauses.
+ selects it using {py:func}`~krrood.entity_query_language.factories.entity` and automatically adds the corresponding {py:meth}`~krrood.entity_query_language.query.query.Query.where` clauses.
 ```
 
 ## Full Example: Finding Connected Parts

--- a/krrood/doc/eql/user/match.md
+++ b/krrood/doc/eql/user/match.md
@@ -55,12 +55,8 @@ fixed_connection = match_variable(FixedConnection, domain=world.connections)(
 ```
 
 ```{note}
-`match_variable` is syntactic sugar. Under the hood, it creates a {py:func}`~krrood.entity_query_language.factories.variable`
-and automatically adds the corresponding {py:meth}`~krrood.entity_query_language.query.query.Query.where` clauses.
-```
-
-```{warning}
-Use `match_variable` instead of `variable` only when you have multiple attribute checks. For simple queries, `variable().where(...)` is often more readable.
+`match_variable` is syntactic sugar. Under the hood, it creates a {py:func}`~krrood.entity_query_language.factories.variable`,
+ selects it using {py:meth}`~krrood.entity_query_language.factories.entity` and automatically adds the corresponding {py:meth}`~krrood.entity_query_language.query.query.Query.where` clauses.
 ```
 
 ## Full Example: Finding Connected Parts

--- a/krrood/doc/eql/user/writing_rule_trees.md
+++ b/krrood/doc/eql/user/writing_rule_trees.md
@@ -1,4 +1,4 @@
-from krrood.entity_query_language.factories import inferencefrom probabilistic_model.scripts.nyga_speed_comparison import variable---
+---
 jupytext:
   text_representation:
     extension: .md
@@ -109,12 +109,12 @@ from krrood.entity_query_language.factories import (
 )
 
 @dataclass
-class ExampleConnection(Symbol):
+class ExampleConnection:
     type_code: int
     name: str
 
 @dataclass
-class ExampleView(Symbol):
+class ExampleView:
     connection: ExampleConnection
 
 @dataclass
@@ -124,29 +124,29 @@ class ExampleFixedView(ExampleView): pass
 class ExampleRevoluteView(ExampleView): pass
 
 # Data
-conns = [ExampleConnection(1, 'c1'), ExampleConnection(2, 'c2'), ExampleConnection(3, 'c3'), ExampleConnection(4, 'm4')]
-c = variable(ExampleConnection, domain=conns)
+connections = [ExampleConnection(1, 'c1'), ExampleConnection(2, 'c2'), ExampleConnection(3, 'c3'), ExampleConnection(4, 'm4')]
+connection = variable(ExampleConnection, domain=connections)
 view = deduced_variable(ExampleView)
 
 # 1. Base query
-query = entity(view).where(c.name.startswith('c'))
+query = entity(view).where(connection.name.startswith('c'))
 
 # 2. Rule Tree definition
 with query:
-    # Default case:
-    add(view, inference(ExampleView)(connection=c))
+    # Default case (when connection name starts with 'c'):
+    add(view, inference(ExampleView)(connection=connection))
     
-    # If type_code is 1, it's a ExampleFixedView
-    with refinement(c.type_code == 1):
-        add(view, inference(ExampleFixedView)(connection=c))
+    # If connection name starts with 'c' and type_code is 1, it's a ExampleFixedView
+    with refinement(connection.type_code == 1):
+        add(view, inference(ExampleFixedView)(connection=connection))
     
-    # Otherwise, if type_code is 2, it's a ExampleRevoluteView
-    with alternative(c.type_code == 2):
-        add(view, inference(ExampleRevoluteView)(connection=c))
+    # Otherwise, if connection name does not start with 'c' and the type_code is 4, it's a ExampleRevoluteView
+    with alternative(connection.type_code == 4):
+        add(view, inference(ExampleRevoluteView)(connection=connection))
 
 # 3. Execution
 results = query.tolist()
-print(f"Inferred {len(results)} views from {len(conns)} connections.")
+print(f"Inferred {len(results)} views from {len(connections)} connections.")
 print("\n".join([str(v) for v in results]))
 ```
 

--- a/krrood/src/krrood/entity_query_language/rules/conclusion_selector.py
+++ b/krrood/src/krrood/entity_query_language/rules/conclusion_selector.py
@@ -139,7 +139,7 @@ class Refinement(LogicalBinaryOperator, ConclusionSelector):
     def get_operation_result_and_clear_conclusion(
         self, result: OperationResult
     ) -> Iterable[OperationResult]:
-        self._is_false_ = result.is_false
+        self._is_false_ = result.operand is self.left and result.is_false
         if result.is_true:
             self._conclusions_.update(result.operand._conclusions_)
         yield OperationResult(result.bindings, self._is_false_, self, result)

--- a/test/krrood_test/dataset/eql_rule_tree_doc_example.py
+++ b/test/krrood_test/dataset/eql_rule_tree_doc_example.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass(unsafe_hash=True)
+class ExampleConnection:
+    type_code: int
+    name: str
+
+@dataclass(unsafe_hash=True)
+class ExampleView:
+    connection: ExampleConnection
+
+@dataclass(eq=False)
+class ExampleFixedView(ExampleView): pass
+
+@dataclass(eq=False)
+class ExampleRevoluteView(ExampleView): pass

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -456,6 +456,34 @@ class GenericClassDAO(
     }
 
 
+class GenericClass_floatDAO(
+    GenericClassDAO,
+    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
+):
+
+    __tablename__ = "GenericClass_floatDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GenericClassDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
+        use_existing_column=True
+    )
+
+    container: Mapped[typing.List[builtins.float]] = mapped_column(
+        JSON, nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GenericClass_floatDAO",
+        "inherit_condition": database_id == GenericClassDAO.database_id,
+    }
+
+
 class GenericClass_PositionDAO(
     GenericClassDAO,
     DataAccessObject[
@@ -501,34 +529,6 @@ class GenericClass_PositionDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "GenericClass_PositionDAO",
-        "inherit_condition": database_id == GenericClassDAO.database_id,
-    }
-
-
-class GenericClass_floatDAO(
-    GenericClassDAO,
-    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
-):
-
-    __tablename__ = "GenericClass_floatDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(GenericClassDAO.database_id),
-        primary_key=True,
-        use_existing_column=True,
-    )
-
-    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
-        use_existing_column=True
-    )
-
-    container: Mapped[typing.List[builtins.float]] = mapped_column(
-        JSON, nullable=False, use_existing_column=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "GenericClass_floatDAO",
         "inherit_condition": database_id == GenericClassDAO.database_id,
     }
 

--- a/test/krrood_test/test_eql/test_core/test_rules.py
+++ b/test/krrood_test/test_eql/test_core/test_rules.py
@@ -492,7 +492,5 @@ def test_doc_example(rule_tree_doc_example_connections, alternative_code,
 
     # 3. Execution
     results = query.tolist()
-    print(f"Inferred {len(results)} views from {len(rule_tree_doc_example_connections)} connections.")
-    print("\n".join([str(v) for v in results]))
     assert len(results) == len(result_set)
     assert set(results) == result_set

--- a/test/krrood_test/test_eql/test_core/test_rules.py
+++ b/test/krrood_test/test_eql/test_core/test_rules.py
@@ -1,4 +1,5 @@
-from krrood.entity_query_language.rules.conclusion import Add
+import pytest
+
 from krrood.entity_query_language.factories import (
     entity,
     variable,
@@ -8,10 +9,11 @@ from krrood.entity_query_language.factories import (
     refinement,
     alternative,
     next_rule,
-    deduced_variable,
+    deduced_variable, add,
 )
 from krrood.entity_query_language.predicate import HasType
-from krrood.entity_query_language.query_graph import QueryGraph
+from krrood.entity_query_language.rules.conclusion import Add
+from ...dataset.eql_rule_tree_doc_example import ExampleConnection, ExampleView, ExampleFixedView, ExampleRevoluteView
 from ...dataset.semantic_world_like_classes import (
     Container,
     Handle,
@@ -49,7 +51,7 @@ def test_generate_drawers_from_direct_condition(handles_and_containers_world):
     all_solutions = list(solutions_gen)
 
     assert (
-        len(all_solutions) == 2
+            len(all_solutions) == 2
     ), "Should generate components for two possible drawer."
     assert all(isinstance(d[drawers], Drawer) for d in all_solutions)
     assert all_solutions[0][drawers].handle.name == "Handle3"
@@ -80,7 +82,7 @@ def test_generate_drawers_from_query(handles_and_containers_world):
     all_solutions = list(solutions)
 
     assert (
-        len(all_solutions) == 2
+            len(all_solutions) == 2
     ), "Should generate components for two possible drawer."
     assert all(isinstance(d, Drawer) for d in all_solutions)
     assert all_solutions[0].handle.name == "Handle3"
@@ -140,8 +142,8 @@ def test_rule_tree_with_multiple_refinements(doors_and_drawers_world):
         with refinement(body.size > 1):
             Add(views, inference(Door)(handle=handle, body=body))
             with alternative(
-                body == revolute_connection.child,
-                container == revolute_connection.parent,
+                    body == revolute_connection.child,
+                    container == revolute_connection.parent,
             ):
                 Add(
                     views,
@@ -181,7 +183,7 @@ def test_rule_tree_with_an_alternative(doors_and_drawers_world):
     with query:
         Add(views, inference(Drawer)(handle=handle, container=body))
         with alternative(
-            body == revolute_connection.parent, handle == revolute_connection.child
+                body == revolute_connection.parent, handle == revolute_connection.child
         ):
             Add(views, inference(Door)(handle=handle, body=body))
 
@@ -223,14 +225,14 @@ def test_rule_tree_with_multiple_alternatives(doors_and_drawers_world):
     with query:
         Add(views, inference(Drawer)(handle=handle, container=body))
         with alternative(
-            revolute_connection.parent == body, revolute_connection.child == handle
+                revolute_connection.parent == body, revolute_connection.child == handle
         ):
             Add(views, inference(Door)(handle=handle, body=body))
         with alternative(
-            fixed_connection.parent == body,
-            fixed_connection.child == handle,
-            body == revolute_connection.child,
-            container == revolute_connection.parent,
+                fixed_connection.parent == body,
+                fixed_connection.child == handle,
+                body == revolute_connection.child,
+                container == revolute_connection.parent,
         ):
             Add(
                 views,
@@ -285,9 +287,9 @@ def test_rule_tree_with_multiple_alternatives_optimized(doors_and_drawers_world)
                 ),
             )
         with alternative(
-            fixed_connection,
-            fixed_connection.parent == revolute_connection.child,
-            HasType(revolute_connection.parent, Container),
+                fixed_connection,
+                fixed_connection.parent == revolute_connection.child,
+                HasType(revolute_connection.parent, Container),
         ):
             Add(
                 views,
@@ -338,15 +340,15 @@ def test_rule_tree_with_multiple_alternatives_better_rule_tree(doors_and_drawers
         with refinement(prismatic_connection.child == body):
             Add(views, inference(Drawer)(handle=handle, container=body))
             with alternative(
-                body == revolute_connection.child,
-                container == revolute_connection.parent,
+                    body == revolute_connection.child,
+                    container == revolute_connection.parent,
             ):
                 Add(
                     views,
                     inference(Wardrobe)(handle=handle, body=body, container=container),
                 )
         with alternative(
-            revolute_connection.parent == body, revolute_connection.child == handle
+                revolute_connection.parent == body, revolute_connection.child == handle
         ):
             Add(views, inference(Door)(handle=handle, body=body))
 
@@ -369,7 +371,7 @@ def test_rule_tree_with_multiple_alternatives_better_rule_tree(doors_and_drawers
 
 
 def test_rule_tree_with_multiple_alternatives_better_rule_tree_optimized(
-    doors_and_drawers_world,
+        doors_and_drawers_world,
 ):
     world = doors_and_drawers_world
     fixed_connection = variable(FixedConnection, domain=world.connections)
@@ -393,8 +395,8 @@ def test_rule_tree_with_multiple_alternatives_better_rule_tree_optimized(
                 ),
             )
             with alternative(
-                fixed_connection.parent == revolute_connection.child,
-                HasType(revolute_connection.parent, Container),
+                    fixed_connection.parent == revolute_connection.child,
+                    HasType(revolute_connection.parent, Container),
             ):
                 Add(
                     views,
@@ -452,3 +454,45 @@ def test_rule_with_grouped_by(inferred_cabinets_world):
     assert cabinets[1].container.name == "Container4"
     assert len(cabinets[1].drawers) == 1
     assert cabinets[1].drawers[0].handle.name == "Handle3"
+
+
+@pytest.fixture
+def rule_tree_doc_example_connections():
+    return [ExampleConnection(1, 'c1'), ExampleConnection(2, 'c2'), ExampleConnection(3, 'c3'),
+             ExampleConnection(4, 'm4')]
+
+
+@pytest.mark.parametrize(["alternative_code", "result_set"],
+                         [(2, og_set := {ExampleFixedView(ExampleConnection(1, 'c1')),
+                                         ExampleView(ExampleConnection(2, 'c2')),
+                                         ExampleView(ExampleConnection(3, 'c3'))}),
+                          (4,
+                           og_set | {ExampleRevoluteView(ExampleConnection(4, 'm4'))})
+                          ])
+def test_doc_example(rule_tree_doc_example_connections, alternative_code,
+                     result_set):
+    c = variable(ExampleConnection, domain=rule_tree_doc_example_connections)
+    view = deduced_variable(ExampleView)
+
+    # 1. Base query
+    query = entity(view).where(c.name.startswith('c'))
+
+    # 2. Rule Tree definition
+    with query:
+        # Default case:
+        add(view, inference(ExampleView)(connection=c))
+
+        # If type_code is 1, it's a ExampleFixedView
+        with refinement(c.type_code == 1):
+            add(view, inference(ExampleFixedView)(connection=c))
+
+        # Otherwise, if type_code is 'alternative_code`, it's a ExampleRevoluteView
+        with alternative(c.type_code == alternative_code):
+            add(view, inference(ExampleRevoluteView)(connection=c))
+
+    # 3. Execution
+    results = query.tolist()
+    print(f"Inferred {len(results)} views from {len(rule_tree_doc_example_connections)} connections.")
+    print("\n".join([str(v) for v in results]))
+    assert len(results) == len(result_set)
+    assert set(results) == result_set


### PR DESCRIPTION
This pull request makes several improvements and corrections to the EQL documentation, example code, and tests, focusing on the clarity and accuracy of rule tree examples and their corresponding test coverage. The main changes include refactoring and fixing the example in the `writing_rule_trees.md` documentation, adding a corresponding test, and making minor clarifications and bug fixes in related files.

**Documentation and Example Improvements:**

* Refactored the example in `writing_rule_trees.md` to use clearer variable names (`connections`, `connection`), removed unnecessary inheritance from `Symbol`, and clarified the logic for rule tree alternatives and refinements. The example now more accurately reflects the intended logic and improves readability. [[1]](diffhunk://#diff-f4683a72b136f70dda7f522e6937196e0a87e50e6d72a6bc8fcc400464b5b9ffL1-R1) [[2]](diffhunk://#diff-f4683a72b136f70dda7f522e6937196e0a87e50e6d72a6bc8fcc400464b5b9ffL112-R117) [[3]](diffhunk://#diff-f4683a72b136f70dda7f522e6937196e0a87e50e6d72a6bc8fcc400464b5b9ffL127-R149)

* Updated documentation in `match.md` and `eql_for_sql_experts.md` to clarify the behavior of `match_variable` and the SQL/EQL filtering distinction. [[1]](diffhunk://#diff-c6ac4f1d733e2ec1344a6456417ee697c2e9e98fcbfc8176d157fa5549361c07L58-R59) [[2]](diffhunk://#diff-ed68caeb81b24282c6a68925dbb00802a34f3d6a20bb7fac44b6a758a1b5cb1cL46-R46)

**Testing Enhancements:**

* Added a new test module (`eql_rule_tree_doc_example.py`) containing dataclasses for the rule tree documentation example, ensuring the example is tested and remains in sync with the documentation.

* Added a new parameterized test in `test_rules.py` that exercises the documented rule tree example, verifying the correct inference of view types based on connection attributes.

**Code Quality and Bug Fixes:**

* Fixed a logic bug in `conclusion_selector.py` where the `_is_false_` flag is now set only when the result operand matches the left operand, ensuring correct rule evaluation.

**Test Infrastructure:**

* Minor import and fixture refactoring in `test_rules.py` to support the new tests and improve clarity. [[1]](diffhunk://#diff-25ea6be8f1bcd946bd6f952f31dead8f9a3109cebe9e2ca8d2eb8edefcc97745L1-R2) [[2]](diffhunk://#diff-25ea6be8f1bcd946bd6f952f31dead8f9a3109cebe9e2ca8d2eb8edefcc97745L11-R16)

**Other:**

* Removed a duplicate or misplaced `GenericClass_floatDAO` class from `ormatic_interface.py` to avoid redundancy. [[1]](diffhunk://#diff-05ee82abefc36cede7a5e6eb5f1557cb911d45622e6ee88a4645aec595b57cf3R459-R486) [[2]](diffhunk://#diff-05ee82abefc36cede7a5e6eb5f1557cb911d45622e6ee88a4645aec595b57cf3L508-L535)