### PR TITLE
Collision Matrix Tool and Interactive Marker fixes

### DIFF
--- a/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
+++ b/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
@@ -111,13 +111,14 @@ class SelfCollisionMatrixInterface:
     def load_urdf(self, urdf_path: str):
         robot_world = URDFParser.from_file(urdf_path).parse()
         self.self_collision_matrix_rule = SelfCollisionMatrixRule()
-        self.robot = MinimalRobot.from_world(robot_world)
+        MinimalRobot.from_world(robot_world)
         with self.world.modify_world():
             self.world.clear()
             self.world.add_body(map := Body(name=PrefixedName("map")))
             self.world.merge_world(
                 robot_world, FixedConnection(parent=map, child=robot_world.root)
             )
+        self.robot = self.world.get_semantic_annotations_by_type(AbstractRobot)[0]
 
     def dye_all_bodies_white_transparent(self):
         with self.world.modify_world():

--- a/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
+++ b/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
@@ -111,14 +111,13 @@ class SelfCollisionMatrixInterface:
     def load_urdf(self, urdf_path: str):
         robot_world = URDFParser.from_file(urdf_path).parse()
         self.self_collision_matrix_rule = SelfCollisionMatrixRule()
-        MinimalRobot.from_world(robot_world)
         with self.world.modify_world():
             self.world.clear()
             self.world.add_body(map := Body(name=PrefixedName("map")))
             self.world.merge_world(
                 robot_world, FixedConnection(parent=map, child=robot_world.root)
             )
-        self.robot = self.world.get_semantic_annotations_by_type(AbstractRobot)[0]
+        self.robot = MinimalRobot.from_world(self.world)
 
     def dye_all_bodies_white_transparent(self):
         with self.world.modify_world():

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -118,20 +118,20 @@ class InteractiveMarkerNode:
 
         :raises WorldEntityNotFoundError: If entities cannot be found after all retries.
         """
-        try:
-            for root, tip in zip(self.root_links, self.tip_links):
+        for root, tip in zip(self.root_links, self.tip_links):
+            try:
                 root_body = self.giskard.world.get_kinematic_structure_entity_by_name(
                     root
                 )
                 tip_body = self.giskard.world.get_kinematic_structure_entity_by_name(
                     tip
                 )
-                kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
-                self.markers[kinematic_chain.name] = kinematic_chain
+            except WorldEntityNotFoundError as error:
+                raise error
+            kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
+            self.markers[kinematic_chain.name] = kinematic_chain
 
-            return
-        except WorldEntityNotFoundError as error:
-            raise error
+        return
 
     def _setup_marker_server(self) -> None:
         """

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from time import sleep
+from dataclasses import dataclass, field
+from typing import Dict
 
 import rclpy
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
 from rclpy import Parameter
+from semantic_digital_twin.world_description.world_entity import KinematicStructureEntity
 from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
 from visualization_msgs.msg import InteractiveMarkerFeedback
 
@@ -10,95 +15,277 @@ from giskardpy.motion_statechart.graph_node import EndMotion
 from giskardpy.motion_statechart.monitors.payload_monitors import CountSeconds
 from giskardpy.motion_statechart.motion_statechart import MotionStatechart
 from giskardpy.motion_statechart.tasks.cartesian_tasks import CartesianPose
-from giskardpy.middleware.ros2.python_interface import (
-    GiskardWrapper,
-)
+from giskardpy.middleware.ros2.python_interface import GiskardWrapper
 from giskardpy.middleware.ros2 import rospy
 from semantic_digital_twin.exceptions import WorldEntityNotFoundError
 from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 
+# Configuration constants
+MARKER_SCALE = 0.25
+MARKER_BOX_SIZE = 0.175
+MARKER_COLOR_VALUE = 0.5
+MARKER_COLOR_ALPHA = 0.5
+MOTION_TIMEOUT_SECONDS = 20
+WORLD_ENTITY_RETRY_ATTEMPTS = 100
+WORLD_ENTITY_RETRY_DELAY = 0.5
 
+
+@dataclass
 class InteractiveMarkerNode:
