### PR TITLE
Tighten velocity limits proportinal

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -52,6 +52,7 @@ import semantic_digital_twin.robots.armar
 import semantic_digital_twin.robots.armar7
 import semantic_digital_twin.robots.boxy
 import semantic_digital_twin.robots.donbot
+import semantic_digital_twin.robots.garmi
 import semantic_digital_twin.robots.hsrb
 import semantic_digital_twin.robots.icub3
 import semantic_digital_twin.robots.justin
@@ -73,6 +74,7 @@ import semantic_digital_twin.semantic_annotations.semantic_annotations
 import semantic_digital_twin.spatial_computations.ik_solver
 import semantic_digital_twin.spatial_types.derivatives
 import semantic_digital_twin.spatial_types.spatial_types
+import semantic_digital_twin.utils
 import semantic_digital_twin.world
 import semantic_digital_twin.world_description.connection_properties
 import semantic_digital_twin.world_description.connections
@@ -1118,6 +1120,17 @@ class DonbotDAO_arms_association(Base, AssociationDataAccessObject):
     source_donbotdao_id: Mapped[int] = mapped_column(
         ForeignKey("DonbotDAO.database_id")
     )
+    target_armdao_id: Mapped[int] = mapped_column(ForeignKey("ArmDAO.database_id"))
+
+    target: Mapped[ArmDAO] = relationship("ArmDAO", foreign_keys=[target_armdao_id])
+
+
+class GarmiDAO_arms_association(Base, AssociationDataAccessObject):
+
+    __tablename__ = "_50446607032975877316565017614330314462576170393779802888493823"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    source_garmidao_id: Mapped[int] = mapped_column(ForeignKey("GarmiDAO.database_id"))
     target_armdao_id: Mapped[int] = mapped_column(ForeignKey("ArmDAO.database_id"))
 
     target: Mapped[ArmDAO] = relationship("ArmDAO", foreign_keys=[target_armdao_id])
@@ -3070,6 +3083,41 @@ class MismatchingIDsInWorldModificationDAO(
     )
     actual_uuids: Mapped[typing.List[uuid.UUID]] = mapped_column(
         JSON, nullable=False, use_existing_column=True
+    )
+
+
+class MockedNodeClassDAO(
+    Base, DataAccessObject[semantic_digital_twin.utils.MockedNodeClass]
+):
+
+    __tablename__ = "MockedNodeClassDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class MockedNodeModuleDAO(
+    Base, DataAccessObject[semantic_digital_twin.utils.MockedNodeModule]
+):
+
+    __tablename__ = "MockedNodeModuleDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    Node: Mapped[TypeType] = mapped_column(
+        TypeType, nullable=False, use_existing_column=True
+    )
+
+
+class MockedRCLPYDAO(Base, DataAccessObject[semantic_digital_twin.utils.MockedRCLPY]):
+
+    __tablename__ = "MockedRCLPYDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
     )
 
 
@@ -9432,6 +9480,40 @@ class DonbotDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "DonbotDAO",
+        "inherit_condition": database_id == AbstractRobotDAO.database_id,
+    }
+
+
+class GarmiDAO(
+    AbstractRobotDAO, DataAccessObject[semantic_digital_twin.robots.garmi.Garmi]
+):
+
+    __tablename__ = "GarmiDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(AbstractRobotDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    neck_id: Mapped[int] = mapped_column(
+        ForeignKey("NeckDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    neck: Mapped[NeckDAO] = relationship(
+        "NeckDAO", uselist=False, foreign_keys=[neck_id], post_update=True
+    )
+    arms: Mapped[builtins.list[GarmiDAO_arms_association]] = relationship(
+        "GarmiDAO_arms_association",
+        collection_class=builtins.list,
+        cascade="all, delete-orphan",
+        foreign_keys="[GarmiDAO_arms_association.source_garmidao_id]",
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GarmiDAO",
         "inherit_condition": database_id == AbstractRobotDAO.database_id,
     }
 

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -52,7 +52,6 @@ import semantic_digital_twin.robots.armar
 import semantic_digital_twin.robots.armar7
 import semantic_digital_twin.robots.boxy
 import semantic_digital_twin.robots.donbot
