### PR TITLE
Fix license of physics_simulators package

### DIFF
--- a/physics_simulators/pyproject.toml
+++ b/physics_simulators/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-license = "MIT"
+license = {text = "MIT"}
 
 dependencies = [
     "mujoco",


### PR DESCRIPTION
Fixed the license string in the physics_simulators package. 
It caused an error during compilation.