-    def __init__(self) -> None:
-        super().__init__()
+    """
+    ROS 2 node that manages interactive markers for Cartesian pose control.
+
+    This node creates interactive markers for specified kinematic chains and allows
+    users to manipulate them via RViz. When a marker is moved, it generates motion
+    goals that are sent to Giskard for execution.
+
+    Parameters are read from ROS parameter server:
+
+    - root_links: List of root link names for kinematic chains
+    - tip_links: List of tip link names corresponding to root_links
+
+    :var giskard: Wrapper for Giskard motion planner (computed)
+    :var markers: Dictionary mapping marker names to KinematicChainMarker instances (computed)
+    :var server: Interactive marker server for RViz (computed)
+    :var root_links: List of root link names (computed from parameters)
+    :var tip_links: List of tip link names (computed from parameters)
+    """
+
+    giskard: GiskardWrapper = field(init=False)
+    markers: Dict[str, KinematicChainMarker] = field(init=False)
+    server: InteractiveMarkerServer | None = field(init=False)
+    root_links: list = field(init=False)
+    tip_links: list = field(init=False)
+
+    def __post_init__(self) -> None:
+        """
+        Initialize the interactive marker node after dataclass initialization.
+
+        Sets up the Giskard wrapper, reads parameters, creates kinematic chain markers,
+        and initializes the interactive marker server. Retries up to WORLD_ENTITY_RETRY_ATTEMPTS
+        times if world entities are not found initially.
+
+        :raises WorldEntityNotFoundError: If kinematic structure entities cannot be found
+            after all retry attempts.
+        """
         self.giskard = GiskardWrapper(
             node_handle=rospy.node, giskard_node_name="giskard"
         )
+        self.markers = {}
+        self.server = None
 
         self.giskard.node_handle.declare_parameters(
             namespace="",
             parameters=[
-                ("root_link", Parameter.Type.STRING),
-                ("tip_link", Parameter.Type.STRING),
+                ("root_links", Parameter.Type.STRING_ARRAY),
+                ("tip_links", Parameter.Type.STRING_ARRAY),
             ],
         )
-        self.root_link = self.giskard.node_handle.get_parameter("root_link").value
-        self.tip_link = self.giskard.node_handle.get_parameter("tip_link").value
-        for i in range(100):
-            try:
-                self.root_body = (
-                    self.giskard.world.get_kinematic_structure_entity_by_name(
-                        self.root_link
-                    )
-                )
-                self.tip_body = (
-                    self.giskard.world.get_kinematic_structure_entity_by_name(
-                        self.tip_link
-                    )
-                )
-                break
-            except WorldEntityNotFoundError as e:
-                sleep(0.5)
-                self.giskard.node_handle.get_logger().error(
-                    "failed to find bodies in world, retrying in 0.5s..."
-                )
-        else:
-            raise e
+        self.root_links = self.giskard.node_handle.get_parameter("root_links").value
+        self.tip_links = self.giskard.node_handle.get_parameter("tip_links").value
 
-        # Create an interactive marker server
+        self._initialize_markers()
+        self._setup_marker_server()
+
+    def _initialize_markers(self) -> None:
+        """
+        Initialize kinematic chain markers with retry logic.
+
+        Attempts to find kinematic structure entities and create markers for them.
+        Retries up to WORLD_ENTITY_RETRY_ATTEMPTS times with WORLD_ENTITY_RETRY_DELAY
+        between attempts.
+
+        :raises WorldEntityNotFoundError: If entities cannot be found after all retries.
+        """
+        last_error: WorldEntityNotFoundError | None = None
+
+        for attempt in range(WORLD_ENTITY_RETRY_ATTEMPTS):
+            try:
+                for root, tip in zip(self.root_links, self.tip_links):
+                    root_body = (
+                        self.giskard.world.get_kinematic_structure_entity_by_name(root)
+                    )
+                    tip_body = (
+                        self.giskard.world.get_kinematic_structure_entity_by_name(tip)
+                    )
+                    kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
+                    self.markers[kinematic_chain.name] = kinematic_chain
+
+                return  # Success
+            except WorldEntityNotFoundError as error:
+                last_error = error
+                self.markers.clear()
+                sleep(WORLD_ENTITY_RETRY_DELAY)
+                self.giskard.node_handle.get_logger().error(
+                    f"Failed to find bodies in world (attempt {attempt + 1}/{WORLD_ENTITY_RETRY_ATTEMPTS}), "
+                    f"retrying in {WORLD_ENTITY_RETRY_DELAY}s..."
+                )
+
+        if last_error is not None:
+            raise last_error
+
+    def _setup_marker_server(self) -> None:
+        """
+        Set up the interactive marker server and register all markers.
+
+        Creates the server, configures each marker with controls,
+        and registers feedback callbacks.
+        """
         self.server = InteractiveMarkerServer(rospy.node, "cartesian_goals")
 
-        # Create an interactive marker
-        int_marker = InteractiveMarker()
-        int_marker.header.frame_id = str(self.tip_body.name)
-        int_marker.name = f"{self.root_link}/{self.tip_link}"
-        int_marker.scale = 0.25
-        int_marker.pose.orientation.w = 1.0
+        for marker in self.markers.values():
+            marker.create_marker()
+            self.server.insert(marker.interactive_marker_message)
+            self.server.setCallback(marker.name, self.process_feedback)
 