-import semantic_digital_twin.robots.garmi
 import semantic_digital_twin.robots.hsrb
 import semantic_digital_twin.robots.icub3
 import semantic_digital_twin.robots.justin
@@ -1120,17 +1119,6 @@ class DonbotDAO_arms_association(Base, AssociationDataAccessObject):
     source_donbotdao_id: Mapped[int] = mapped_column(
         ForeignKey("DonbotDAO.database_id")
     )
-    target_armdao_id: Mapped[int] = mapped_column(ForeignKey("ArmDAO.database_id"))
-
-    target: Mapped[ArmDAO] = relationship("ArmDAO", foreign_keys=[target_armdao_id])
-
-
-class GarmiDAO_arms_association(Base, AssociationDataAccessObject):
-
-    __tablename__ = "_50446607032975877316565017614330314462576170393779802888493823"
-
-    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    source_garmidao_id: Mapped[int] = mapped_column(ForeignKey("GarmiDAO.database_id"))
     target_armdao_id: Mapped[int] = mapped_column(ForeignKey("ArmDAO.database_id"))
 
     target: Mapped[ArmDAO] = relationship("ArmDAO", foreign_keys=[target_armdao_id])
@@ -3083,41 +3071,6 @@ class MismatchingIDsInWorldModificationDAO(
     )
     actual_uuids: Mapped[typing.List[uuid.UUID]] = mapped_column(
         JSON, nullable=False, use_existing_column=True
-    )
-
-
-class MockedNodeClassDAO(
-    Base, DataAccessObject[semantic_digital_twin.utils.MockedNodeClass]
-):
-
-    __tablename__ = "MockedNodeClassDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-
-class MockedNodeModuleDAO(
-    Base, DataAccessObject[semantic_digital_twin.utils.MockedNodeModule]
-):
-
-    __tablename__ = "MockedNodeModuleDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    Node: Mapped[TypeType] = mapped_column(
-        TypeType, nullable=False, use_existing_column=True
-    )
-
-
-class MockedRCLPYDAO(Base, DataAccessObject[semantic_digital_twin.utils.MockedRCLPY]):
-
-    __tablename__ = "MockedRCLPYDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
     )
 
 
@@ -9480,40 +9433,6 @@ class DonbotDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "DonbotDAO",
-        "inherit_condition": database_id == AbstractRobotDAO.database_id,
-    }
-
-
-class GarmiDAO(
-    AbstractRobotDAO, DataAccessObject[semantic_digital_twin.robots.garmi.Garmi]
-):
-
-    __tablename__ = "GarmiDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(AbstractRobotDAO.database_id),
-        primary_key=True,
-        use_existing_column=True,
-    )
-
-    neck_id: Mapped[int] = mapped_column(
-        ForeignKey("NeckDAO.database_id", use_alter=True),
-        nullable=True,
-        use_existing_column=True,
-    )
-
-    neck: Mapped[NeckDAO] = relationship(
-        "NeckDAO", uselist=False, foreign_keys=[neck_id], post_update=True
-    )
-    arms: Mapped[builtins.list[GarmiDAO_arms_association]] = relationship(
-        "GarmiDAO_arms_association",
-        collection_class=builtins.list,
-        cascade="all, delete-orphan",
-        foreign_keys="[GarmiDAO_arms_association.source_garmidao_id]",
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "GarmiDAO",
         "inherit_condition": database_id == AbstractRobotDAO.database_id,
     }
 

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
@@ -21,10 +21,6 @@ from semantic_digital_twin.collision_checking.collision_rules import (
     AllowSelfCollisions,
 )
 from semantic_digital_twin.reasoning.predicates import is_place_occupied
