### PR TITLE
Collision Matrix Tool Bugfix

### DIFF
--- a/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
+++ b/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
@@ -184,9 +184,23 @@ class SelfCollisionMatrixInterface:
             )
 
     def safe_srdf(self, file_path: str):
+        self._sync_reasons_to_collision_pairs()
         self.self_collision_matrix_rule.save_self_collision_matrix(
             self.robot.name.name, file_path
         )
+
+    def _sync_reasons_to_collision_pairs(self):
+        """
+        Synchronizes the _reasons dictionary back into allowed_collision_pairs.
+        This ensures UI changes are persisted when saving the SRDF.
+        """
+        self.self_collision_matrix_rule.allowed_collision_pairs.clear()
+        for (body_a, body_b), reason in self._reasons.items():
+            if reason is not None:
+                collision_check = CollisionCheck.create_and_validate(body_a, body_b)
+                self.self_collision_matrix_rule.allowed_collision_pairs.add(
+                    collision_check
+                )
 
     def add_body(self, body: Body):
         self.self_collision_matrix_rule.allowed_collision_bodies.discard(body)


### PR DESCRIPTION
### Bugged behavior
Manual changes to the collision pairs did not get saved.

### Fix
Before saving the srdf-File, apply changes from the UI to the actual collision matrix rule.