-        # Create a marker for the interactive marker
+        self.server.applyChanges()
+
+    def process_feedback(self, feedback: InteractiveMarkerFeedback) -> None:
+        """
+        Process feedback from interactive markers when user interactions occur.
+
+        When a marker is released (MOUSE_UP event), this method extracts the new pose,
+        creates a motion goal with a timeout, and sends it to Giskard for execution.
+        The marker is then reset to its default pose.
+
+        :param feedback: The interactive marker feedback containing pose and event information.
+        """
+        if feedback.event_type != InteractiveMarkerFeedback.MOUSE_UP:
+            return
+
+        self.giskard.node_handle.get_logger().info(
+            f"Marker feedback received: {feedback.event_type}"
+        )
+
+        kinematic_chain_marker = self.markers[feedback.marker_name]
+
+        goal_transformation = HomogeneousTransformationMatrix.from_xyz_quaternion(
+            pos_x=feedback.pose.position.x,
+            pos_y=feedback.pose.position.y,
+            pos_z=feedback.pose.position.z,
+            quat_x=feedback.pose.orientation.x,
+            quat_y=feedback.pose.orientation.y,
+            quat_z=feedback.pose.orientation.z,
+            quat_w=feedback.pose.orientation.w,
+            reference_frame=kinematic_chain_marker.tip_body,
+        )
+
+        motion_statechart = MotionStatechart()
+        motion_statechart.add_nodes(
+            [
+                goal_transformation := CartesianPose(
+                    root_link=kinematic_chain_marker.root_body,
+                    tip_link=kinematic_chain_marker.tip_body,
+                    goal_pose=goal_transformation,
+                ),
+                motion_timeout := CountSeconds(seconds=MOTION_TIMEOUT_SECONDS),
+            ]
+        )
+        motion_statechart.add_node(EndMotion.when_any_true([goal_transformation, motion_timeout]))
+        self.giskard.execute_async(motion_statechart)
+
+        # Reset marker pose
+        kinematic_chain_marker.reset_pose()
+
+        # Update marker in server
+        self.server.insert(kinematic_chain_marker.interactive_marker_message)
+        self.server.applyChanges()
+
+
+@dataclass
+class KinematicChainMarker:
+    """
+    Represents an interactive marker for a kinematic chain in RViz.
+
+    This dataclass encapsulates all data and functionality needed to create and manage
+    an interactive marker for a robot kinematic chain. It handles marker visualization,
+    control setup (translation and rotation), and pose representation.
+
+    :var root_link: Name of the root link in the kinematic chain
+    :var tip_link: Name of the tip/end-effector link in the kinematic chain
+    :var root_body: Kinematic structure entity representing the root body
+    :var tip_body: Kinematic structure entity representing the tip body
+    :var name: Formatted name combining root and tip links (computed)
+    :var interactive_marker_message: ROS InteractiveMarker message object (computed)
+    """
+
+    root_link: str
+    tip_link: str
+    root_body: KinematicStructureEntity
+    tip_body: KinematicStructureEntity
+    name: str = field(init=False)
+    interactive_marker_message: InteractiveMarker = field(init=False)
+
+    def __post_init__(self) -> None:
+        """
+        Initialize computed attributes after dataclass initialization.
+
+        Creates the name attribute and initializes an empty InteractiveMarker object.
+        """
+        self.name = f"{self.root_link}/{self.tip_link}"
+        self.interactive_marker_message = InteractiveMarker()
+
+    def create_marker(self) -> None:
+        """
+        Configure and create the interactive marker with all controls.
+
+        Sets up marker frame, appearance (cube visualization), and movement and
+        rotation controls for all axes.
+        """
+        self._setup_marker_properties()
+        self._add_box_control()
+        self._add_movement_controls()
+        self._add_rotation_controls()
+
+    def _setup_marker_properties(self) -> None:
+        """
+        Set up basic marker properties and appearance.
+        """
+        self.interactive_marker_message.header.frame_id = str(self.tip_body.name)
+        self.interactive_marker_message.name = self.name
+        self.interactive_marker_message.scale = MARKER_SCALE
+        self.interactive_marker_message.pose.orientation.w = 1.0
+
+    def _add_box_control(self) -> None:
+        """
+        Add the visual box control to the marker.
+        """
         box_marker = Marker()
         box_marker.type = Marker.CUBE
