### PR TITLE
Motion Statechart Inspector bug fix

### DIFF
--- a/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/motion_statechart_inspector.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/scripts/tools/motion_statechart_inspector.py
@@ -216,7 +216,7 @@ class DotGraphViewer(QWidget):
         if self.topic_selector.currentText() == "":
             # Find all topics of type ExecutionState
             topics = rospy.node.get_topic_names_and_types()
-            target_type = "giskard_msgs/action/JsonAction_FeedbackMessage"
+            target_type = "json_msgs/action/JsonAction_FeedbackMessage"
             execution_state_topics = [
                 name for name, types in topics if target_type in types
             ]

--- a/giskardpy/src/giskardpy/tree/behaviors/publish_feedback.py
+++ b/giskardpy/src/giskardpy/tree/behaviors/publish_feedback.py
@@ -32,7 +32,8 @@ class PublishFeedback(GiskardBehavior):
     @record_time
     def update(self):
         data = {}
-        if self.has_new_goal():
+        has_new_goal = self.has_new_goal()
+        if has_new_goal:
             self.last_goal_id = self.move_action_server.goal_id
             data["motion_statechart"] = (
                 GiskardBlackboard().motion_statechart.create_structure_copy().to_json()
@@ -46,7 +47,7 @@ class PublishFeedback(GiskardBehavior):
             GiskardBlackboard().motion_statechart.observation_state.to_json()
         )
 
-        if self.has_state_changed() or self.has_new_goal():
+        if self.has_state_changed() or has_new_goal:
             msg = JsonAction.Feedback()
             msg.feedback = json.dumps(data)
             self.move_action_server.send_feedback(msg)


### PR DESCRIPTION
In `motion_statechart_inspector.py` changed giskard_msgs to json_msgs to find correct topic.
- Fixed an issue, where no input could be received and as such, no diagrams where generated and shown

In `publish_feedback.py` fixed a logic error, where self.has_new_goal()'s output would change between the if-condition, because self.last_goal_id would be overwritten in the first if-condition. Added variable to save self.has_new_goal() state to stay consistent during the method call.
- Fixed an issue, where sometimes new goals would not get an updated motion statechart, causing the amount of statechart nodes and lifecycle/observation states to be out of sync.