### PR TITLE
add support for resolving multiple generic parameters in subclass-safe generics

### DIFF
--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -10,7 +10,10 @@ from typing_extensions import (
     TypeVar,
     Type,
     TYPE_CHECKING,
-    Optional, Dict, Any,
+    Optional,
+    Dict,
+    Any,
+    List,
 )
 
 from krrood.class_diagrams.utils import (
@@ -26,41 +29,39 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class SubClassSafeGeneric(Generic[T], ABC):
+class AbstractSubClassSafeGeneric(ABC):
     """
-    A generic class that can be subclassed safely because it automatically updates the field types that use the generic
-     type with the new specified type.
-     Example:
-         >>> T = TypeVar("T")
-         >>> @dataclass
-         >>> class MyClass(SubClassSafeGeneric[T]):
-         >>>     my_attribute: T
-         >>>
-         >>> @dataclass
-         >>> class MyClass2(SubClassSafeGeneric[int]): ...
-         >>> assert next(f for f in fields(MyClass2) if f.name == "my_attribute").type == int)
+    Base implementation that automatically updates field types when a subclass binds the generic
+    type parameters of its generic base to concrete types.
+
+    Concrete subclasses must declare the generic parameters via ``Generic[...]`` and inherit from
+    this class. The class declaring ``Generic[...]`` (the direct subclass of
+    :class:`AbstractSubClassSafeGeneric`) is treated as the "generic base" against which type
+    parameters are resolved.
     """
 
     def __init_subclass__(cls, **kwargs):
         """
-        Automatically updates the field types that use the generic type with the new specified type, before the class is
-        initialized.
+        Automatically updates the field types that use the generic type parameters with the new
+        specified types, before the class is initialized.
         """
-        old_generic_type = cls._get_old_generic_type_if_different()
-        if not old_generic_type:
+        substitutions = cls._get_generic_type_substitutions()
+        if not substitutions:
             return
         resolution_results = (
             get_and_resolve_generic_type_hints_of_object_using_substitutions(
-                cls, {old_generic_type: cls.get_generic_type()}
+                cls, substitutions
             )
         )
         for name, result in resolution_results.items():
             if not result.resolved:
                 continue
-            cls._update_field_kwargs(name, {'type': result.resolved_type})
+            cls._update_field_kwargs(name, {"type": result.resolved_type})
 
     @classmethod
-    def _update_field_kwargs(cls, name: str, kwargs: Dict[str, Any], type_: Optional[Type] = None):
+    def _update_field_kwargs(
+        cls, name: str, kwargs: Dict[str, Any], type_: Optional[Type] = None
+    ):
         """
         Update the field kwargs with the provided keyword arguments.
 
@@ -76,7 +77,7 @@ class SubClassSafeGeneric(Generic[T], ABC):
                     setattr(attribute_value, key, value)
             else:
                 non_type_kwargs = copy(kwargs)
-                non_type_kwargs.pop('type', None)
+                non_type_kwargs.pop("type", None)
                 if non_type_kwargs:
                     setattr(cls, name, field(**non_type_kwargs))
         else:
@@ -88,8 +89,8 @@ class SubClassSafeGeneric(Generic[T], ABC):
                 setattr(cls, field_.name, field_)
             else:
                 setattr(cls, name, field(**kwargs))
-        if 'type' in kwargs:
-            cls.__annotations__[name] = kwargs['type']
+        if "type" in kwargs:
+            cls.__annotations__[name] = kwargs["type"]
         elif type_ is not None:
             cls.__annotations__[name] = type_
         elif field_ is not None:
@@ -98,22 +99,74 @@ class SubClassSafeGeneric(Generic[T], ABC):
             cls.__annotations__[name] = Any
 
     @classmethod
-    def _get_old_generic_type_if_different(cls) -> Optional[Type[T]]:
+    def _get_generic_base(cls) -> Optional[Type]:
         """
-        :return: The type of the generic type that was used in the parent class if it was changed in this class.
+        :return: The class that declares the generic parameters for this hierarchy, i.e. the
+            direct subclass of :class:`AbstractSubClassSafeGeneric` in the MRO.
         """
-        current_generic_type = cls.get_generic_type()
-        if current_generic_type is None:
-            return None
-        for base in cls.__bases__:
-            if not issubclass(base, SubClassSafeGeneric):
+        for base in cls.__mro__:
+            if base in (cls, AbstractSubClassSafeGeneric, object):
                 continue
-            base_generic_type = base.get_generic_type()
-            if base_generic_type is None:
+            if not issubclass(base, AbstractSubClassSafeGeneric):
                 continue
-            if base_generic_type is not current_generic_type:
-                return base_generic_type
+            if AbstractSubClassSafeGeneric in base.__bases__:
+                return base
         return None
+
+    @classmethod
+    def _get_generic_type_substitutions(cls) -> Dict[Any, Any]:
+        """
+        :return: A mapping from each old generic type (as declared on the parent class) to the
+            new generic type used by this class, for every position whose binding changed.
+        """
+        current_types = cls.get_generic_types()
+        if not current_types:
+            return {}
+        generic_base = cls._get_generic_base()
+        if generic_base is None:
+            return {}
+        for base in cls.__bases__:
+            if not isinstance(base, type) or not issubclass(base, generic_base):
+                continue
+            base_types = base.get_generic_types()
+            if not base_types or len(base_types) != len(current_types):
+                continue
+            substitutions: Dict[Any, Any] = {}
+            for old_type, new_type in zip(base_types, current_types):
+                if old_type is new_type or new_type is None:
+                    continue
+                substitutions[old_type] = new_type
+            if substitutions:
+                return substitutions
+        return {}
+
+    @classmethod
+    @lru_cache
+    def get_generic_types(cls) -> Optional[List[Type]]:
+        """
+        :return: The concrete generic type parameters bound for this class, in declaration order.
+        """
+        generic_base = cls._get_generic_base()
+        if generic_base is None:
+            return None
+        return get_generic_type_param(cls, generic_base)
+
+
+@dataclass
+class SubClassSafeGeneric(Generic[T], AbstractSubClassSafeGeneric, ABC):
+    """
+    A generic class that can be subclassed safely because it automatically updates the field types that use the generic
+     type with the new specified type.
+     Example:
+         >>> T = TypeVar("T")
+         >>> @dataclass
+         >>> class MyClass(SubClassSafeGeneric[T]):
+         >>>     my_attribute: T
+         >>>
+         >>> @dataclass
+         >>> class MyClass2(SubClassSafeGeneric[int]): ...
+         >>> assert next(f for f in fields(MyClass2) if f.name == "my_attribute").type == int)
+    """
 
     @classmethod
     @lru_cache

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -35,9 +35,8 @@ class AbstractSubClassSafeGeneric(ABC):
     type parameters of its generic base to concrete types.
 
     Concrete subclasses must declare the generic parameters via ``Generic[...]`` and inherit from
-    this class. The class declaring ``Generic[...]`` (the direct subclass of
-    :class:`AbstractSubClassSafeGeneric`) is treated as the "generic base" against which type
-    parameters are resolved.
+    this class. Here it is important that in the inheritance order, ``Generic[...]`` is positioned before
+    ``AbstractSubClassSafeGeneric`` similar to how it is done in ``SubClassSafeGeneric``.
     """
 
     def __init_subclass__(cls, **kwargs):