-        box_marker.scale.x = 0.175
-        box_marker.scale.y = 0.175
-        box_marker.scale.z = 0.175
-        box_marker.color.r = 0.5
-        box_marker.color.g = 0.5
-        box_marker.color.b = 0.5
-        box_marker.color.a = 0.5
+        box_marker.scale.x = MARKER_BOX_SIZE
+        box_marker.scale.y = MARKER_BOX_SIZE
+        box_marker.scale.z = MARKER_BOX_SIZE
+        box_marker.color.r = MARKER_COLOR_VALUE
+        box_marker.color.g = MARKER_COLOR_VALUE
+        box_marker.color.b = MARKER_COLOR_VALUE
+        box_marker.color.a = MARKER_COLOR_ALPHA
 
-        # Create a control that contains the marker
         box_control = InteractiveMarkerControl()
         box_control.always_visible = True
         box_control.markers.append(box_marker)
         box_control.interaction_mode = InteractiveMarkerControl.MOVE_PLANE
 
-        # Add the control to the interactive marker
-        int_marker.controls.append(box_control)
+        self.interactive_marker_message.controls.append(box_control)
 
-        # Create controls to move the marker along all axes
+    def _add_movement_controls(self) -> None:
+        """
+        Add translation controls for X, Y, Z axes.
+        """
         self.add_control(
-            int_marker, "move_x", InteractiveMarkerControl.MOVE_AXIS, 1.0, 0.0, 0.0, 1.0
+            "move_x", InteractiveMarkerControl.MOVE_AXIS, 1.0, 0.0, 0.0, 1.0
         )
         self.add_control(
-            int_marker, "move_y", InteractiveMarkerControl.MOVE_AXIS, 0.0, 1.0, 0.0, 1.0
+            "move_y", InteractiveMarkerControl.MOVE_AXIS, 0.0, 1.0, 0.0, 1.0
         )
         self.add_control(
-            int_marker, "move_z", InteractiveMarkerControl.MOVE_AXIS, 0.0, 0.0, 1.0, 1.0
+            "move_z", InteractiveMarkerControl.MOVE_AXIS, 0.0, 0.0, 1.0, 1.0
         )
 
-        # Create controls to rotate the marker around all axes
+    def _add_rotation_controls(self) -> None:
+        """
+        Add rotation controls for X, Y, Z axes.
+        """
         self.add_control(
-            int_marker,
             "rotate_x",
             InteractiveMarkerControl.ROTATE_AXIS,
             1.0,
@@ -107,7 +294,6 @@ class InteractiveMarkerNode:
             1.0,
         )
         self.add_control(
-            int_marker,
             "rotate_y",
             InteractiveMarkerControl.ROTATE_AXIS,
             0.0,
@@ -116,7 +302,6 @@ class InteractiveMarkerNode:
             1.0,
         )
         self.add_control(
-            int_marker,
             "rotate_z",
             InteractiveMarkerControl.ROTATE_AXIS,
             0.0,
@@ -125,20 +310,8 @@ class InteractiveMarkerNode:
             1.0,
         )
 
-        # Add the interactive marker to the server
-        self.server.insert(int_marker)
-
-        # Set the callback for marker feedback
-        self.server.setCallback(int_marker.name, self.process_feedback)
-
-        # 'commit' changes and send to all clients
-        self.server.applyChanges()
-
-        self.int_marker = int_marker
-
     def add_control(
         self,
-        int_marker: InteractiveMarker,
         name: str,
         interaction_mode: int,
         x: float,
@@ -146,6 +319,16 @@ class InteractiveMarkerNode:
         z: float,
         w: float,
     ) -> None:
+        """
+        Add a single interactive marker control for translation or rotation.
+
+        :param name: Identifier for the control (e.g., "move_x", "rotate_z")
+        :param interaction_mode: InteractiveMarkerControl mode (MOVE_AXIS or ROTATE_AXIS)
+        :param x: X component of the control orientation quaternion
+        :param y: Y component of the control orientation quaternion
+        :param z: Z component of the control orientation quaternion
+        :param w: W component of the control orientation quaternion
+        """
         control = InteractiveMarkerControl()
         control.name = name
         control.interaction_mode = interaction_mode
@@ -153,52 +336,32 @@ class InteractiveMarkerNode:
         control.orientation.x = x
         control.orientation.y = y
         control.orientation.z = z
-        int_marker.controls.append(control)
+        self.interactive_marker_message.controls.append(control)
 
