### PR TITLE
flatteningand  & edge clearance in region sampling

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
@@ -700,14 +700,17 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         candidates_filtered = candidates.submesh([clear_mask], append=True)
 
         # --- Build the region ---
+        all_z = candidates_filtered.vertices[:, 2]
+        average_z = np.mean(all_z)
+
         points_3d = [
             Point3(
                 x,
                 y,
-                z,
+                average_z,
                 reference_frame=self.root,
             )
-            for x, y, z in candidates_filtered.vertices
+            for x, y, _ in candidates_filtered.vertices
         ]
         supporting_surface = Region.from_3d_points(
             name=PrefixedName(
@@ -717,7 +720,10 @@ class HasSupportingSurface(HasStorageSpace, ABC):
             points_3d=points_3d,
         )
 
-        supporting_surface_z_position = self.root.collision.scale.z / 2
+        if self.root.global_transform.z < 0.1:
+            supporting_surface_z_position = self.root.collision.scale.z
+        else:
+            supporting_surface_z_position = self.root.collision.scale.z / 2
         self_C_supporting_surface = FixedConnection(
             parent=self.root,
             child=supporting_surface,
@@ -740,6 +746,7 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         body_to_sample_for: Optional[HasRootBody] = None,
         category_of_interest: Optional[Type[SemanticAnnotation]] = None,
         amount: int = 100,
+        edge_clearance: Optional[float] = None,
     ) -> List[Point3]:
         """
         Samples points from a surface around the semantic annotation. The surface is determined by the supporting
@@ -752,6 +759,8 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         :param body_to_sample_for: The physical object to sample points for.
         :param category_of_interest: The type of object sample points around.
         :param amount: The number of points to sample.
+        :param edge_clearance: Minimum distance to keep from the supporting surface edge in x/y. If not provided,
+            half of the sampled object's largest x/y extent is used.
 
         :return: A list of sampled points, sorted by distance to the around_object.
         """
@@ -769,6 +778,9 @@ class HasSupportingSurface(HasStorageSpace, ABC):
             ].max()
             z_object_dimension = body_to_sample_for.root.combined_mesh.extents[2]
 
+        if edge_clearance is None:
+            edge_clearance = largest_xy_object_dimension / 2
+
         self_max_z = self.supporting_surface.area.max_point.z
         z_coordinate = np.full(
             (amount, 1),
@@ -778,6 +790,7 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         surface_circuit = self._build_surface_sampler(
             category_of_interest=category_of_interest,
             object_bloat=largest_xy_object_dimension,
+            edge_clearance=edge_clearance,
         )
 
         if surface_circuit is None:
@@ -797,6 +810,7 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         self,
         category_of_interest: Optional[Type[SemanticAnnotation]] = None,
         object_bloat: float = 0.1,
+        edge_clearance: float = 0.0,
     ):
         """
         Build a probabilistic circuit representing the supporting surface, truncated by the objects on the surface,
@@ -804,9 +818,11 @@ class HasSupportingSurface(HasStorageSpace, ABC):
 
         :param category_of_interest: The type of object sample points around.
         :param object_bloat: The amount of bloat to apply to the object event.
+        :param edge_clearance: Minimum distance to keep from the supporting surface edge in x/y.
         """
         truncated_event_2d = self._2d_surface_sample_space_excluding_objects(
-            object_bloat
+            object_bloat,
+            edge_clearance=edge_clearance,
         )
 
         objects_of_interest = (
@@ -824,15 +840,31 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         else:
             return uniform_measure_of_event(truncated_event_2d)
 
-    def _2d_surface_sample_space_excluding_objects(self, object_bloat: float) -> Event:
+    def _2d_surface_sample_space_excluding_objects(
+        self, object_bloat: float, edge_clearance: float = 0.0
+    ) -> Event:
         """
         Compute a 2D event representing the supporting surface, truncated by the objects on the surface.
 
         :param object_bloat: The amount of bloat to apply to the object events.
+        :param edge_clearance: Minimum distance to keep from the supporting surface edge in x/y.
         """
         area_of_self = BoundingBoxCollection.from_shapes(self.supporting_surface.area)
         area_of_self.transform_all_shapes_to_own_frame()
         event = area_of_self.event
+
+        if edge_clearance > 0:
+            shrunk_surface = area_of_self.bounding_box()
+            max_clearance = min(
+                (shrunk_surface.max_x - shrunk_surface.min_x) / 2,
+                (shrunk_surface.max_y - shrunk_surface.min_y) / 2,
+            )
+            applied_clearance = min(edge_clearance, np.nextafter(max_clearance, 0.0))
+            if applied_clearance > 0:
+                shrunk_surface = shrunk_surface.bloat(
+                    -applied_clearance, -applied_clearance, 0.0
+                )
+                event = shrunk_surface.simple_event.as_composite_set()
 
         event_2d = event.marginal(SpatialVariables.xy)
         for obj in self.objects:

--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
@@ -720,6 +720,10 @@ class HasSupportingSurface(HasStorageSpace, ABC):
             points_3d=points_3d,
         )
 
+        # This assumes the object frame is near the geometric center.
+        # Some URDFs violate that assumption and place the frame close to the ground
+        # instead, as with some coffee-table models. In those cases, place the
+        # supporting surface at the full object height rather than half height.
         if self.root.global_transform.z < 0.1:
             supporting_surface_z_position = self.root.collision.scale.z
         else:
@@ -854,16 +858,21 @@ class HasSupportingSurface(HasStorageSpace, ABC):
         event = area_of_self.event
 
         if edge_clearance > 0:
+            # Start from the full supporting surface bounds in the surface's own frame.
             shrunk_surface = area_of_self.bounding_box()
+            # Clearance cannot exceed half the surface extent, otherwise the box would invert.
             max_clearance = min(
                 (shrunk_surface.max_x - shrunk_surface.min_x) / 2,
                 (shrunk_surface.max_y - shrunk_surface.min_y) / 2,
             )
+            # Clamp the requested clearance slightly below the geometric limit for stability.
             applied_clearance = min(edge_clearance, np.nextafter(max_clearance, 0.0))
             if applied_clearance > 0:
+                # Shrink only in x/y so sampled points stay away from the surface edges.
                 shrunk_surface = shrunk_surface.bloat(
                     -applied_clearance, -applied_clearance, 0.0
                 )
+                # Replace the original event with the shrunken support region.
                 event = shrunk_surface.simple_event.as_composite_set()
 
         event_2d = event.marginal(SpatialVariables.xy)


### PR DESCRIPTION
- Flattened detected supporting-surface regions to a single representative height using the average vertex z, so support surfaces behave like stable planar placement regions instead of noisy mesh patches.

- Adjusted the supporting-surface attachment z offset heuristic to place the generated region more accurately for near-ground versus elevated parent objects.

- Added an optional edge_clearance parameter to sample_points_from_surface() to support footprint-aware sampling.

- Defaulted edge_clearance to half of the sampled object’s largest XY extent when no explicit value is provided.

- Propagated edge_clearance through the supporting-surface sampler pipeline.

- Shrunk the 2D valid sampling region by the requested clearance before sampling, so sampled points stay away from support-surface edges and produce more usable placement candidates.