### PR TITLE
[SemDT] adding optional mesh_decomposer argument in world

### DIFF
--- a/semantic_digital_twin/scripts/benchmark_mesh_decomposers.py
+++ b/semantic_digital_twin/scripts/benchmark_mesh_decomposers.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+import time
+from importlib.resources import files
+from pathlib import Path
+
+import trimesh
+
+from semantic_digital_twin.adapters.mesh import STLParser
+from semantic_digital_twin.collision_checking.pybullet_collision_detector import (
+    clear_cache,
+    convert_to_decomposed_obj_and_save_in_tmp,
+    create_cache_dir,
+)
+from semantic_digital_twin.pipeline.mesh_decomposition.bullet_vhacd import (
+    BulletVHACDMeshDecomposer,
+)
+from semantic_digital_twin.pipeline.mesh_decomposition.coacd import COACDMeshDecomposer
+from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
+from semantic_digital_twin.world_description.world_entity import Body
+
+
+def load_non_convex_mesh():
+    stl_path = os.path.join(
+        Path(files("semantic_digital_twin")).parent.parent,
+        "resources",
+        "stl",
+        "jeroen_cup.stl",
+    )
+    body: Body = STLParser(stl_path).parse().root
+    return body.collision[0]
+
+
+def run(decomposer, mesh, cache_dir):
+    clear_cache(cache_dir)
+    start = time.perf_counter()
+    output_path = convert_to_decomposed_obj_and_save_in_tmp(
+        mesh, mesh_decomposer=decomposer, cache_dir=cache_dir
+    )
+    elapsed = time.perf_counter() - start
+    size_kb = os.path.getsize(output_path) / 1024
+    n_hulls = sum(1 for line in open(output_path) if line.startswith("o "))
+    return elapsed, size_kb, n_hulls
+
+
+def main():
+    cache_dir = create_cache_dir("benchmark_mesh_decomposers")
+    non_convex_mesh = load_non_convex_mesh()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        input_obj_path = os.path.join(tmp_dir, "input.obj")
+        with open(input_obj_path, "w") as f:
+            f.write(trimesh.exchange.obj.export_obj(non_convex_mesh.mesh))
+        input_size_kb = os.path.getsize(input_obj_path) / 1024
+    input_n_vertices = len(non_convex_mesh.mesh.vertices)
+    input_n_faces = len(non_convex_mesh.mesh.faces)
+
+    decomposers = [
+        ("coacd", COACDMeshDecomposer()),
+        ("vhacd", VHACDMeshDecomposer()),
+        ("bullet_vhacd", BulletVHACDMeshDecomposer()),
+    ]
+
+    results = []
+    for name, decomposer in decomposers:
+        elapsed, size_kb, n_hulls = run(decomposer, non_convex_mesh, cache_dir)
+        results.append((name, elapsed, size_kb, n_hulls))
+
+    clear_cache(cache_dir)
+
+    print("\nDecomposer characterization on jeroen_cup.stl (library defaults):")
+    print(
+        f"  input mesh: {input_size_kb:.2f} KB as .obj, "
+        f"{input_n_vertices} vertices, {input_n_faces} faces"
+    )
+    print(
+        f"{'name':<14} {'time (s)':>10} {'size (KB)':>10}"
+        f" {'hulls':>6} {'ms/hull':>9} {'KB/hull':>9}"
+    )
+    for name, elapsed, size_kb, n_hulls in results:
+        ms_per_hull = (elapsed * 1000) / n_hulls
+        kb_per_hull = size_kb / n_hulls
+        print(
+            f"{name:<14} {elapsed:>10.3f} {size_kb:>10.2f}"
+            f" {n_hulls:>6} {ms_per_hull:>9.2f} {kb_per_hull:>9.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
@@ -22,6 +22,8 @@ from semantic_digital_twin.collision_checking.collision_detector import (
     ClosestPoints,
 )
 from semantic_digital_twin.collision_checking.collision_matrix import CollisionMatrix
+from semantic_digital_twin.pipeline.mesh_decomposition.base import MeshDecomposer
+from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
 from semantic_digital_twin.utils import suppress_stdout_stderr
 from semantic_digital_twin.world_description.geometry import (
     Shape,
@@ -110,10 +112,14 @@ def create_sphere_shape(diameter: float) -> bullet.SphereShape:
     return out
 
 
-def create_shape_from_geometry(geometry: Shape) -> bullet.CollisionShape:
+def create_shape_from_geometry(
+    geometry: Shape,
+    mesh_decomposer: Optional[MeshDecomposer] = None,
+) -> bullet.CollisionShape:
     """
     Creates a bullet collision shape from a geometry.
     :param geometry: the geometry to create a collision shape from.
+    :param mesh_decomposer: optional decomposer used for non-convex meshes.
     :return: the bullet collision shape.
     """
     match geometry:
@@ -135,6 +141,7 @@ def create_shape_from_geometry(geometry: Shape) -> bullet.CollisionShape:
                 mesh=geometry,
                 single_shape=False,
                 scale=geometry.scale,
+                mesh_decomposer=mesh_decomposer,
             )
 
         case _:
@@ -143,15 +150,21 @@ def create_shape_from_geometry(geometry: Shape) -> bullet.CollisionShape:
     return shape
 
 
-def create_shape_from_body(body: Body) -> bullet.CollisionObject:
+def create_shape_from_body(
+    body: Body,
+    mesh_decomposer: Optional[MeshDecomposer] = None,
+) -> bullet.CollisionObject:
     """
     Creates a bullet collision object from a body.
     :param body: the body to create a collision object from.
+    :param mesh_decomposer: optional decomposer forwarded to non-convex mesh handling.
     :return: the bullet collision object.
     """
     shapes = []
     for collision_id, geometry in enumerate(body.collision):
-        shape = create_shape_from_geometry(geometry=geometry)
+        shape = create_shape_from_geometry(
+            geometry=geometry, mesh_decomposer=mesh_decomposer
+        )
         link_T_geometry = bullet.Transform.from_np(geometry.origin.to_np())
         shapes.append((link_T_geometry, shape))
     compouned_shape = create_compound_shape(shapes_poses=shapes)
@@ -173,17 +186,23 @@ def create_compound_shape(
 
 
 def load_convex_mesh_shape(
-    mesh: Mesh, single_shape: bool, scale: Scale
+    mesh: Mesh,
+    single_shape: bool,
+    scale: Scale,
+    mesh_decomposer: Optional[MeshDecomposer] = None,
 ) -> bullet.ConvexShape:
     """
     Loads a convex mesh shape from a mesh.
     :param mesh: the mesh to load the convex shape from.
     :param single_shape: whether to load the mesh as a single shape.
     :param scale: the scale of the mesh.
+    :param mesh_decomposer: optional decomposer used for non-convex meshes.
     :return: the bullet convex shape.
     """
-    if not mesh.mesh.is_convex:
-        obj_pkg_filename = convert_to_decomposed_obj_and_save_in_tmp(mesh=mesh.mesh)
+    if not mesh.mesh.is_convex and mesh_decomposer is not None:
+        obj_pkg_filename = convert_to_decomposed_obj_and_save_in_tmp(
+            mesh=mesh.mesh, mesh_decomposer=mesh_decomposer
+        )
     else:
         obj_pkg_filename = mesh.filename
     return bullet.load_convex_shape(
@@ -204,12 +223,14 @@ def clear_cache(cache_dir: Path = CACHE_DIR):
 
 def convert_to_decomposed_obj_and_save_in_tmp(
     mesh: Trimesh,
+    mesh_decomposer: Optional[MeshDecomposer] = None,
     cache_dir: Path = CACHE_DIR,
     log_path: Path = LOG_DIR,
 ) -> str:
     """
     Converts a mesh to a convex decomposition and saves it in a cache file.
     :param mesh: the mesh to convert.
+    :param mesh_decomposer: optional decomposer used for non-convex meshes.
     :param cache_dir: the cache directory to save the convex decomposition in.
     :param log_path: the path to the log file.
     :return: the path to the convex decomposition file.
@@ -221,9 +242,13 @@ def convert_to_decomposed_obj_and_save_in_tmp(
         create_path(obj_file_name)
         with open(obj_file_name, "w") as f:
             f.write(obj_str)
-        if not mesh.is_convex:
+        if not mesh.is_convex and mesh_decomposer is not None:
+            wrapper = Mesh.from_trimesh(mesh=mesh, scale=Scale(1.0, 1.0, 1.0))
             with suppress_stdout_stderr():
-                bullet.vhacd(obj_file_name, obj_file_name, str(log_path / "vhacd.log"))
+                parts = mesh_decomposer.apply_to_mesh(wrapper)
+            trimesh.Scene([p.mesh for p in parts]).export(
+                obj_file_name, file_type="obj"
+            )
             logging.info(f'Saved convex decomposition to "{obj_file_name}".')
         else:
             logging.info(f'Saved obj to "{obj_file_name}".')
@@ -278,6 +303,11 @@ class BulletCollisionDetector(CollisionDetector):
     The bullet collision objects in the order they are added to the world.
     This is only a cache for performance reasons.
     """
+    mesh_decomposer: Optional[MeshDecomposer] = field(default_factory=VHACDMeshDecomposer)
+    """
+    Decomposer used to split non-convex meshes into convex parts before handing them to
+    Bullet. Defaults to VHACD; pass ``None`` to skip decomposition.
+    """
 
     def sync_world_model(self) -> None:
         self.reset_cache()
@@ -301,7 +331,7 @@ class BulletCollisionDetector(CollisionDetector):
             )
 
     def add_body(self, body: Body):
-        o = create_shape_from_body(body=body)
+        o = create_shape_from_body(body=body, mesh_decomposer=self.mesh_decomposer)
         self.kineverse_world.add_collision_object(o)
         self.body_to_bullet_object[body] = o
 

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
@@ -13,7 +13,6 @@ import giskardpy_bullet_bindings as bullet
 import numpy as np
 import trimesh
 from platformdirs import user_cache_dir
-from trimesh import Trimesh
 
 from giskardpy.utils.utils import create_path
 from semantic_digital_twin.collision_checking.collision_detector import (
@@ -50,7 +49,9 @@ CACHE_DIR = create_cache_dir("convex_decompositions")
 LOG_DIR = create_cache_dir("log")
 
 
-def trimesh_quantized_hash(mesh, decimals: int = 6, digest_size: int = 16) -> str:
+def trimesh_quantized_hash(
+    mesh: trimesh.Trimesh, decimals: int = 6, digest_size: int = 16
+) -> str:
     """
     Hash tolerant to tiny float differences by rounding vertices.
     Still order-sensitive (vertex/face order changes -> different hash).
@@ -201,7 +202,7 @@ def load_convex_mesh_shape(
     """
     if not mesh.mesh.is_convex and mesh_decomposer is not None:
         obj_pkg_filename = convert_to_decomposed_obj_and_save_in_tmp(
-            mesh=mesh.mesh, mesh_decomposer=mesh_decomposer
+            mesh=mesh, mesh_decomposer=mesh_decomposer
         )
     else:
         obj_pkg_filename = mesh.filename
@@ -222,7 +223,7 @@ def clear_cache(cache_dir: Path = CACHE_DIR):
 
 
 def convert_to_decomposed_obj_and_save_in_tmp(
-    mesh: Trimesh,
+    mesh: Mesh,
     mesh_decomposer: Optional[MeshDecomposer] = None,
     cache_dir: Path = CACHE_DIR,
     log_path: Path = LOG_DIR,
@@ -235,17 +236,17 @@ def convert_to_decomposed_obj_and_save_in_tmp(
     :param log_path: the path to the log file.
     :return: the path to the convex decomposition file.
     """
-    file_hash = trimesh_quantized_hash(mesh)
+    trimesh_obj = mesh.mesh
+    file_hash = trimesh_quantized_hash(trimesh_obj)
     obj_file_name = str(cache_dir / f"{file_hash}.obj")
     if not os.path.exists(obj_file_name):
-        obj_str = trimesh.exchange.obj.export_obj(mesh)
+        obj_str = trimesh.exchange.obj.export_obj(trimesh_obj)
         create_path(obj_file_name)
         with open(obj_file_name, "w") as f:
             f.write(obj_str)
-        if not mesh.is_convex and mesh_decomposer is not None:
-            wrapper = Mesh.from_trimesh(mesh=mesh, scale=Scale(1.0, 1.0, 1.0))
+        if not trimesh_obj.is_convex and mesh_decomposer is not None:
             with suppress_stdout_stderr():
-                parts = mesh_decomposer.apply_to_mesh(wrapper)
+                parts = mesh_decomposer.apply_to_mesh(mesh)
             trimesh.Scene([p.mesh for p in parts]).export(
                 obj_file_name, file_type="obj"
             )
@@ -303,7 +304,9 @@ class BulletCollisionDetector(CollisionDetector):
     The bullet collision objects in the order they are added to the world.
     This is only a cache for performance reasons.
     """
-    mesh_decomposer: Optional[MeshDecomposer] = field(default_factory=VHACDMeshDecomposer)
+    mesh_decomposer: Optional[MeshDecomposer] = field(
+        default_factory=VHACDMeshDecomposer
+    )
     """
     Decomposer used to split non-convex meshes into convex parts before handing them to
     Bullet. Defaults to VHACD; pass ``None`` to skip decomposition.

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/pybullet_collision_detector.py
@@ -246,10 +246,7 @@ def convert_to_decomposed_obj_and_save_in_tmp(
             f.write(obj_str)
         if not trimesh_obj.is_convex and mesh_decomposer is not None:
             with suppress_stdout_stderr():
-                parts = mesh_decomposer.apply_to_mesh(mesh)
-            trimesh.Scene([p.mesh for p in parts]).export(
-                obj_file_name, file_type="obj"
-            )
+                mesh_decomposer.apply_to_mesh_and_save(mesh, obj_file_name)
             logging.info(f'Saved convex decomposition to "{obj_file_name}".')
         else:
             logging.info(f'Saved obj to "{obj_file_name}".')

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -40,6 +40,7 @@ import semantic_digital_twin.orm.model
 import semantic_digital_twin.pipeline.gltf_loader
 import semantic_digital_twin.pipeline.mesh_decomposition.base
 import semantic_digital_twin.pipeline.mesh_decomposition.box_decomposer
+import semantic_digital_twin.pipeline.mesh_decomposition.bullet_vhacd
 import semantic_digital_twin.pipeline.mesh_decomposition.coacd
 import semantic_digital_twin.pipeline.mesh_decomposition.vhacd
 import semantic_digital_twin.pipeline.pipeline
@@ -4665,6 +4666,52 @@ class BoxDecomposerDAO(
     }
 
 
+class BulletVHACDMeshDecomposerDAO(
+    MeshDecomposerDAO,
+    DataAccessObject[
+        semantic_digital_twin.pipeline.mesh_decomposition.bullet_vhacd.BulletVHACDMeshDecomposer
+    ],
+):
+
+    __tablename__ = "BulletVHACDMeshDecomposerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(MeshDecomposerDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    concavity: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    alpha: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    beta: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    gamma: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    min_volume_per_convex_hull: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+    resolution: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    max_vertices_per_convex_hull: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    depth: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    plane_downsampling: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    convex_hull_downsampling: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    pca: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    mode: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    convex_hull_approximation: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    log_path: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "BulletVHACDMeshDecomposerDAO",
+        "inherit_condition": database_id == MeshDecomposerDAO.database_id,
+    }
+
+
 class COACDMeshDecomposerDAO(
     MeshDecomposerDAO,
     DataAccessObject[
@@ -6258,6 +6305,19 @@ class BulletCollisionDetectorDAO(
         ForeignKey(CollisionDetectorDAO.database_id),
         primary_key=True,
         use_existing_column=True,
+    )
+
+    mesh_decomposer_id: Mapped[typing.Optional[builtins.int]] = mapped_column(
+        ForeignKey("MeshDecomposerDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    mesh_decomposer: Mapped[MeshDecomposerDAO] = relationship(
+        "MeshDecomposerDAO",
+        uselist=False,
+        foreign_keys=[mesh_decomposer_id],
+        post_update=True,
     )
 
     __mapper_args__ = {

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/base.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/base.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from pygments.styles import vs
 
 from semantic_digital_twin.pipeline.pipeline import Step
-from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.geometry import Shape, Mesh
 from semantic_digital_twin.world_description.shape_collection import ShapeCollection
 from semantic_digital_twin.world_description.world_entity import Body
+
+if TYPE_CHECKING:
+    from semantic_digital_twin.world import World
 
 
 @dataclass

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/base.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/base.py
@@ -32,6 +32,14 @@ class MeshDecomposer(Step, ABC):
         """
         ...
 
+    @abstractmethod
+    def apply_to_mesh_and_save(self, mesh: Mesh, output_path: str) -> str:
+        """
+        Apply the mesh decomposition to a given mesh and write the decomposed result
+        directly to ``output_path`` (an .obj file).
+        """
+        ...
+
     def apply_to_shape(self, shape: Shape) -> List[Mesh]:
         """
         Apply the mesh decomposition to a given shape.

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/box_decomposer.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/box_decomposer.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List
 
 import numpy as np
+import trimesh
 from scipy import ndimage
 
 from semantic_digital_twin.pipeline.mesh_decomposition.base import MeshDecomposer
@@ -646,3 +647,15 @@ class BoxDecomposer(MeshDecomposer):
             )
             for box in all_boxes
         ]
+
+    def apply_to_mesh_and_save(self, mesh: Mesh, output_path: str) -> str:
+        boxes = self.apply_to_mesh(mesh)
+        trimesh_boxes = []
+        for box in boxes:
+            box_mesh = trimesh.creation.box(
+                extents=(box.scale.x, box.scale.y, box.scale.z)
+            )
+            box_mesh.apply_transform(box.origin.to_np())
+            trimesh_boxes.append(box_mesh)
+        trimesh.Scene(trimesh_boxes).export(output_path, file_type="obj")
+        return output_path

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/bullet_vhacd.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/bullet_vhacd.py
@@ -1,0 +1,140 @@
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import List
+
+import giskardpy_bullet_bindings as bullet
+import trimesh
+
+from semantic_digital_twin.pipeline.mesh_decomposition.base import MeshDecomposer
+from semantic_digital_twin.world_description.geometry import Mesh
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BulletVHACDMeshDecomposer(MeshDecomposer):
+    """
+    Decompose meshes using Voxelized Hierarchical Approximate Convex Decomposition
+    via the Bullet binding (``giskardpy_bullet_bindings.vhacd``).
+
+    Any parameter left at ``-1`` is forwarded as-is and tells V-HACD to use its
+    internal default for that parameter.
+    """
+
+    concavity: float = -1
+    """
+    Maximum concavity of each generated convex hull.
+    """
+
+    alpha: float = -1
+    """
+    Bias toward symmetry-plane clipping during decomposition.
+    """
+
+    beta: float = -1
+    """
+    Bias toward revolution-axis clipping during decomposition.
+    """
+
+    gamma: float = -1
+    """
+    Maximum allowed concavity during the merge step.
+    """
+
+    min_volume_per_convex_hull: float = -1
+    """
+    Minimum volume to add vertices to a convex hull.
+    """
+
+    resolution: int = -1
+    """
+    Voxel grid resolution used to represent the mesh during processing.
+    """
+
+    max_vertices_per_convex_hull: int = -1
+    """
+    Maximum number of vertices allowed per generated convex hull.
+    """
+
+    depth: int = -1
+    """
+    Maximum recursion depth of the decomposition.
+    """
+
+    plane_downsampling: int = -1
+    """
+    Granularity of the search for the best clipping plane.
+    """
+
+    convex_hull_downsampling: int = -1
+    """
+    Precision of the convex-hull generation during clipping plane search.
+    """
+
+    pca: int = -1
+    """
+    Whether to enable Principal Component Analysis preprocessing (1) or not (0).
+    """
+
+    mode: int = -1
+    """
+    Decomposition mode: 0 = voxel-based, 1 = tetrahedron-based.
+    """
+
+    convex_hull_approximation: int = -1
+    """
+    Whether to approximate the generated convex hulls (1) or not (0).
+    """
+
+    log_path: str = "/tmp/vhacd.log"
+    """
+    Path to a file where V-HACD writes its log output.
+    """
+
+    def apply_to_mesh(self, mesh: Mesh) -> List[Mesh]:
+        """
+        Decompose the mesh and return the resulting convex parts as ``Mesh`` objects.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = os.path.join(tmp_dir, "output.obj")
+            self.apply_to_mesh_and_save(mesh, output_path)
+            return self._load_convex_parts(output_path, origin=mesh.origin)
+
+    def apply_to_mesh_and_save(self, mesh: Mesh, output_path: str) -> str:
+        """
+        Decompose the mesh and write the resulting multi-hull .obj directly to
+        ``output_path``.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            input_path = os.path.join(tmp_dir, "input.obj")
+            with open(input_path, "w") as f:
+                f.write(trimesh.exchange.obj.export_obj(mesh.mesh))
+            bullet.vhacd(
+                input_path,
+                output_path,
+                self.log_path,
+                self.concavity,
+                self.alpha,
+                self.beta,
+                self.gamma,
+                self.min_volume_per_convex_hull,
+                self.resolution,
+                self.max_vertices_per_convex_hull,
+                self.depth,
+                self.plane_downsampling,
+                self.convex_hull_downsampling,
+                self.pca,
+                self.mode,
+                self.convex_hull_approximation,
+            )
+        return output_path
+
+    @staticmethod
+    def _load_convex_parts(path: str, origin) -> List[Mesh]:
+        loaded = trimesh.load(path, process=False)
+        return [
+            Mesh.from_trimesh(mesh=part, origin=origin)
+            for part in loaded.split(only_watertight=False)
+        ]

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/coacd.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/coacd.py
@@ -187,3 +187,8 @@ class COACDMeshDecomposer(MeshDecomposer):
             )
 
         return new_geometry
+
+    def apply_to_mesh_and_save(self, mesh: Mesh, output_path: str) -> str:
+        parts = self.apply_to_mesh(mesh)
+        trimesh.Scene([p.mesh for p in parts]).export(output_path, file_type="obj")
+        return output_path

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/vhacd.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/mesh_decomposition/vhacd.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import List
 
+import trimesh
+
 from semantic_digital_twin.pipeline.mesh_decomposition.base import MeshDecomposer
 from semantic_digital_twin.world_description.geometry import Mesh
 
@@ -125,3 +127,8 @@ class VHACDMeshDecomposer(MeshDecomposer):
             for decomposed_part in decomposed
         ]
         return new_geometry
+
+    def apply_to_mesh_and_save(self, mesh: Mesh, output_path: str) -> str:
+        parts = self.apply_to_mesh(mesh)
+        trimesh.Scene([p.mesh for p in parts]).export(output_path, file_type="obj")
+        return output_path

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/pipeline.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/pipeline.py
@@ -1,21 +1,25 @@
+from __future__ import annotations
+
 import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Callable
+from typing import List, Callable, TYPE_CHECKING
 
 import numpy as np
 
-from semantic_digital_twin.semantic_annotations.mixins import (
-    HasRootKinematicStructureEntity,
-)
 from semantic_digital_twin.spatial_types import Point3
 from semantic_digital_twin.spatial_types.spatial_types import (
     HomogeneousTransformationMatrix,
 )
-from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.geometry import Mesh
 from semantic_digital_twin.world_description.world_entity import Body
+
+if TYPE_CHECKING:
+    from semantic_digital_twin.semantic_annotations.mixins import (
+        HasRootKinematicStructureEntity,
+    )
+    from semantic_digital_twin.world import World
 
 
 @dataclass

--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/mixins.py
@@ -43,7 +43,6 @@ from semantic_digital_twin.spatial_types import (
     HomogeneousTransformationMatrix,
     Vector3,
 )
-from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.connections import (
     FixedConnection,
 )
@@ -66,6 +65,7 @@ from semantic_digital_twin.world_description.world_modification import (
 )
 
 if TYPE_CHECKING:
+    from semantic_digital_twin.world import World
     from semantic_digital_twin.semantic_annotations.semantic_annotations import (
         Drawer,
         Door,

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -106,6 +106,9 @@ from semantic_digital_twin.world_description.world_modification import (
 from semantic_digital_twin.world_description.world_state import WorldState
 from krrood.utils import memoize, clear_memoization_cache
 
+from semantic_digital_twin.pipeline.mesh_decomposition.base import MeshDecomposer
+from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
+
 if TYPE_CHECKING:
     from semantic_digital_twin.spatial_types import GenericSpatialType
 
@@ -392,6 +395,15 @@ class World(HasSimulatorProperties):
     Class that manages collision detection related stuff for this world.
     """
 
+    mesh_decomposer: Optional[MeshDecomposer] = field(
+        default_factory=VHACDMeshDecomposer, kw_only=True
+    )
+    """
+    Decomposer used by the Bullet collision detector to split non-convex meshes into
+    convex parts. Defaults to VHACD; pass ``None`` to skip decomposition (non-convex
+    meshes will then be treated as their convex hulls).
+    """
+
     _current_active_atomic_world_modification: Optional[Callable] = field(
         init=False, default=None
     )
@@ -436,7 +448,10 @@ class World(HasSimulatorProperties):
         self.state = WorldState(_world=self)
         self._forward_kinematic_manager = ForwardKinematicsManager(_world=self)
         self.collision_manager = CollisionManager(
-            _world=self, collision_detector=BulletCollisionDetector(_world=self)
+            _world=self,
+            collision_detector=BulletCollisionDetector(
+                _world=self, mesh_decomposer=self.mesh_decomposer
+            ),
         )
 
     def __hash__(self):

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -587,6 +587,27 @@ class Mesh(Shape):
             pass
 
     @classmethod
+    def box(
+        cls,
+        extents: Tuple[float, float, float] = (1.0, 1.0, 1.0),
+        origin: Optional[HomogeneousTransformationMatrix] = None,
+        scale: Optional[Scale] = None,
+    ) -> "Mesh":
+        """
+        Create a box-shaped Mesh.
+
+        :param extents: Side lengths of the box along x, y, z.
+        :param origin: Origin of the mesh.
+        :param scale: Scale of the mesh.
+        :return: Mesh wrapping a box trimesh.
+        """
+        return cls.from_trimesh(
+            mesh=trimesh.creation.box(extents=extents),
+            origin=origin,
+            scale=scale,
+        )
+
+    @classmethod
     def from_vertices_and_faces(
         cls,
         vertices: np.ndarray,

--- a/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
+++ b/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
@@ -12,6 +12,8 @@ from semantic_digital_twin.collision_checking.pybullet_collision_detector import
     convert_to_decomposed_obj_and_save_in_tmp,
     create_cache_dir,
 )
+from semantic_digital_twin.pipeline.mesh_decomposition.coacd import COACDMeshDecomposer
+from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
 from semantic_digital_twin.world_description.world_entity import Body
 
 
@@ -48,19 +50,32 @@ def convex_mesh():
     return mesh
 
 
-def test_convert_non_convex_mesh_decomposes(clean_cache, cache_dir, non_convex_mesh):
+@pytest.fixture(
+    scope="module",
+    params=[COACDMeshDecomposer, VHACDMeshDecomposer],
+    ids=["coacd", "vhacd"],
+)
+def mesh_decomposer(request):
+    return request.param()
+
+
+def test_convert_non_convex_mesh_decomposes(
+    clean_cache, cache_dir, non_convex_mesh, mesh_decomposer
+):
     """
     Test that for a non-convex mesh, the function produces a valid .obj file in the cache directory.
     """
     output_path = convert_to_decomposed_obj_and_save_in_tmp(
-        non_convex_mesh, cache_dir=cache_dir
+        non_convex_mesh, mesh_decomposer=mesh_decomposer, cache_dir=cache_dir
     )
 
     assert os.path.exists(output_path)
     assert output_path.endswith(".obj")
     assert str(cache_dir) in output_path
-    # For non-convex, it should have triggered VHACD (we can't easily check if VHACD ran
-    # but we can check if it exists and is not empty)
+    # The decomposer should have produced multiple convex parts, written as multiple
+    # 'o' groups in the OBJ. A single-group OBJ would mean decomposition didn't run.
+    n_objects = sum(1 for line in open(output_path) if line.startswith("o "))
+    assert n_objects > 1
     assert os.path.getsize(output_path) > 0
 
 
@@ -77,27 +92,33 @@ def test_convert_convex_mesh_saves_directly(clean_cache, cache_dir, convex_mesh)
     assert str(cache_dir) in output_path
 
 
-def test_convert_caching_behavior(clean_cache, non_convex_mesh):
+def test_convert_caching_behavior(clean_cache, cache_dir, non_convex_mesh, mesh_decomposer):
     """
     Test that calling the function twice with the same mesh returns the same file path
     and does not re-run the decomposition process (same modification time).
     """
-    path1 = convert_to_decomposed_obj_and_save_in_tmp(non_convex_mesh)
+    path1 = convert_to_decomposed_obj_and_save_in_tmp(
+        non_convex_mesh, mesh_decomposer=mesh_decomposer, cache_dir=cache_dir
+    )
 
     # Capture modification time
     mtime1 = os.path.getmtime(path1)
 
-    path2 = convert_to_decomposed_obj_and_save_in_tmp(non_convex_mesh)
+    path2 = convert_to_decomposed_obj_and_save_in_tmp(
+        non_convex_mesh, mesh_decomposer=mesh_decomposer, cache_dir=cache_dir
+    )
 
     assert path1 == path2
     assert os.path.getmtime(path2) == mtime1
 
 
-def test_generated_obj_is_loadable(clean_cache, non_convex_mesh):
+def test_generated_obj_is_loadable(clean_cache, cache_dir, non_convex_mesh, mesh_decomposer):
     """
     Verify that the generated file can be loaded via pb.load_convex_shape.
     """
-    output_path = convert_to_decomposed_obj_and_save_in_tmp(non_convex_mesh)
+    output_path = convert_to_decomposed_obj_and_save_in_tmp(
+        non_convex_mesh, mesh_decomposer=mesh_decomposer, cache_dir=cache_dir
+    )
     shape = pb.load_convex_shape(
         output_path, single_shape=False, scaling=pb.Vector3(1, 1, 1)
     )

--- a/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
+++ b/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
@@ -2,7 +2,6 @@ import os
 
 import giskardpy_bullet_bindings as pb
 import pytest
-import trimesh
 from importlib.resources import files
 from pathlib import Path
 
@@ -14,6 +13,7 @@ from semantic_digital_twin.collision_checking.pybullet_collision_detector import
 )
 from semantic_digital_twin.pipeline.mesh_decomposition.coacd import COACDMeshDecomposer
 from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
+from semantic_digital_twin.world_description.geometry import Mesh
 from semantic_digital_twin.world_description.world_entity import Body
 
 
@@ -39,15 +39,13 @@ def non_convex_mesh():
     )
     world_with_stl = STLParser(stl_path).parse()
     body: Body = world_with_stl.root
-    mesh = body.collision[0]
-    return mesh.mesh
+    return body.collision[0]
 
 
 @pytest.fixture
 def convex_mesh():
     # A box is convex
-    mesh = trimesh.creation.box(extents=(1, 1, 1))
-    return mesh
+    return Mesh.box(extents=(1, 1, 1))
 
 
 @pytest.fixture(
@@ -92,7 +90,9 @@ def test_convert_convex_mesh_saves_directly(clean_cache, cache_dir, convex_mesh)
     assert str(cache_dir) in output_path
 
 
-def test_convert_caching_behavior(clean_cache, cache_dir, non_convex_mesh, mesh_decomposer):
+def test_convert_caching_behavior(
+    clean_cache, cache_dir, non_convex_mesh, mesh_decomposer
+):
     """
     Test that calling the function twice with the same mesh returns the same file path
     and does not re-run the decomposition process (same modification time).
@@ -112,7 +112,9 @@ def test_convert_caching_behavior(clean_cache, cache_dir, non_convex_mesh, mesh_
     assert os.path.getmtime(path2) == mtime1
 
 
-def test_generated_obj_is_loadable(clean_cache, cache_dir, non_convex_mesh, mesh_decomposer):
+def test_generated_obj_is_loadable(
+    clean_cache, cache_dir, non_convex_mesh, mesh_decomposer
+):
     """
     Verify that the generated file can be loaded via pb.load_convex_shape.
     """

--- a/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
+++ b/test/semantic_digital_twin_test/test_collision_checking/test_giskard_bullet_wrapper.py
@@ -11,6 +11,9 @@ from semantic_digital_twin.collision_checking.pybullet_collision_detector import
     convert_to_decomposed_obj_and_save_in_tmp,
     create_cache_dir,
 )
+from semantic_digital_twin.pipeline.mesh_decomposition.bullet_vhacd import (
+    BulletVHACDMeshDecomposer,
+)
 from semantic_digital_twin.pipeline.mesh_decomposition.coacd import COACDMeshDecomposer
 from semantic_digital_twin.pipeline.mesh_decomposition.vhacd import VHACDMeshDecomposer
 from semantic_digital_twin.world_description.geometry import Mesh
@@ -50,8 +53,8 @@ def convex_mesh():
 
 @pytest.fixture(
     scope="module",
-    params=[COACDMeshDecomposer, VHACDMeshDecomposer],
-    ids=["coacd", "vhacd"],
+    params=[COACDMeshDecomposer, VHACDMeshDecomposer, BulletVHACDMeshDecomposer],
+    ids=["coacd", "vhacd", "bullet_vhacd"],
 )
 def mesh_decomposer(request):
     return request.param()


### PR DESCRIPTION
## Summary
- Plumbs an optional `MeshDecomposer` from `World` through `BulletCollisionDetector`; non-convex meshes are now decomposed into convex parts (default: `VHACDMeshDecomposer`) instead of collapsed to a single convex hull.
- Updates `convert_to_decomposed_obj_and_save_in_tmp` to use the `MeshDecomposer.apply_to_mesh` + `trimesh.Scene(...).export(...)` API.
- Moves `World` / `HasRootKinematicStructureEntity` imports into `if TYPE_CHECKING:` blocks in `pipeline.py`, `mesh_decomposition/base.py`, and `mixins.py` to break a circular import.
- Parametrizes the bullet-wrapper tests across CoACD and VHACD decomposers.