-    def process_feedback(self, feedback: InteractiveMarkerFeedback) -> None:
-        if feedback.event_type == InteractiveMarkerFeedback.MOUSE_UP:
-            self.giskard.node_handle.get_logger().info(
-                f"Marker feedback received: {feedback.event_type}"
-            )
+    def reset_pose(self) -> None:
+        """
+        Reset the marker pose to the default identity position and orientation.
 
-            goal = HomogeneousTransformationMatrix.from_xyz_quaternion(
-                pos_x=feedback.pose.position.x,
-                pos_y=feedback.pose.position.y,
-                pos_z=feedback.pose.position.z,
-                quat_x=feedback.pose.orientation.x,
-                quat_y=feedback.pose.orientation.y,
-                quat_z=feedback.pose.orientation.z,
-                quat_w=feedback.pose.orientation.w,
-                reference_frame=self.tip_body,
-            )
-
-            msc = MotionStatechart()
-            msc.add_nodes(
-                [
-                    goal := CartesianPose(
-                        root_link=self.root_body,
-                        tip_link=self.tip_body,
-                        goal_pose=goal,
-                    ),
-                    time_out := CountSeconds(seconds=20),
-                ]
-            )
-            msc.add_node(EndMotion.when_any_true([goal, time_out]))
-            self.giskard.execute_async(msc)
-            # reset marker pose
-            self.int_marker.pose.position.x = 0.0
-            self.int_marker.pose.position.y = 0.0
-            self.int_marker.pose.position.z = 0.0
-            self.int_marker.pose.orientation.x = 0.0
-            self.int_marker.pose.orientation.y = 0.0
-            self.int_marker.pose.orientation.z = 0.0
-            self.int_marker.pose.orientation.w = 1.0
-            # self.server.clear()
-            self.server.insert(self.int_marker)
-            self.server.applyChanges()
+        Sets position to origin and orientation to identity quaternion.
+        """
+        self.interactive_marker_message.pose.position.x = 0.0
+        self.interactive_marker_message.pose.position.y = 0.0
+        self.interactive_marker_message.pose.position.z = 0.0
+        self.interactive_marker_message.pose.orientation.x = 0.0
+        self.interactive_marker_message.pose.orientation.y = 0.0
+        self.interactive_marker_message.pose.orientation.z = 0.0
+        self.interactive_marker_message.pose.orientation.w = 1.0
 
 
 def main(args: None = None) -> None:
+    """
+    Main entry point for the interactive marker ROS 2 node.
+
+    Initializes the ROS 2 node, creates the InteractiveMarkerNode instance,
+    logs a startup message, and keeps the node running until shutdown is requested.
+
+    :param args: Optional command-line arguments (currently unused)
+    """
     rospy.init_node("interactive_marker")
     node = InteractiveMarkerNode()
     node.giskard.node_handle.get_logger().info("interactive marker server running")

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from time import sleep
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List
 
 import rclpy
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
@@ -22,15 +22,6 @@ from giskardpy.middleware.ros2 import rospy
 from semantic_digital_twin.exceptions import WorldEntityNotFoundError
 from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 
-# Configuration constants
-MARKER_SCALE = 0.25
-MARKER_BOX_SIZE = 0.175
-MARKER_COLOR_VALUE = 0.5
-MARKER_COLOR_ALPHA = 0.5
-MOTION_TIMEOUT_SECONDS = 20
-WORLD_ENTITY_RETRY_ATTEMPTS = 100
-WORLD_ENTITY_RETRY_DELAY = 0.5
-
 
 @dataclass
 class InteractiveMarkerNode:
@@ -46,7 +37,9 @@ class InteractiveMarkerNode:
     - root_links: List of root link names for kinematic chains
     - tip_links: List of tip link names corresponding to root_links
 
-    Example Node for .launch.py::
+    Example Node for .launch.py:
+
+    .. code-block:: python
 
         Node(
             package="giskardpy_ros",
@@ -66,6 +59,18 @@ class InteractiveMarkerNode:
         ),
     """
 
+    motion_timeout_seconds: float = 20
+    """
+    Timeout in seconds for motion execution.
+    """
+    world_entity_retry_attempts: int = 100
+    """
+    Number of retry attempts when finding world entities.
+    """
+    world_entity_retry_delay: float = 0.5
+    """
+    Delay in seconds between retry attempts for world entities.
+    """
     giskard: GiskardWrapper = field(init=False)
     """
     Wrapper for Giskard motion planner.
@@ -78,21 +83,19 @@ class InteractiveMarkerNode:
     """
     Interactive marker server for RViz.
     """
-    root_links: list = field(init=False)
+    root_links: List[str] = field(init=False)
     """
     List of root link names from parameters.
     """
-    tip_links: list = field(init=False)
+    tip_links: List[str] = field(init=False)
     """
     List of tip link names from parameters.
     """
 
     def __post_init__(self) -> None:
         """
-        Initialize the interactive marker node after dataclass initialization.
-
         Sets up the Giskard wrapper, reads parameters, creates kinematic chain markers,
-        and initializes the interactive marker server. Retries up to WORLD_ENTITY_RETRY_ATTEMPTS
+        and initializes the interactive marker server. Retries up to world_entity_retry_attempts
         times if world entities are not found initially.
 
         :raises WorldEntityNotFoundError: If kinematic structure entities cannot be found
@@ -119,17 +122,15 @@ class InteractiveMarkerNode:
 
     def _initialize_markers(self) -> None:
         """
