### PR TITLE
[PYCRAM] fix pycram examples

### DIFF
--- a/pycram/examples/action_designator.md
+++ b/pycram/examples/action_designator.md
@@ -64,8 +64,6 @@ world = setup_world()
 pr2_view = PR2.from_world(world)
 
 context = Context(world, pr2_view)
-
-
 ```
 
 To move the robot we need to create a description which will be resolved to the actual designator. The description of navigation
@@ -77,7 +75,7 @@ from pycram.robot_plans import NavigateActionDescription
 from pycram.datastructures.pose import PoseStamped
 from pycram.language import SequentialPlan
 
-pose = PoseStamped.from_list([1.3, 2, 0], [0, 0, 0, 1])
+pose = PoseStamped.from_list([1.3, 2, 0], [0, 0, 0, 1], world.root)
 
 # This is the Designator Description
 navigate_description = NavigateActionDescription(target_location=[pose])
@@ -93,30 +91,30 @@ description.
 To execute the created plan just call perform on it. 
 
 ```python
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 
 with simulated_robot:
     plan.perform()
 ```
 
 Every designator that is performed needs to be in an environment that specifies where to perform the designator either
-on the real robot or the simulated one. This environment is called {meth}`~pycram.process_module.simulated_robot`  similar there is also
-a {meth}`~pycram.process_module.real_robot` environment.
+on the real robot or the simulated one. This environment is called {meth}`~pycram.motion_executor.simulated_robot`  similar there is also
+a {meth}`~pycram.motion_executor.real_robot` environment.
 
-There are also decorators which do the same thing but for whole methods, they are called {meth}`~pycram.process_module.with_real_robot` 
-and {meth}`~pycram.process_module.with_simulated_robot`.
+There are also decorators which do the same thing but for whole methods, they are called {meth}`~pycram.motion_executor.with_real_robot` 
+and {meth}`~pycram.motion_executor.with_simulated_robot`.
 
 ## Move Torso
 
 This action designator moves the torso up or down, specifically it sets the torso joint to a given value.
 
 We start again by creating a description and resolving it to a designator. Afterwards, the designator is performed in
-a {meth}`~pycram.process_module.simulated_robot` environment.
+a {meth}`~pycram.motion_executor.simulated_robot` environment.
 
 ```python
 from pycram.robot_plans import MoveTorsoActionDescription
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import TorsoState
+from pycram.motion_executor import simulated_robot
+from semantic_digital_twin.datastructures.definitions import TorsoState
 from pycram.language import SequentialPlan
 
 torso_pose = TorsoState.HIGH
@@ -137,8 +135,9 @@ The procedure is similar to the last time, but this time we will shorten it a bi
 
 ```python
 from pycram.robot_plans import SetGripperActionDescription
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import GripperState, Arms
+from pycram.motion_executor import simulated_robot
+from pycram.datastructures.enums import Arms
+from semantic_digital_twin.datastructures.definitions import GripperState
 from pycram.language import SequentialPlan
 
 gripper = Arms.RIGHT
@@ -154,7 +153,7 @@ Park arms is used to move one or both arms into the default parking position.
 
 ```python
 from pycram.robot_plans import ParkArmsActionDescription
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.enums import Arms
 from pycram.language import SequentialPlan
 
@@ -174,13 +173,16 @@ To start we need an environment in which we can pick up and place things as well
 
 ```python
 from pycram.robot_plans import PickUpActionDescription, PlaceActionDescription, ParkArmsActionDescription, MoveTorsoActionDescription, NavigateActionDescription
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import Arms, ApproachDirection, TorsoState, VerticalAlignment
+from pycram.motion_executor import simulated_robot
+from pycram.datastructures.enums import Arms, ApproachDirection, VerticalAlignment
+from semantic_digital_twin.datastructures.definitions import TorsoState
 from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.grasp import GraspDescription
 from pycram.language import SequentialPlan
+from pycram.view_manager import ViewManager
 
 arm = Arms.RIGHT
+manipulator = ViewManager.get_arm_view(arm, pr2_view).manipulator
 
 with simulated_robot:
     SequentialPlan(context,
@@ -189,15 +191,15 @@ with simulated_robot:
         MoveTorsoActionDescription([TorsoState.HIGH]),
     
         NavigateActionDescription([PoseStamped.from_list([1.8, 2.2, 0.0],
-                                                         [0.0, 0.0, 0., 1])]),
+                                                         [0.0, 0.0, 0., 1], world.root)]),
     
         PickUpActionDescription(object_designator=world.get_body_by_name("milk.stl"),
                                 arm=[arm],
-                                grasp_description= GraspDescription(ApproachDirection.FRONT, VerticalAlignment.NoAlignment, False)),
+                                grasp_description= GraspDescription(ApproachDirection.FRONT, VerticalAlignment.NoAlignment, manipulator)),
     
         PlaceActionDescription(object_designator=world.get_body_by_name("milk.stl"),
                                target_location=[PoseStamped.from_list([2.4, 1.8, 1],
-                                                                      [0, 0, 0, 1], world.root)],
+                                                                      [0, 0, 0, 1])],
                                arm=arm)).perform()
 ```
 