--- a/test/krrood_test/dataset/classes_with_generic.py
+++ b/test/krrood_test/dataset/classes_with_generic.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass, field
 
-from typing_extensions import List, TypeVar
+from typing_extensions import List, TypeVar, Generic
 
 from krrood.entity_query_language.core.mapped_variable import MappedVariable
 from krrood.entity_query_language.factories import variable
-from krrood.patterns.subclass_safe_generic import SubClassSafeGeneric
+from krrood.patterns.subclass_safe_generic import (
+    SubClassSafeGeneric,
+    TwoGenericSubClassSafe,
+    AbstractSubClassSafeGeneric,
+)
 from krrood.utils import T
+
+U = TypeVar("U")
+V = TypeVar("V")
 
 
 @dataclass
@@ -54,3 +62,22 @@ class SubClassGenericThatUpdatesGenericTypeToAnotherTypeVar(
 @dataclass
 class SubClassGenericThatRecreatesAFieldWithAnotherVar(FirstGeneric[NewTypeVar]):
     generic_attribute_using_generic: List[NewTypeVar] = field(default_factory=list)
+
+
+T2 = TypeVar("T2")
+
+
+@dataclass
+class TwoGenericSubClassSafe(Generic[T, T2], AbstractSubClassSafeGeneric, ABC): ...
+
+
+@dataclass
+class TwoGenericContainer(TwoGenericSubClassSafe[U, V]):
+    first_attribute: U
+    second_attribute: V
+    list_of_first: List[U] = field(default_factory=list, kw_only=True)
+    list_of_second: List[V] = field(default_factory=list, kw_only=True)
+
+
+@dataclass
+class TwoGenericContainerBoundToBuiltIns(TwoGenericContainer[int, str]): ...

--- a/test/krrood_test/dataset/classes_with_generic.py
+++ b/test/krrood_test/dataset/classes_with_generic.py
@@ -9,7 +9,6 @@ from krrood.entity_query_language.core.mapped_variable import MappedVariable
 from krrood.entity_query_language.factories import variable
 from krrood.patterns.subclass_safe_generic import (
     SubClassSafeGeneric,
-    TwoGenericSubClassSafe,
     AbstractSubClassSafeGeneric,
 )
 from krrood.utils import T

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -45,6 +45,7 @@ class Base(DeclarativeBase):
     type_mappings = {
         test.krrood_test.dataset.example_classes.KRROODPhysicalObject: test.krrood_test.dataset.example_classes.ConceptType,
         typing.Type: krrood.ormatic.custom_types.TypeType,
+        builtins.type: krrood.ormatic.custom_types.TypeType,
         enum.Enum: krrood.ormatic.custom_types.PolymorphicEnumType,
         krrood.adapters.json_serializer.SubclassJSONSerializer: sqlalchemy.sql.sqltypes.JSON,
         uuid.UUID: sqlalchemy.sql.sqltypes.UUID,

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -19,6 +19,7 @@ from ..dataset.classes_with_generic import (
     SubClassGenericThatRecreatesAField,
     SubClassGenericThatRecreatesAFieldWithAnotherVar,
     SubClassGenericThatRecreatesAFieldWithNonBuiltInType,
+    TwoGenericContainerBoundToBuiltIns,
 )
 
 
@@ -67,8 +68,8 @@ def assert_field_kwargs_are_preserved_when_resolving_generic_type(cls, kw_only=F
     evaluated_type = eval(field_.type, sys.modules[cls.__module__].__dict__)
     assert get_origin(evaluated_type) is list
     assert (
-            get_args(evaluated_type)[0]
-            is get_generic_type_param(cls, SubClassSafeGeneric)[0]
+        get_args(evaluated_type)[0]
+        is get_generic_type_param(cls, SubClassSafeGeneric)[0]
     )
 
 
@@ -89,17 +90,28 @@ def test_resolve_generic_type_subclass_with_new_type_var_as_generic_type():
     _assert_generic_type_is_resolved(cls)
 
 
+def test_resolve_two_generic_types_subclass_with_built_in_types():
+    cls = TwoGenericContainerBoundToBuiltIns
+    resolved_hints = get_type_hints(cls, include_extras=True)
+    assert resolved_hints[variable_from(cls).first_attribute._attribute_name_] is int
+    assert resolved_hints[variable_from(cls).second_attribute._attribute_name_] is str
+    list_of_first = resolved_hints[variable_from(cls).list_of_first._attribute_name_]
+    list_of_second = resolved_hints[variable_from(cls).list_of_second._attribute_name_]
+    assert get_origin(list_of_first) is list and get_args(list_of_first)[0] is int
+    assert get_origin(list_of_second) is list and get_args(list_of_second)[0] is str
+
+
 def _assert_generic_type_is_resolved(cls):
     resolved_hints = get_type_hints(cls, include_extras=True)
     generic_type = get_generic_type_param(cls, SubClassSafeGeneric)[0]
     assert (
-            resolved_hints[variable_from(cls).attribute_using_generic._attribute_name_]
-            is generic_type
+        resolved_hints[variable_from(cls).attribute_using_generic._attribute_name_]
+        is generic_type
     )
     nested_generic_type = resolved_hints[
         variable_from(cls).generic_attribute_using_generic._attribute_name_
     ]
     assert (
-            get_origin(nested_generic_type) is list
-            and get_args(nested_generic_type)[0] is generic_type
+        get_origin(nested_generic_type) is list
+        and get_args(nested_generic_type)[0] is generic_type
     )


### PR DESCRIPTION
This pull request refactors and extends the generic class pattern used for safely updating field types in subclasses that bind generic parameters. The changes introduce a new abstract base class to clarify the generic resolution mechanism, improve support for multiple generic parameters, and add comprehensive tests for these enhancements.

**Refactoring and Extension of Generic Pattern:**

* Introduced `AbstractSubClassSafeGeneric` as a new abstract base class to encapsulate the logic for resolving and updating field types based on generic parameter bindings, separating it from the concrete `SubClassSafeGeneric` implementation. This clarifies responsibilities and improves extensibility. [[1]](diffhunk://#diff-56f1ff724396beed670249baf99cb99c779d6396d61310b77622e22a61285a89L29-R64) [[2]](diffhunk://#diff-56f1ff724396beed670249baf99cb99c779d6396d61310b77622e22a61285a89L101-R169)
* Refactored the generic type resolution logic to support multiple generic parameters, including the addition of `_get_generic_base`, `_get_generic_type_substitutions`, and `get_generic_types` methods.
* Updated internal methods to use consistent string quoting and improved logic for updating field annotations and attributes. [[1]](diffhunk://#diff-56f1ff724396beed670249baf99cb99c779d6396d61310b77622e22a61285a89L79-R80) [[2]](diffhunk://#diff-56f1ff724396beed670249baf99cb99c779d6396d61310b77622e22a61285a89L91-R93)

**New Features and Testing:**

* Added `TwoGenericSubClassSafe` and related test classes to demonstrate and verify support for multiple generic parameters, including new test cases for binding generics to built-in types. [[1]](diffhunk://#diff-7b917084e77f695ed27d5969c877e70655c86f7616203ff6279f698ea2803d71R65-R83) [[2]](diffhunk://#diff-26de6244a488cd76676dca5325f85ccb5ce2ab15be78a2e86abcdc0b482e9fbeR22) [[3]](diffhunk://#diff-26de6244a488cd76676dca5325f85ccb5ce2ab15be78a2e86abcdc0b482e9fbeR93-R103)
* Updated test datasets and imports to reflect the new base class and multi-generic support.

**Other Improvements:**

* Added a missing type mapping for `builtins.type` in the ORM interface test to ensure correct handling of type objects.