-        Initialize kinematic chain markers with retry logic.
-
         Attempts to find kinematic structure entities and create markers for them.
-        Retries up to WORLD_ENTITY_RETRY_ATTEMPTS times with WORLD_ENTITY_RETRY_DELAY
+        Retries up to world_entity_retry_attempts times with world_entity_retry_delay
         between attempts.
 
         :raises WorldEntityNotFoundError: If entities cannot be found after all retries.
         """
         last_error: WorldEntityNotFoundError | None = None
 
-        for attempt in range(WORLD_ENTITY_RETRY_ATTEMPTS):
+        for attempt in range(self.world_entity_retry_attempts):
             try:
                 for root, tip in zip(self.root_links, self.tip_links):
                     root_body = (
@@ -147,10 +148,10 @@ class InteractiveMarkerNode:
             except WorldEntityNotFoundError as error:
                 last_error = error
                 self.markers.clear()
-                sleep(WORLD_ENTITY_RETRY_DELAY)
+                sleep(self.world_entity_retry_delay)
                 self.giskard.node_handle.get_logger().error(
-                    f"Failed to find bodies in world (attempt {attempt + 1}/{WORLD_ENTITY_RETRY_ATTEMPTS}), "
-                    f"retrying in {WORLD_ENTITY_RETRY_DELAY}s..."
+                    f"Failed to find bodies in world (attempt {attempt + 1}/{self.world_entity_retry_attempts}), "
+                    f"retrying in {self.world_entity_retry_delay}s..."
                 )
 
         if last_error is not None:
@@ -210,7 +211,7 @@ class InteractiveMarkerNode:
                     tip_link=kinematic_chain_marker.tip_body,
                     goal_pose=goal_transformation,
                 ),
-                motion_timeout := CountSeconds(seconds=MOTION_TIMEOUT_SECONDS),
+                motion_timeout := CountSeconds(seconds=self.motion_timeout_seconds),
             ]
         )
         motion_statechart.add_node(
@@ -252,6 +253,22 @@ class KinematicChainMarker:
     """
     Kinematic structure entity representing the tip body.
     """
+    marker_scale: float = 0.25
+    """
+    Scale of the interactive marker in meters.
+    """
+    marker_box_size: float = 0.175
+    """
+    Size of the marker box along each axis in meters.
+    """
+    marker_color_value: float = 0.5
+    """
+    RGB color value for the marker box (0.0 to 1.0).
+    """
+    marker_color_alpha: float = 0.5
+    """
+    Alpha transparency value for the marker box (0.0 to 1.0).
+    """
     name: str = field(init=False)
     """
     Formatted name combining root and tip links.
@@ -263,8 +280,6 @@ class KinematicChainMarker:
 
     def __post_init__(self) -> None:
         """
-        Initialize computed attributes after dataclass initialization.
-
         Creates the name attribute and initializes an empty InteractiveMarker object.
         """
         self.name = f"{self.root_link}/{self.tip_link}"
@@ -288,7 +303,7 @@ class KinematicChainMarker:
         """
         self.interactive_marker_message.header.frame_id = str(self.tip_body.name)
         self.interactive_marker_message.name = self.name
-        self.interactive_marker_message.scale = MARKER_SCALE
+        self.interactive_marker_message.scale = self.marker_scale
         self.interactive_marker_message.pose.orientation.w = 1.0
 
     def _add_box_control(self) -> None:
@@ -297,13 +312,13 @@ class KinematicChainMarker:
         """
         box_marker = Marker()
         box_marker.type = Marker.CUBE
-        box_marker.scale.x = MARKER_BOX_SIZE
-        box_marker.scale.y = MARKER_BOX_SIZE
-        box_marker.scale.z = MARKER_BOX_SIZE
-        box_marker.color.r = MARKER_COLOR_VALUE
-        box_marker.color.g = MARKER_COLOR_VALUE
-        box_marker.color.b = MARKER_COLOR_VALUE
-        box_marker.color.a = MARKER_COLOR_ALPHA
+        box_marker.scale.x = self.marker_box_size
+        box_marker.scale.y = self.marker_box_size
+        box_marker.scale.z = self.marker_box_size
+        box_marker.color.r = self.marker_color_value
+        box_marker.color.g = self.marker_color_value
+        box_marker.color.b = self.marker_color_value
+        box_marker.color.a = self.marker_color_alpha
 
         box_control = InteractiveMarkerControl()
         box_control.always_visible = True

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -7,7 +7,9 @@ from typing import Dict
 import rclpy
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
 from rclpy import Parameter