@@ -208,7 +210,7 @@ Look at lets the robot look at a specific point, for example if it should look a
 
 ```python
 from pycram.robot_plans import LookAtActionDescription
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.pose import PoseStamped
 
 target_location = PoseStamped.from_list([3, 2, 1], [0, 0, 0, 1], world.root)
@@ -227,7 +229,7 @@ designator will return a resolved instance of an ObjectDesignatorDescription.
 # from pycram.robot_plans import DetectActionDescription, LookAtActionDescription, ParkArmsActionDescription, NavigateActionDescription
 # from pycram.designators.object_designator import BelieveObject
 # from pycram.datastructures.enums import Arms
-# from pycram.process_module import simulated_robot
+# from pycram.motion_executor import simulated_robot
 # from pycram.datastructures.pose import PoseStamped
 # from pycram.datastructures.enums import DetectionTechnique
 # 
@@ -256,9 +258,10 @@ don't need to do this if you already have spawned it in a previous example.
 ```python
 from pycram.robot_plans import *
 from pycram.designators.object_designator import *
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.pose import PoseStamped
-from pycram.datastructures.enums import Arms, TorsoState
+from pycram.datastructures.enums import Arms
+from semantic_digital_twin.datastructures.definitions import TorsoState
 
 
 description = TransportActionDescription(world.get_body_by_name("milk.stl"),
@@ -282,8 +285,9 @@ apartment.
 ```python
 from pycram.robot_plans import *
 from pycram.designators.object_designator import *
-from pycram.datastructures.enums import Arms, TorsoState
-from pycram.process_module import simulated_robot
+from pycram.datastructures.enums import Arms
+from semantic_digital_twin.datastructures.definitions import TorsoState
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.pose import PoseStamped
 
 
@@ -292,7 +296,7 @@ with simulated_robot:
         MoveTorsoActionDescription([TorsoState.HIGH]),
         ParkArmsActionDescription([Arms.BOTH]),
         NavigateActionDescription([PoseStamped.from_list([1.7474915981292725, 2.6873629093170166, 0.0],
-                                               [-0.0, 0.0, 0.5253598267689507, -0.850880163370435])]),
+                                               [-0.0, 0.0, 0.5253598267689507, -0.850880163370435], world.root)]),
         OpenActionDescription(world.get_body_by_name("handle_cab10_t"), [Arms.RIGHT])).perform()
 ```
 
@@ -308,7 +312,7 @@ the apartment. Additionally, we open the drawer such that we can close it with t
 from pycram.robot_plans import *
 from pycram.designators.object_designator import *
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.pose import PoseStamped
 
 with simulated_robot:
@@ -316,6 +320,6 @@ with simulated_robot:
         MoveTorsoActionDescription([TorsoState.HIGH]),
         ParkArmsActionDescription([Arms.BOTH]),
         NavigateActionDescription([PoseStamped.from_list([1.7474915981292725, 2.6873629093170166, 0.0],
-                                               [-0.0, 0.0, 0.5253598267689507, -0.850880163370435])]),
+                                               [-0.0, 0.0, 0.5253598267689507, -0.850880163370435], world.root)]),
         CloseActionDescription(world.get_body_by_name("handle_cab10_t"), [Arms.RIGHT])).perform()
 ```

--- a/pycram/examples/language.md
+++ b/pycram/examples/language.md
@@ -3,7 +3,7 @@ jupyter:
   jupytext:
     text_representation:
       extension: .md
-      format_name: myst
+      format_name: markdown
       format_version: '1.3'
       jupytext_version: 1.16.3
   kernelspec:
@@ -66,7 +66,7 @@ from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
 from pycram.language import SequentialPlan
 
-navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0]))
+navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0], frame=world.root))
 park = ParkArmsActionDescription([Arms.BOTH])
 
 plan = SequentialPlan(context, navigate, park)
@@ -86,7 +86,7 @@ The plan can be executed by wrapping it inside a ```with simulated_robot``` envi
 plan.
 
 ```python
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 
 with simulated_robot:
     plan.perform()
@@ -104,7 +104,7 @@ Besides the described difference in behaviour this language expression can be us
 from pycram.robot_plans import *
 from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import TryAllPLan
 
 navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0]))
@@ -141,10 +141,10 @@ Using the parallel expressions works like Sequential and TryInOrder.
 from pycram.robot_plans import *
 from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import ParallelPlan
 
-navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0]))
+navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0], frame=world.root))
 park = ParkArmsActionDescription([Arms.BOTH])
 
 plan = ParallelPlan(context, navigate, park)
@@ -164,10 +164,10 @@ TryAll can be used like any other language expression.
 from pycram.robot_plans import *
 from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import TryAllPLan
 
-navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0]))
+navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0], frame=world.root))
 park = ParkArmsActionDescription([Arms.BOTH])
 
 plan = TryAllPLan(context, navigate, park)
@@ -192,10 +192,10 @@ with Sequential. You can try this yourself in the following cell.
 from pycram.robot_plans import *
 from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import SequentialPlan, ParallelPlan
 
-navigate = NavigateActionDescription([PoseStamped.from_list([1, 1, 0])])
+navigate = NavigateActionDescription([PoseStamped.from_list([1, 1, 0], frame=world.root)])
 park = ParkArmsActionDescription([Arms.BOTH])
 move_torso = MoveTorsoActionDescription([TorsoState.HIGH])
 
@@ -219,7 +219,7 @@ other parts of the plan.
 ```python
 from pycram.robot_plans import *
 from pycram.datastructures.enums import Arms
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import CodePlan, ParallelPlan
 
 
@@ -245,7 +245,7 @@ will be caught and saved to a dictionary. In general all designators in a langua
 of exceptions raised, the only exception from this is the Sequential expression which stops after it encountered an
 exception.
 
-The language will only catch exceptions that are of type {class}`~pycram.plan_failures.PlanFailure` meaning errors that are defined in
+The language will only catch exceptions that are of type `PlanFailure` meaning errors that are defined in
 plan_failures.py in PyCRAM. This also means normal Python errors, such as KeyError, will interrupt the execution of your
 designators.
 
@@ -253,7 +253,7 @@ We will see how exceptions are handled at a simple example.
 
 ```python
 from pycram.robot_plans import *
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import CodePlan, ParallelPlan
 from pycram.failures import PlanFailure
 
@@ -262,7 +262,7 @@ def code_test():
     raise PlanFailure
 
 
-navigate = NavigateActionDescription([PoseStamped.from_list([1, 1, 0])])
+navigate = NavigateActionDescription([PoseStamped.from_list([1, 1, 0], frame=world.root)])
 code_func = CodePlan(context, code_test)
 
 plan = ParallelPlan(context, navigate, code_func)
@@ -285,8 +285,8 @@ You can see an example of how to use Repeat below.
 
 ```python
 from pycram.robot_plans import *
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import TorsoState
+from pycram.motion_executor import simulated_robot
+from semantic_digital_twin.datastructures.definitions import TorsoState
 from pycram.language import SequentialPlan, RepeatPlan
 
 move_torso_up = MoveTorsoActionDescription([TorsoState.HIGH, TorsoState.MID, TorsoState.LOW])
@@ -311,10 +311,10 @@ Monitor to interrupt the execution after 2 seconds instead of executing the whol
 
 ```python
 from pycram.robot_plans import *
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import MonitorPlan, RepeatPlan, SequentialPlan
 import time
-from pycram.datastructures.enums import TorsoState
+from semantic_digital_twin.datastructures.definitions import TorsoState
 
 move_torso_up = MoveTorsoActionDescription([TorsoState.HIGH, TorsoState.MID, TorsoState.LOW])
 move_torso_down = MoveTorsoActionDescription([TorsoState.LOW, TorsoState.MID, TorsoState.HIGH])
@@ -338,9 +338,9 @@ If the `behavior` is set to `resume`, the plan will be launched in a paused stat
 
 ```python
 from pycram.robot_plans.actions.core import MoveTorsoActionDescription
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import MonitorPlan, RepeatPlan, SequentialPlan
-from pycram.datastructures.enums import TorsoState
+from semantic_digital_twin.datastructures.definitions import TorsoState
 import time
 
 def monitor_func():

--- a/pycram/examples/location_designator.md
+++ b/pycram/examples/location_designator.md
@@ -48,7 +48,7 @@ pr2_view = PR2.from_world(world)
 context = Context(world, pr2_view)
 ```
 
-Next up we will create the location designator description, the {meth}`~pycram.designators.location_designator.CostmapLocation` that we will be using needs a
+Next up we will create the location designator description, the `CostmapLocation` that we will be using needs a
 target as a parameter. This target describes what the location designator is for, this could either be a pose or object
 that the robot should be able to see or reach.
 
@@ -81,7 +81,7 @@ Since a robot is needed we will use the PR2 and use a milk as a target point for
 PR2 will be set to 0.2 since otherwise the arms of the robot will be too low to reach on the countertop.
 
 ```python
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import SequentialPlan
 from pycram.robot_plans.actions import ParkArmsActionDescription, MoveTorsoActionDescription
 from pycram.datastructures.enums import Arms, TorsoState

--- a/pycram/examples/motion_designator.md
+++ b/pycram/examples/motion_designator.md
@@ -1,4 +1,4 @@
-from pycram.language import SequentialPlan---
+---
 jupyter:
   jupytext:
     text_representation:
@@ -43,7 +43,7 @@ designator.
 ```python
 from pycram.datastructures.pose import PoseStamped
 from pycram.robot_plans.motions import MoveMotion
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.language import SequentialPlan
 
 with simulated_robot:
@@ -59,7 +59,7 @@ Like any designator we start by creating a description and then resolving and pe
 
 ```python
 from pycram.robot_plans.motions import MoveTCPMotion
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.datastructures.enums import Arms
 
 with simulated_robot:
@@ -75,10 +75,10 @@ motion designator takes the target as position and orientation, in reality only 
 
 ```python
 from pycram.robot_plans.motions import LookingMotion
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 
 with simulated_robot:
-    motion_description = LookingMotion(target=PoseStamped.from_list([1, 1, 1], [0, 0, 0, 1], world.root))
+    motion_description = LookingMotion(target=PoseStamped.from_list([1, 1, 1], [0, 0, 0, 1]), camera=pr2_view.get_default_camera())
 
     SequentialPlan(context, motion_description).perform()
 ```
@@ -90,8 +90,9 @@ and close the gripper respectively.
 
 ```python
 from pycram.robot_plans.motions import MoveGripperMotion
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import Arms, GripperState
+from pycram.motion_executor import simulated_robot
+from pycram.datastructures.enums import Arms
+from semantic_digital_twin.datastructures.definitions import GripperState
 
 with simulated_robot:
     motion_description = MoveGripperMotion(motion=GripperState.OPEN, gripper=Arms.LEFT)
@@ -110,7 +111,7 @@ Since we need an object that we can detect, we will spawn a milk for this.
 
 ```python
 # from pycram.robot_plans.motions import DetectingMotion, LookingMotion
-# from pycram.process_module import simulated_robot
+# from pycram.motion_executor import simulated_robot
 # from pycram.datastructures.pose import PoseStamped
 # from pycram.datastructures.enums import DetectionTechnique, DetectionState
 # from pycram.designators.object_designator import BelieveObject
@@ -134,11 +135,11 @@ This motion designator moves one or both arms. Movement targets are a dictionary
 as value.
 
 ```python
-from pycram.robot_plans.motions import MoveArmJointsMotion
-from pycram.process_module import simulated_robot
+from pycram.robot_plans.motions import MoveJointsMotion
+from pycram.motion_executor import simulated_robot
 
 with simulated_robot:
-    motion_description = MoveArmJointsMotion(right_arm_poses={"r_shoulder_pan_joint": -0.7})
+    motion_description = MoveJointsMotion(names=["r_shoulder_pan_joint"], positions=[-0.7])
 
     SequentialPlan(context, motion_description).perform()
 ```
@@ -150,7 +151,7 @@ the names of all joints that should be moved and the second list are the positio
 
 ```python
 from pycram.robot_plans.motions import MoveJointsMotion
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 
 with simulated_robot:
     motion_description = MoveJointsMotion(names=["torso_lift_joint", "r_shoulder_pan_joint"], positions=[0.2, -1.2])

--- a/pycram/examples/orm_example.md
+++ b/pycram/examples/orm_example.md
@@ -1,4 +1,4 @@
-from pycram.orm.ormatic_interface import ResolvedActionNodeMappingDAOfrom pycram.orm.model import ResolvedActionNodeMapping---
+---
 jupyter:
   jupytext:
     text_representation:
@@ -40,26 +40,29 @@ Next, we will write a simple plan where the robot parks its arms, moves somewher
 ```python
 from pycram.robot_plans import *
 from pycram.designators.location_designator import *
-from pycram.process_module import simulated_robot
-from pycram.datastructures.enums import Arms, ObjectType, Grasp, WorldMode, TorsoState
+from pycram.motion_executor import simulated_robot
+from pycram.datastructures.enums import Arms, Grasp
+from semantic_digital_twin.datastructures.definitions import TorsoState
 from pycram.designators.object_designator import *
 from pycram.datastructures.pose import PoseStamped
 from pycram.language import SequentialPlan
 from pycram.testing import setup_world
 from semantic_digital_twin.robots.pr2 import PR2
 from pycram.datastructures.dataclasses import Context
+from pycram.view_manager import ViewManager
 
 world = setup_world()
 pr2_view = PR2.from_world(world)
 context = Context(world, pr2_view)
+manipulator = ViewManager.get_arm_view(Arms.LEFT, pr2_view).manipulator
 
 with simulated_robot:
     sp = SequentialPlan(context,
-        NavigateActionDescription(PoseStamped.from_list([0.6, 0.4, 0], [0, 0, 0, 1]), True),
+        NavigateActionDescription(PoseStamped.from_list([0.6, 0.4, 0], [0, 0, 0, 1], world.root), True),
         ParkArmsActionDescription(Arms.BOTH),
-        PickUpActionDescription(world.get_body_by_name("milk.stl"), Arms.LEFT, GraspDescription(ApproachDirection.FRONT, VerticalAlignment.NoAlignment, False)),
+        PickUpActionDescription(world.get_body_by_name("milk.stl"), Arms.LEFT, GraspDescription(ApproachDirection.FRONT, VerticalAlignment.NoAlignment, manipulator)),
         NavigateActionDescription(PoseStamped.from_list([1.3, 1, 0.], [0, 0, 0, 1], world.root), True),
-        PlaceActionDescription(world.get_body_by_name("milk.stl"), PoseStamped.from_list([2.0, 1.6, 0.9], [0, 0, 0, 1], world.root),
+        PlaceActionDescription(world.get_body_by_name("milk.stl"), PoseStamped.from_list([2.0, 1.6, 0.9], [0, 0, 0, 1]),
                                Arms.LEFT))
     sp.perform()
 ```