-from semantic_digital_twin.spatial_computations.ik_solver import (
-    MaxIterationsException,
-    UnreachableException,
-)
 from semantic_digital_twin.robots.abstract_robot import (
     AbstractRobot,
     ParallelGripper,

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
@@ -21,6 +21,10 @@ from semantic_digital_twin.collision_checking.collision_rules import (
     AllowSelfCollisions,
 )
 from semantic_digital_twin.reasoning.predicates import is_place_occupied
+from semantic_digital_twin.spatial_computations.ik_solver import (
+    MaxIterationsException,
+    UnreachableException,
+)
 from semantic_digital_twin.robots.abstract_robot import (
     AbstractRobot,
     ParallelGripper,
@@ -108,9 +112,12 @@ def blocking(
     :param tip: The threshold between the end effector and the position.
     :return: A list of bodies the robot is in collision with when reaching for the specified object or None if the pose or object is not reachable.
     """
-    result = root._world.compute_inverse_kinematics(
-        root=root, tip=tip, target=pose, max_iterations=1000
-    )
+    try:
+        result = root._world.compute_inverse_kinematics(
+            root=root, tip=tip, target=pose, max_iterations=1000
+        )
+    except (MaxIterationsException, UnreachableException):
+        return []
     with root._world.modify_world():
         for dof, state in result.items():
             root._world.state[dof.id].position = state

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/robot_predicates.py
@@ -112,12 +112,9 @@ def blocking(
     :param tip: The threshold between the end effector and the position.
     :return: A list of bodies the robot is in collision with when reaching for the specified object or None if the pose or object is not reachable.
     """
-    try:
-        result = root._world.compute_inverse_kinematics(
-            root=root, tip=tip, target=pose, max_iterations=1000
-        )
-    except (MaxIterationsException, UnreachableException):
-        return []
+    result = root._world.compute_inverse_kinematics(
+        root=root, tip=tip, target=pose, max_iterations=1000
+    )
     with root._world.modify_world():
         for dof, state in result.items():
             root._world.state[dof.id].position = state

--- a/semantic_digital_twin/src/semantic_digital_twin/robots/abstract_robot.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/robots/abstract_robot.py
@@ -615,6 +615,43 @@ class AbstractRobot(Agent, ABC):
                 ),
             )
 
+    def tighten_dof_velocity_limits_proportionally(
+        self, maximum_velocity: float
+    ) -> None:
+        """
+        Tightens the velocity limits of all 1-DOF active connections proportionally,
+        preserving the relative magnitudes defined in the original robot description.
+
+        The joint with the highest current velocity limit is mapped to
+        ``maximum_velocity``; all others are scaled by the same factor.
+        Joints with no velocity limit are left unchanged.
+
+        If the current maximum is already at or below ``maximum_velocity``,
+        no changes are applied.
+
+        :param maximum_velocity: The target velocity for the joint with the
+            highest current velocity limit.
+        """
+        connections_with_velocity_limits = [
+            (connection, connection.raw_dof.limits.upper.velocity)
+            for connection in self._world.get_connections_by_type(ActiveConnection1DOF)
+            if connection.raw_dof.limits.upper.velocity is not None
+        ]
+        if not connections_with_velocity_limits:
+            return
+        original_maximum = max(
+            velocity for _, velocity in connections_with_velocity_limits
+        )
+        if original_maximum <= maximum_velocity:
+            return
+        scale_factor = maximum_velocity / original_maximum
+        for connection, current_velocity in connections_with_velocity_limits:
+            scaled_limit = current_velocity * scale_factor
+            connection.raw_dof._overwrite_dof_limits(
+                new_lower_limits=DerivativeMap(None, -scaled_limit, None, None),
+                new_upper_limits=DerivativeMap(None, scaled_limit, None, None),
+            )
+
     def add_manipulator(self, manipulator: Manipulator):
         """
         Adds a manipulator to the robot's collection of manipulators.

--- a/semantic_digital_twin/src/semantic_digital_twin/robots/tracy.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/robots/tracy.py
@@ -174,8 +174,7 @@ class Tracy(AbstractRobot, SpecifiesLeftRightArm, HasNeck):
         )
 
     def _setup_velocity_limits(self):
-        vel_limits = defaultdict(lambda: 0.2)
-        self.tighten_dof_velocity_limits_of_1dof_connections(new_limits=vel_limits)
+        self.tighten_dof_velocity_limits_proportionally(maximum_velocity=0.2)
 
     def _setup_hardware_interfaces(self):
         controlled_joints = [

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -1865,10 +1865,7 @@ class World(HasSimulatorProperties):
             for dof in self.degrees_of_freedom:
                 new_dof = DegreeOfFreedom(
                     name=dof.name,
-                    limits=DegreeOfFreedomLimits(
-                        lower=dof.limits.lower,
-                        upper=dof.limits.upper,
-                    ),
+                    limits=deepcopy(dof.limits),
                     id=dof.id,
                 )
                 new_world.add_degree_of_freedom(new_dof)

--- a/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
+++ b/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
@@ -503,84 +503,84 @@ def test_pr2_tighten_dof_velocity_limits_of_1dof_connections(pr2_world_state_res
     )
 
 
-def test_pr2_tighten_dof_velocity_limits_proportionally(pr2_world_state_reset):
-    """All limits scale by the same factor; the joint with the highest limit reaches maximum_velocity."""
-    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-
-    connections_with_limits = [
-        (connection, connection.raw_dof.limits.upper.velocity)
-        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-        if connection.raw_dof.limits.upper.velocity is not None
-    ]
-    initial_maximum = max(velocity for _, velocity in connections_with_limits)
-    maximum_velocity = initial_maximum / 10
-
-    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=maximum_velocity)
-
-    for connection, initial_limit in connections_with_limits:
-        expected = initial_limit * (maximum_velocity / initial_maximum)
-        assert connection.raw_dof.limits.upper.velocity == pytest.approx(expected)
-        # Symmetry: lower bound is the negative of the upper bound
-        assert connection.raw_dof.limits.lower.velocity == pytest.approx(-expected)
-
-
-def test_pr2_tighten_dof_velocity_limits_proportionally_preserves_ratios(
-    pr2_world_state_reset,
-):
-    """The ratio between any two joints with different limits is identical before and after scaling."""
-    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-
-    initial_limits = {
-        connection: connection.raw_dof.limits.upper.velocity
-        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-        if connection.raw_dof.limits.upper.velocity is not None
-    }
-    initial_maximum = max(initial_limits.values())
-
-    distinct_pair = next(
-        (
-            (connection_a, connection_b)
-            for connection_a in initial_limits
-            for connection_b in initial_limits
-            if abs(initial_limits[connection_a] - initial_limits[connection_b]) > 1e-10
-        ),
-        None,
-    )
-
-    connection_a, connection_b = distinct_pair
-    before_ratio = initial_limits[connection_a] / initial_limits[connection_b]
-
-    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum / 2)
-
-    after_ratio = (
-        connection_a.raw_dof.limits.upper.velocity
-        / connection_b.raw_dof.limits.upper.velocity
-    )
-    assert before_ratio == pytest.approx(after_ratio)
-
-
-def test_pr2_tighten_dof_velocity_limits_proportionally_no_op_when_within_bounds(
-    pr2_world_state_reset,
-):
-    """When maximum_velocity is at or above the current maximum, no limits are changed."""
-    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-
-    initial_limits = {
-        connection: connection.raw_dof.limits.upper.velocity
-        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-        if connection.raw_dof.limits.upper.velocity is not None
-    }
-    initial_maximum = max(initial_limits.values())
-
-    # Calling with the exact current maximum must be a no-op
-    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum)
-    for connection, initial_limit in initial_limits.items():
-        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
-
-    # Calling with a larger value must also be a no-op
-    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=100.0)
-    for connection, initial_limit in initial_limits.items():
-        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
+# def test_pr2_tighten_dof_velocity_limits_proportionally(pr2_world_state_reset):
+#     """All limits scale by the same factor; the joint with the highest limit reaches maximum_velocity."""
+#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+#
+#     connections_with_limits = [
+#         (connection, connection.raw_dof.limits.upper.velocity)
+#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+#         if connection.raw_dof.limits.upper.velocity is not None
+#     ]
+#     initial_maximum = max(velocity for _, velocity in connections_with_limits)
+#     maximum_velocity = initial_maximum / 10
+#
+#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=maximum_velocity)
+#
+#     for connection, initial_limit in connections_with_limits:
+#         expected = initial_limit * (maximum_velocity / initial_maximum)
+#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(expected)
+#         # Symmetry: lower bound is the negative of the upper bound
+#         assert connection.raw_dof.limits.lower.velocity == pytest.approx(-expected)
+#
+#
+# def test_pr2_tighten_dof_velocity_limits_proportionally_preserves_ratios(
+#     pr2_world_state_reset,
+# ):
+#     """The ratio between any two joints with different limits is identical before and after scaling."""
+#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+#
+#     initial_limits = {
+#         connection: connection.raw_dof.limits.upper.velocity
+#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+#         if connection.raw_dof.limits.upper.velocity is not None
+#     }
+#     initial_maximum = max(initial_limits.values())
+#
+#     distinct_pair = next(
+#         (
+#             (connection_a, connection_b)
+#             for connection_a in initial_limits
+#             for connection_b in initial_limits
+#             if abs(initial_limits[connection_a] - initial_limits[connection_b]) > 1e-10
+#         ),
+#         None,
+#     )
+#
+#     connection_a, connection_b = distinct_pair
+#     before_ratio = initial_limits[connection_a] / initial_limits[connection_b]
+#
+#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum / 2)
+#
+#     after_ratio = (
+#         connection_a.raw_dof.limits.upper.velocity
+#         / connection_b.raw_dof.limits.upper.velocity
+#     )
+#     assert before_ratio == pytest.approx(after_ratio)
+#
+#
+# def test_pr2_tighten_dof_velocity_limits_proportionally_no_op_when_within_bounds(
+#     pr2_world_state_reset,
+# ):
+#     """When maximum_velocity is at or above the current maximum, no limits are changed."""
+#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+#
+#     initial_limits = {
+#         connection: connection.raw_dof.limits.upper.velocity
+#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+#         if connection.raw_dof.limits.upper.velocity is not None
+#     }
+#     initial_maximum = max(initial_limits.values())
+#
+#     # Calling with the exact current maximum must be a no-op
+#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum)
+#     for connection, initial_limit in initial_limits.items():
+#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
+#
+#     # Calling with a larger value must also be a no-op
+#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=100.0)
+#     for connection, initial_limit in initial_limits.items():
+#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
 
 
 def test_split_chain_of_connections(pr2_world_state_reset):

--- a/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
+++ b/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
@@ -27,6 +27,7 @@ from semantic_digital_twin.world_description.connections import (
     DifferentialDrive,
     PrismaticConnection,
     RevoluteConnection,
+    ActiveConnection1DOF,
 )
 from semantic_digital_twin.orm.ormatic_interface import *  # noqa
 
@@ -500,6 +501,86 @@ def test_pr2_tighten_dof_velocity_limits_of_1dof_connections(pr2_world_state_res
         pr2._world.get_connection_by_name("torso_lift_joint").dof.limits.upper.velocity
         == 0.013
     )
+
+
+def test_pr2_tighten_dof_velocity_limits_proportionally(pr2_world_state_reset):
+    """All limits scale by the same factor; the joint with the highest limit reaches maximum_velocity."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    connections_with_limits = [
+        (connection, connection.raw_dof.limits.upper.velocity)
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    ]
+    initial_maximum = max(velocity for _, velocity in connections_with_limits)
+    maximum_velocity = initial_maximum / 10
+
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=maximum_velocity)
+
+    for connection, initial_limit in connections_with_limits:
+        expected = initial_limit * (maximum_velocity / initial_maximum)
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(expected)
+        # Symmetry: lower bound is the negative of the upper bound
+        assert connection.raw_dof.limits.lower.velocity == pytest.approx(-expected)
+
+
+def test_pr2_tighten_dof_velocity_limits_proportionally_preserves_ratios(
+    pr2_world_state_reset,
+):
+    """The ratio between any two joints with different limits is identical before and after scaling."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    initial_limits = {
+        connection: connection.raw_dof.limits.upper.velocity
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    }
+    initial_maximum = max(initial_limits.values())
+
+    distinct_pair = next(
+        (
+            (connection_a, connection_b)
+            for connection_a in initial_limits
+            for connection_b in initial_limits
+            if abs(initial_limits[connection_a] - initial_limits[connection_b]) > 1e-10
+        ),
+        None,
+    )
+
+    connection_a, connection_b = distinct_pair
+    before_ratio = initial_limits[connection_a] / initial_limits[connection_b]
+
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum / 2)
+
+    after_ratio = (
+        connection_a.raw_dof.limits.upper.velocity
+        / connection_b.raw_dof.limits.upper.velocity
+    )
+    assert before_ratio == pytest.approx(after_ratio)
+
+
+def test_pr2_tighten_dof_velocity_limits_proportionally_no_op_when_within_bounds(
+    pr2_world_state_reset,
+):
+    """When maximum_velocity is at or above the current maximum, no limits are changed."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    initial_limits = {
+        connection: connection.raw_dof.limits.upper.velocity
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    }
+    initial_maximum = max(initial_limits.values())
+
+    # Calling with the exact current maximum must be a no-op
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum)
+    for connection, initial_limit in initial_limits.items():
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
+
+    # Calling with a larger value must also be a no-op
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=100.0)
+    for connection, initial_limit in initial_limits.items():
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
 
 
 def test_split_chain_of_connections(pr2_world_state_reset):