-from semantic_digital_twin.world_description.world_entity import KinematicStructureEntity
+from semantic_digital_twin.world_description.world_entity import (
+    KinematicStructureEntity,
+)
 from visualization_msgs.msg import InteractiveMarker, InteractiveMarkerControl, Marker
 from visualization_msgs.msg import InteractiveMarkerFeedback
 
@@ -39,23 +41,51 @@ class InteractiveMarkerNode:
     users to manipulate them via RViz. When a marker is moved, it generates motion
     goals that are sent to Giskard for execution.
 
-    Parameters are read from ROS parameter server:
+    Node parameters for launching the node:
 
     - root_links: List of root link names for kinematic chains
     - tip_links: List of tip link names corresponding to root_links
 
-    :var giskard: Wrapper for Giskard motion planner (computed)
-    :var markers: Dictionary mapping marker names to KinematicChainMarker instances (computed)
-    :var server: Interactive marker server for RViz (computed)
-    :var root_links: List of root link names (computed from parameters)
-    :var tip_links: List of tip link names (computed from parameters)
+    Example Node for .launch.py::
+
+        Node(
+            package="giskardpy_ros",
+            executable="interactive_marker",
+            name="giskard_interactive_marker",
+            parameters=[
+                {
+                    "root_links": ["map", "map", "map"],
+                    "tip_links": [
+                        "r_gripper_tool_frame",
+                        "l_gripper_tool_frame",
+                        "base_footprint",
+                    ],
+                }
+            ],
+            output="screen",
+        ),
     """
 
     giskard: GiskardWrapper = field(init=False)
+    """
+    Wrapper for Giskard motion planner.
+    """
     markers: Dict[str, KinematicChainMarker] = field(init=False)
+    """
+    Dictionary mapping marker names to KinematicChainMarker instances.
+    """
     server: InteractiveMarkerServer | None = field(init=False)
+    """
+    Interactive marker server for RViz.
+    """
     root_links: list = field(init=False)
+    """
+    List of root link names from parameters.
+    """
     tip_links: list = field(init=False)
+    """
+    List of tip link names from parameters.
+    """
 
     def __post_init__(self) -> None:
         """
@@ -108,7 +138,9 @@ class InteractiveMarkerNode:
                     tip_body = (
                         self.giskard.world.get_kinematic_structure_entity_by_name(tip)
                     )
-                    kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
+                    kinematic_chain = KinematicChainMarker(
+                        root, tip, root_body, tip_body
+                    )
                     self.markers[kinematic_chain.name] = kinematic_chain
 
                 return  # Success
@@ -181,7 +213,9 @@ class InteractiveMarkerNode:
                 motion_timeout := CountSeconds(seconds=MOTION_TIMEOUT_SECONDS),
             ]
         )
-        motion_statechart.add_node(EndMotion.when_any_true([goal_transformation, motion_timeout]))
+        motion_statechart.add_node(
+            EndMotion.when_any_true([goal_transformation, motion_timeout])
+        )
         self.giskard.execute_async(motion_statechart)
 
         # Reset marker pose
@@ -200,21 +234,32 @@ class KinematicChainMarker:
     This dataclass encapsulates all data and functionality needed to create and manage
     an interactive marker for a robot kinematic chain. It handles marker visualization,
     control setup (translation and rotation), and pose representation.
-
-    :var root_link: Name of the root link in the kinematic chain
-    :var tip_link: Name of the tip/end-effector link in the kinematic chain
-    :var root_body: Kinematic structure entity representing the root body
-    :var tip_body: Kinematic structure entity representing the tip body
-    :var name: Formatted name combining root and tip links (computed)
-    :var interactive_marker_message: ROS InteractiveMarker message object (computed)
     """
 
     root_link: str
+    """
+    Name of the root link in the kinematic chain.
+    """
     tip_link: str
+    """
+    Name of the tip/end-effector link in the kinematic chain.
+    """
     root_body: KinematicStructureEntity
+    """
+    Kinematic structure entity representing the root body.
+    """
     tip_body: KinematicStructureEntity
+    """
+    Kinematic structure entity representing the tip body.
+    """
     name: str = field(init=False)
+    """
+    Formatted name combining root and tip links.
+    """
     interactive_marker_message: InteractiveMarker = field(init=False)
+    """
+    ROS InteractiveMarker message object.
+    """
 
     def __post_init__(self) -> None:
         """

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -63,14 +63,6 @@ class InteractiveMarkerNode:
     """
     Timeout in seconds for motion execution.
     """
