### PR TITLE
[Giskard] Removed switched arrow direction for TransitionKind.END

### DIFF
--- a/giskardpy/src/giskardpy/motion_statechart/plotters/plot_specs.py
+++ b/giskardpy/src/giskardpy/motion_statechart/plotters/plot_specs.py
@@ -109,11 +109,7 @@ TRANSITION_SPECS: Dict[TransitionKind, EdgeSpec] = {
         src_selector="child",
         dst_selector="parent",
         state_selector="child",
-        extra_edge_kwargs={
-            "arrowhead": "none",
-            "arrowtail": "normal",
-            "dir": "both",
-        },
+        extra_edge_kwargs={},
     ),
     TransitionKind.RESET: EdgeSpec(
         color=ConditionColors.ResetCondColor,


### PR DESCRIPTION
### Change
Removed the `extra_edge_kwargs` from TransitionKind.END for easier flow of information in the generated dot graphs for MotionStatecharts.

### Example
#### Before
<img width="531" height="977" alt="before" src="https://github.com/user-attachments/assets/a73f6f17-c394-4298-9653-0931357fbe5d" />  

#### After
<img width="531" height="977" alt="after" src="https://github.com/user-attachments/assets/4ace21f2-09e2-40d0-94bc-b175143643ff" />