--- a/pycram/examples/plan.md
+++ b/pycram/examples/plan.md
@@ -25,7 +25,7 @@ need a language expression.
 # Setup a World 
 
 ```python
-from pycram.process_module import simulated_robot
+from pycram.motion_executor import simulated_robot
 from pycram.testing import setup_world
 from pycram.datastructures.dataclasses import Context
 from semantic_digital_twin.robots.pr2 import PR2
@@ -46,7 +46,7 @@ from pycram.datastructures.pose import PoseStamped
 from pycram.datastructures.enums import Arms
 from pycram.language import SequentialPlan
 
-navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0]))
+navigate = NavigateActionDescription(PoseStamped.from_list([1, 1, 0], frame=world.root))
 park = ParkArmsActionDescription([Arms.BOTH])
 
 plan = SequentialPlan(context, navigate, park)
@@ -76,7 +76,6 @@ Now let's take a look at the arguments of the plan we just created.
 ```python
 print(plan.root.status)
 print(plan.root.start_time)
-print(plan.root.execute)
 ```
 
 ## Plan Execution

--- a/semantic_digital_twin/resources/collision_configs/pr2.srdf
+++ b/semantic_digital_twin/resources/collision_configs/pr2.srdf
@@ -14,15 +14,12 @@
   <disable_all_collisions link="fr_caster_rotation_link"/>
   <disable_all_collisions link="l_elbow_flex_link"/>
   <disable_all_collisions link="l_forearm_roll_link"/>
-  <disable_all_collisions link="l_torso_lift_side_item_profile_link"/>
   <disable_all_collisions link="l_upper_arm_roll_link"/>
   <disable_all_collisions link="l_wrist_flex_link"/>
   <disable_all_collisions link="l_wrist_roll_link"/>
   <disable_all_collisions link="laser_tilt_mount_link"/>
-  <disable_all_collisions link="m_torso_lift_side_item_profile_link"/>
   <disable_all_collisions link="r_elbow_flex_link"/>
   <disable_all_collisions link="r_forearm_roll_link"/>
-  <disable_all_collisions link="r_torso_lift_side_item_profile_link"/>
   <disable_all_collisions link="r_upper_arm_roll_link"/>
   <disable_all_collisions link="r_wrist_flex_link"/>
   <disable_all_collisions link="r_wrist_roll_link"/>
@@ -40,12 +37,10 @@
   <disable_self_collision link1="base_bellow_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_gripper_l_finger_link" reason="Unknown"/>
@@ -55,13 +50,11 @@
   <disable_self_collision link1="base_bellow_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -72,12 +65,10 @@
   <disable_self_collision link1="base_bellow_link" link2="r_gripper_r_finger_tip_link" reason="Unknown"/>
   <disable_self_collision link1="base_bellow_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="base_bellow_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_bellow_link" link2="torso_lift_link" reason="Default"/>
   <disable_self_collision link1="base_link" link2="base_link" reason="Adjacent"/>
   <disable_self_collision link1="base_link" link2="bl_caster_l_wheel_link" reason="Default"/>
@@ -92,28 +83,22 @@
   <disable_self_collision link1="base_link" link2="fr_caster_l_wheel_link" reason="Default"/>
   <disable_self_collision link1="base_link" link2="fr_caster_r_wheel_link" reason="Default"/>
   <disable_self_collision link1="base_link" link2="fr_caster_rotation_link" reason="Default"/>
-  <disable_self_collision link1="base_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="base_link" link2="l_force_torque_link" reason="Unknown"/>
   <disable_self_collision link1="base_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="base_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="base_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="base_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="base_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="base_link" link2="torso_lift_link" reason="Default"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="bl_caster_l_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="bl_caster_r_wheel_link" reason="Never"/>
@@ -127,24 +112,20 @@
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -155,12 +136,10 @@
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_l_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_l_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="bl_caster_r_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="bl_caster_rotation_link" reason="AlmostAlways"/>
@@ -173,12 +152,10 @@
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_gripper_palm_link" reason="Never"/>
@@ -186,13 +163,11 @@
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -203,12 +178,10 @@
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_r_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_r_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="bl_caster_rotation_link" reason="Adjacent"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="br_caster_l_wheel_link" reason="Never"/>
@@ -220,7 +193,6 @@
   <disable_self_collision link1="bl_caster_rotation_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_rotation_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="head_tilt_link" reason="Never"/>
@@ -228,12 +200,10 @@
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_rotation_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_rotation_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -244,12 +214,10 @@
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_rotation_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="bl_caster_rotation_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="bl_caster_rotation_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="br_caster_l_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="br_caster_r_wheel_link" reason="Never"/>
@@ -260,12 +228,10 @@
   <disable_self_collision link1="br_caster_l_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -275,13 +241,11 @@
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -292,12 +256,10 @@
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_l_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_l_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="br_caster_r_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="br_caster_rotation_link" reason="AlmostAlways"/>
@@ -307,12 +269,10 @@
   <disable_self_collision link1="br_caster_r_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -322,13 +282,11 @@
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -339,12 +297,10 @@
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_r_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_r_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="br_caster_rotation_link" reason="Adjacent"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="fl_caster_l_wheel_link" reason="Never"/>
@@ -353,12 +309,10 @@
   <disable_self_collision link1="br_caster_rotation_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -368,21 +322,17 @@
   <disable_self_collision link1="br_caster_rotation_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="br_caster_rotation_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="br_caster_rotation_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="fl_caster_l_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="fl_caster_r_wheel_link" reason="Never"/>
@@ -390,7 +340,6 @@
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_l_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="head_tilt_link" reason="Never"/>
@@ -398,12 +347,10 @@
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_l_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -414,19 +361,16 @@
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_l_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_l_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="fl_caster_r_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="fl_caster_rotation_link" reason="AlmostAlways"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_r_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="head_tilt_link" reason="Never"/>
@@ -434,11 +378,9 @@
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_r_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -449,18 +391,15 @@
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_r_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_r_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="fl_caster_rotation_link" reason="Adjacent"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="fr_caster_l_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="fr_caster_rotation_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_rotation_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="head_tilt_link" reason="Never"/>
@@ -468,29 +407,23 @@
   <disable_self_collision link1="fl_caster_rotation_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_rotation_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_rotation_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_rotation_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="fl_caster_rotation_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fl_caster_rotation_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="fr_caster_l_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="fr_caster_r_wheel_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="fr_caster_rotation_link" reason="AlmostAlways"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -498,30 +431,24 @@
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_gripper_palm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_l_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_l_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="fr_caster_r_wheel_link" reason="Adjacent"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="fr_caster_rotation_link" reason="AlmostAlways"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="head_tilt_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -531,26 +458,21 @@
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_r_wheel_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_r_wheel_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="fr_caster_rotation_link" reason="Adjacent"/>
-  <disable_self_collision link1="fr_caster_rotation_link" link2="head_mount_kinect2_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="head_mount_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="head_tilt_link" reason="Never"/>
@@ -558,64 +480,20 @@
   <disable_self_collision link1="fr_caster_rotation_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_rotation_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_rotation_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_rotation_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="fr_caster_rotation_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="fr_caster_rotation_link" link2="torso_lift_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="head_mount_kinect2_link" reason="Adjacent"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="head_mount_link" reason="Adjacent"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="head_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="head_tilt_link" reason="Adjacent"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_force_torque_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_forearm_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_gripper_l_finger_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_gripper_palm_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_gripper_r_finger_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="l_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_forearm_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_gripper_l_finger_link" reason="Unknown"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_gripper_l_finger_tip_link" reason="Unknown"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_gripper_palm_link" reason="Unknown"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_gripper_r_finger_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_kinect2_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="head_mount_link" reason="Adjacent"/>
   <disable_self_collision link1="head_mount_link" link2="head_pan_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="head_tilt_link" reason="Adjacent"/>
   <disable_self_collision link1="head_mount_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -625,13 +503,11 @@
   <disable_self_collision link1="head_mount_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -642,7 +518,6 @@
   <disable_self_collision link1="head_mount_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_mount_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_mount_link" link2="r_wrist_flex_link" reason="Never"/>
@@ -651,20 +526,17 @@
   <disable_self_collision link1="head_pan_link" link2="head_pan_link" reason="Adjacent"/>
   <disable_self_collision link1="head_pan_link" link2="head_tilt_link" reason="Default"/>
   <disable_self_collision link1="head_pan_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_pan_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_gripper_l_finger_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_gripper_palm_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_pan_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="head_pan_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -672,16 +544,13 @@
   <disable_self_collision link1="head_pan_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_pan_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_pan_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_pan_link" link2="torso_lift_link" reason="Default"/>
   <disable_self_collision link1="head_tilt_link" link2="head_tilt_link" reason="Adjacent"/>
   <disable_self_collision link1="head_tilt_link" link2="l_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="head_tilt_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -691,13 +560,11 @@
   <disable_self_collision link1="head_tilt_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_tilt_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="head_tilt_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -705,15 +572,12 @@
   <disable_self_collision link1="head_tilt_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="head_tilt_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="head_tilt_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="head_tilt_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_elbow_flex_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_elbow_flex_link" link2="l_force_torque_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_forearm_link" reason="Default"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_forearm_roll_link" reason="Default"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -723,47 +587,17 @@
   <disable_self_collision link1="l_elbow_flex_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_elbow_flex_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_upper_arm_link" reason="Default"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_elbow_flex_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_elbow_flex_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_elbow_flex_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_elbow_flex_link" link2="torso_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_force_torque_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_forearm_link" reason="Default"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_gripper_l_finger_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_gripper_palm_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_gripper_r_finger_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_shoulder_pan_link" reason="Unknown"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_wrist_flex_link" reason="AlmostAlways"/>
-  <disable_self_collision link1="l_force_torque_link" link2="l_wrist_roll_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_force_torque_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_shoulder_lift_link" reason="Unknown"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_shoulder_pan_link" reason="Unknown"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_force_torque_link" link2="torso_lift_link" reason="Unknown"/>
   <disable_self_collision link1="l_forearm_link" link2="l_forearm_link" reason="Adjacent"/>
   <disable_self_collision link1="l_forearm_link" link2="l_forearm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="l_forearm_link" link2="l_gripper_l_finger_link" reason="Never"/>
@@ -772,16 +606,12 @@
   <disable_self_collision link1="l_forearm_link" link2="l_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="l_wrist_flex_link" reason="Default"/>
   <disable_self_collision link1="l_forearm_link" link2="l_wrist_roll_link" reason="AlmostAlways"/>
   <disable_self_collision link1="l_forearm_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_link" link2="r_shoulder_lift_link" reason="Unknown"/>
-  <disable_self_collision link1="l_forearm_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_forearm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_gripper_l_finger_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_gripper_l_finger_tip_link" reason="Never"/>
@@ -790,21 +620,17 @@
   <disable_self_collision link1="l_forearm_roll_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_roll_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_roll_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_roll_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_forearm_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_forearm_roll_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_gripper_l_finger_link" reason="Adjacent"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_gripper_l_finger_tip_link" reason="Default"/>
@@ -812,157 +638,101 @@
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_gripper_r_finger_link" reason="Default"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="l_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_gripper_l_finger_tip_link" reason="Adjacent"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_gripper_palm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_l_finger_tip_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_gripper_palm_link" reason="Adjacent"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_gripper_r_finger_link" reason="Default"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_palm_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_palm_link" link2="l_wrist_roll_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_gripper_palm_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_palm_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_palm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_gripper_r_finger_link" reason="Adjacent"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_gripper_r_finger_tip_link" reason="Default"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="l_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_gripper_r_finger_tip_link" reason="Adjacent"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="l_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_gripper_l_finger_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_gripper_r_finger_tip_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_shoulder_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_shoulder_pan_link" reason="Default"/>
-  <disable_self_collision link1="l_shoulder_lift_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_upper_arm_link" reason="AlmostAlways"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_upper_arm_roll_link" reason="Default"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_lift_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_lift_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_lift_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_lift_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="l_shoulder_pan_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_shoulder_pan_link" link2="l_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="l_upper_arm_link" reason="Default"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="l_upper_arm_roll_link" reason="AlmostAlways"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_pan_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_pan_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_shoulder_pan_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_shoulder_pan_link" link2="torso_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="l_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="l_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="l_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="l_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="l_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="m_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_forearm_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_gripper_l_finger_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_gripper_palm_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_gripper_r_finger_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="t_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="l_torso_lift_side_item_profile_link" link2="torso_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="l_upper_arm_link" link2="l_upper_arm_link" reason="Adjacent"/>
   <disable_self_collision link1="l_upper_arm_link" link2="l_upper_arm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="l_upper_arm_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="l_upper_arm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="l_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="l_wrist_roll_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_roll_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -971,35 +741,26 @@
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_roll_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_upper_arm_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_upper_arm_roll_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="l_wrist_flex_link" reason="Adjacent"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="l_wrist_roll_link" reason="Default"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_flex_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_flex_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_flex_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_flex_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="l_wrist_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="laser_tilt_mount_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_roll_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_forearm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_roll_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="l_wrist_roll_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="l_wrist_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="laser_tilt_mount_link" reason="Adjacent"/>
-  <disable_self_collision link1="laser_tilt_mount_link" link2="m_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_elbow_flex_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_forearm_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_forearm_roll_link" reason="Never"/>
@@ -1008,31 +769,11 @@
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="laser_tilt_mount_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="laser_tilt_mount_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="laser_tilt_mount_link" link2="torso_lift_link" reason="Default"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="m_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_elbow_flex_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_forearm_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_forearm_roll_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_gripper_l_finger_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_gripper_palm_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_gripper_r_finger_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="t_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="m_torso_lift_side_item_profile_link" link2="torso_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_elbow_flex_link" reason="Adjacent"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_forearm_link" reason="Default"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_forearm_roll_link" reason="Default"/>
@@ -1043,12 +784,10 @@
   <disable_self_collision link1="r_elbow_flex_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="r_elbow_flex_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_upper_arm_link" reason="Default"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_elbow_flex_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_elbow_flex_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_forearm_link" reason="Adjacent"/>
   <disable_self_collision link1="r_forearm_link" link2="r_forearm_roll_link" reason="Adjacent"/>
@@ -1058,12 +797,10 @@
   <disable_self_collision link1="r_forearm_link" link2="r_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_forearm_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_link" link2="r_wrist_flex_link" reason="Default"/>
   <disable_self_collision link1="r_forearm_link" link2="r_wrist_roll_link" reason="AlmostAlways"/>
-  <disable_self_collision link1="r_forearm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_forearm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_gripper_l_finger_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_gripper_l_finger_tip_link" reason="Never"/>
@@ -1072,12 +809,10 @@
   <disable_self_collision link1="r_forearm_roll_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_shoulder_lift_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_shoulder_pan_link" reason="Never"/>
-  <disable_self_collision link1="r_forearm_roll_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_forearm_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_forearm_roll_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_gripper_l_finger_link" reason="Adjacent"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_gripper_l_finger_tip_link" reason="Default"/>
@@ -1085,89 +820,62 @@
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_gripper_r_finger_link" reason="Default"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_l_finger_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_l_finger_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_gripper_l_finger_tip_link" reason="Adjacent"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_gripper_palm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_gripper_r_finger_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_l_finger_tip_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_gripper_palm_link" reason="Adjacent"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_gripper_r_finger_link" reason="Default"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_gripper_r_finger_tip_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_palm_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_wrist_flex_link" reason="Default"/>
   <disable_self_collision link1="r_gripper_palm_link" link2="r_wrist_roll_link" reason="Adjacent"/>
-  <disable_self_collision link1="r_gripper_palm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_gripper_r_finger_link" reason="Adjacent"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_gripper_r_finger_tip_link" reason="Default"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_r_finger_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_r_finger_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_gripper_r_finger_tip_link" reason="Adjacent"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_shoulder_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_upper_arm_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_upper_arm_roll_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_gripper_r_finger_tip_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_shoulder_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_shoulder_pan_link" reason="Default"/>
-  <disable_self_collision link1="r_shoulder_lift_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_upper_arm_link" reason="AlmostAlways"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_upper_arm_roll_link" reason="Default"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_shoulder_lift_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_lift_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_pan_link" link2="r_shoulder_pan_link" reason="Adjacent"/>
-  <disable_self_collision link1="r_shoulder_pan_link" link2="r_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_pan_link" link2="r_upper_arm_link" reason="Default"/>
   <disable_self_collision link1="r_shoulder_pan_link" link2="r_upper_arm_roll_link" reason="AlmostAlways"/>
-  <disable_self_collision link1="r_shoulder_pan_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_shoulder_pan_link" link2="torso_lift_link" reason="Never"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="r_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="r_upper_arm_link" reason="Never"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="r_upper_arm_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="r_wrist_flex_link" reason="Never"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="t_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="r_torso_lift_side_item_profile_link" link2="torso_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="r_upper_arm_link" link2="r_upper_arm_link" reason="Adjacent"/>
   <disable_self_collision link1="r_upper_arm_link" link2="r_upper_arm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="r_upper_arm_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_upper_arm_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_upper_arm_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_upper_arm_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="r_upper_arm_roll_link" link2="r_upper_arm_roll_link" reason="Adjacent"/>
   <disable_self_collision link1="r_upper_arm_roll_link" link2="r_wrist_flex_link" reason="Never"/>
   <disable_self_collision link1="r_upper_arm_roll_link" link2="r_wrist_roll_link" reason="Never"/>
-  <disable_self_collision link1="r_upper_arm_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_upper_arm_roll_link" link2="torso_lift_link" reason="Never"/>
   <disable_self_collision link1="r_wrist_flex_link" link2="r_wrist_flex_link" reason="Adjacent"/>
   <disable_self_collision link1="r_wrist_flex_link" link2="r_wrist_roll_link" reason="Default"/>
-  <disable_self_collision link1="r_wrist_flex_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
   <disable_self_collision link1="r_wrist_roll_link" link2="r_wrist_roll_link" reason="Adjacent"/>
-  <disable_self_collision link1="r_wrist_roll_link" link2="t_torso_lift_side_item_profile_link" reason="Never"/>
-  <disable_self_collision link1="t_torso_lift_side_item_profile_link" link2="t_torso_lift_side_item_profile_link" reason="Adjacent"/>
-  <disable_self_collision link1="t_torso_lift_side_item_profile_link" link2="torso_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="torso_lift_link" link2="torso_lift_link" reason="Adjacent"/>
 </robot>


### PR DESCRIPTION
- Fix some wrong imports inside the examples: 
example of wrong imports:
- from pycram.process_module import simulated_robot  -> from pycram.motion_executor import simulated_robot
- from pycram.datastructures.enums import TorsoState ->  from semantic_digital_twin.datastructures.definitions import TorsoState


- fixed missing reference frame inside PoseStamped
- Removed links inside pr2.srdf inside the self collision because they do not have collision element.

To test I regenerated the tutorials into jupyter notebook and it was working.