-    world_entity_retry_attempts: int = 100
-    """
-    Number of retry attempts when finding world entities.
-    """
-    world_entity_retry_delay: float = 0.5
-    """
-    Delay in seconds between retry attempts for world entities.
-    """
     giskard: GiskardWrapper = field(init=False)
     """
     Wrapper for Giskard motion planner.
@@ -123,39 +115,23 @@ class InteractiveMarkerNode:
     def _initialize_markers(self) -> None:
         """
         Attempts to find kinematic structure entities and create markers for them.
-        Retries up to world_entity_retry_attempts times with world_entity_retry_delay
-        between attempts.
 
         :raises WorldEntityNotFoundError: If entities cannot be found after all retries.
         """
-        last_error: WorldEntityNotFoundError | None = None
-
-        for attempt in range(self.world_entity_retry_attempts):
-            try:
-                for root, tip in zip(self.root_links, self.tip_links):
-                    root_body = (
-                        self.giskard.world.get_kinematic_structure_entity_by_name(root)
-                    )
-                    tip_body = (
-                        self.giskard.world.get_kinematic_structure_entity_by_name(tip)
-                    )
-                    kinematic_chain = KinematicChainMarker(
-                        root, tip, root_body, tip_body
-                    )
-                    self.markers[kinematic_chain.name] = kinematic_chain
-
-                return  # Success
-            except WorldEntityNotFoundError as error:
-                last_error = error
-                self.markers.clear()
-                sleep(self.world_entity_retry_delay)
-                self.giskard.node_handle.get_logger().error(
-                    f"Failed to find bodies in world (attempt {attempt + 1}/{self.world_entity_retry_attempts}), "
-                    f"retrying in {self.world_entity_retry_delay}s..."
+        try:
+            for root, tip in zip(self.root_links, self.tip_links):
+                root_body = self.giskard.world.get_kinematic_structure_entity_by_name(
+                    root
                 )
+                tip_body = self.giskard.world.get_kinematic_structure_entity_by_name(
+                    tip
+                )
+                kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
+                self.markers[kinematic_chain.name] = kinematic_chain
 
-        if last_error is not None:
-            raise last_error
+            return
+        except WorldEntityNotFoundError as error:
+            raise error
 
     def _setup_marker_server(self) -> None:
         """

--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/interactive_marker.py
@@ -119,15 +119,8 @@ class InteractiveMarkerNode:
         :raises WorldEntityNotFoundError: If entities cannot be found after all retries.
         """
         for root, tip in zip(self.root_links, self.tip_links):
-            try:
-                root_body = self.giskard.world.get_kinematic_structure_entity_by_name(
-                    root
-                )
-                tip_body = self.giskard.world.get_kinematic_structure_entity_by_name(
-                    tip
-                )
-            except WorldEntityNotFoundError as error:
-                raise error
+            root_body = self.giskard.world.get_kinematic_structure_entity_by_name(root)
+            tip_body = self.giskard.world.get_kinematic_structure_entity_by_name(tip)
             kinematic_chain = KinematicChainMarker(root, tip, root_body, tip_body)
             self.markers[kinematic_chain.name] = kinematic_chain
 

--- a/test/giskardpy_test/test_ros2_tools/test_collision_matrix_tool.py
+++ b/test/giskardpy_test/test_ros2_tools/test_collision_matrix_tool.py
@@ -178,3 +178,17 @@ def test_script_launch_and_kill():
     finally:
         if process.poll() is None:
             process.kill()
+
+
+def test_load_urdf_and_compute_srdf_pr2(interface):
+    pr2_xacro_path = (
+        "package://iai_pr2_description/robots/pr2_with_ft2_cableguide.xacro"
+    )
+    interface.load_urdf(pr2_xacro_path)
+    assert len(interface.world.bodies) > 0
+
+    progess_mock = MagicMock()
+    interface.compute_self_collision_matrix(
+        progress_bar=progess_mock, number_of_tries_never=100
+    )
+    assert len(interface._reasons) > 0


### PR DESCRIPTION
### Collision Matrix Tool
- Fixed robot._world being None in Collision Matrix Tool
- Added Test for running PR2 xacro through collision matrix tool load_urdf and compute_self_collision_matrix

### Interactive Markers
- Fixed the Giskard Interactive Markers only being able to handle one interactive marker.
- Changed Node parameters to STRING_ARRAY and now matches the root_links and tip_links in order.
- Added KinematicChainMarker Class to handle individual interactive markers.
- Added docstrings

PR2 with Multiple InteractiveMarkers:
<img width="462" height="503" alt="image" src="https://github.com/user-attachments/assets/98f2b838-455e-4e03-a2e7-66e2abd0bebf" />