--- a/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
+++ b/test/semantic_digital_twin_test/test_robots/test_world_pr2.py
@@ -503,84 +503,84 @@ def test_pr2_tighten_dof_velocity_limits_of_1dof_connections(pr2_world_state_res
     )
 
 
-# def test_pr2_tighten_dof_velocity_limits_proportionally(pr2_world_state_reset):
-#     """All limits scale by the same factor; the joint with the highest limit reaches maximum_velocity."""
-#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-#
-#     connections_with_limits = [
-#         (connection, connection.raw_dof.limits.upper.velocity)
-#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-#         if connection.raw_dof.limits.upper.velocity is not None
-#     ]
-#     initial_maximum = max(velocity for _, velocity in connections_with_limits)
-#     maximum_velocity = initial_maximum / 10
-#
-#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=maximum_velocity)
-#
-#     for connection, initial_limit in connections_with_limits:
-#         expected = initial_limit * (maximum_velocity / initial_maximum)
-#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(expected)
-#         # Symmetry: lower bound is the negative of the upper bound
-#         assert connection.raw_dof.limits.lower.velocity == pytest.approx(-expected)
-#
-#
-# def test_pr2_tighten_dof_velocity_limits_proportionally_preserves_ratios(
-#     pr2_world_state_reset,
-# ):
-#     """The ratio between any two joints with different limits is identical before and after scaling."""
-#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-#
-#     initial_limits = {
-#         connection: connection.raw_dof.limits.upper.velocity
-#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-#         if connection.raw_dof.limits.upper.velocity is not None
-#     }
-#     initial_maximum = max(initial_limits.values())
-#
-#     distinct_pair = next(
-#         (
-#             (connection_a, connection_b)
-#             for connection_a in initial_limits
-#             for connection_b in initial_limits
-#             if abs(initial_limits[connection_a] - initial_limits[connection_b]) > 1e-10
-#         ),
-#         None,
-#     )
-#
-#     connection_a, connection_b = distinct_pair
-#     before_ratio = initial_limits[connection_a] / initial_limits[connection_b]
-#
-#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum / 2)
-#
-#     after_ratio = (
-#         connection_a.raw_dof.limits.upper.velocity
-#         / connection_b.raw_dof.limits.upper.velocity
-#     )
-#     assert before_ratio == pytest.approx(after_ratio)
-#
-#
-# def test_pr2_tighten_dof_velocity_limits_proportionally_no_op_when_within_bounds(
-#     pr2_world_state_reset,
-# ):
-#     """When maximum_velocity is at or above the current maximum, no limits are changed."""
-#     pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
-#
-#     initial_limits = {
-#         connection: connection.raw_dof.limits.upper.velocity
-#         for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
-#         if connection.raw_dof.limits.upper.velocity is not None
-#     }
-#     initial_maximum = max(initial_limits.values())
-#
-#     # Calling with the exact current maximum must be a no-op
-#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum)
-#     for connection, initial_limit in initial_limits.items():
-#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
-#
-#     # Calling with a larger value must also be a no-op
-#     pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=100.0)
-#     for connection, initial_limit in initial_limits.items():
-#         assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
+def test_pr2_tighten_dof_velocity_limits_proportionally(pr2_world_state_reset):
+    """All limits scale by the same factor; the joint with the highest limit reaches maximum_velocity."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    connections_with_limits = [
+        (connection, connection.raw_dof.limits.upper.velocity)
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    ]
+    initial_maximum = max(velocity for _, velocity in connections_with_limits)
+    maximum_velocity = initial_maximum / 10
+
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=maximum_velocity)
+
+    for connection, initial_limit in connections_with_limits:
+        expected = initial_limit * (maximum_velocity / initial_maximum)
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(expected)
+        # Symmetry: lower bound is the negative of the upper bound
+        assert connection.raw_dof.limits.lower.velocity == pytest.approx(-expected)
+
+
+def test_pr2_tighten_dof_velocity_limits_proportionally_preserves_ratios(
+    pr2_world_state_reset,
+):
+    """The ratio between any two joints with different limits is identical before and after scaling."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    initial_limits = {
+        connection: connection.raw_dof.limits.upper.velocity
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    }
+    initial_maximum = max(initial_limits.values())
+
+    distinct_pair = next(
+        (
+            (connection_a, connection_b)
+            for connection_a in initial_limits
+            for connection_b in initial_limits
+            if abs(initial_limits[connection_a] - initial_limits[connection_b]) > 1e-10
+        ),
+        None,
+    )
+
+    connection_a, connection_b = distinct_pair
+    before_ratio = initial_limits[connection_a] / initial_limits[connection_b]
+
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum / 2)
+
+    after_ratio = (
+        connection_a.raw_dof.limits.upper.velocity
+        / connection_b.raw_dof.limits.upper.velocity
+    )
+    assert before_ratio == pytest.approx(after_ratio)
+
+
+def test_pr2_tighten_dof_velocity_limits_proportionally_no_op_when_within_bounds(
+    pr2_world_state_reset,
+):
+    """When maximum_velocity is at or above the current maximum, no limits are changed."""
+    pr2 = pr2_world_state_reset.get_semantic_annotations_by_type(PR2)[0]
+
+    initial_limits = {
+        connection: connection.raw_dof.limits.upper.velocity
+        for connection in pr2._world.get_connections_by_type(ActiveConnection1DOF)
+        if connection.raw_dof.limits.upper.velocity is not None
+    }
+    initial_maximum = max(initial_limits.values())
+
+    # Calling with the exact current maximum must be a no-op
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=initial_maximum)
+    for connection, initial_limit in initial_limits.items():
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
+
+    # Calling with a larger value must also be a no-op
+    pr2.tighten_dof_velocity_limits_proportionally(maximum_velocity=100.0)
+    for connection, initial_limit in initial_limits.items():
+        assert connection.raw_dof.limits.upper.velocity == pytest.approx(initial_limit)
 
 
 def test_split_chain_of_connections(pr2_world_state_reset):


### PR DESCRIPTION
Adds an alternative to tighten_dof_velocity_limits_of_1dof_connections that scales all joint velocity limits by a common factor instead of applying a flat cap. This preserves the relative magnitudes defined in the URDF, which is important for robots like Tracy where matching the ratio between joint velocities is necessary for smooth rotational and translational end-effector motion. Tracy's _setup_velocity_limits is updated to use the new method as the first use case.