### PR TITLE
subclass safe generic fix for multiple generics

### DIFF
--- a/krrood/src/krrood/class_diagrams/class_diagram.py
+++ b/krrood/src/krrood/class_diagrams/class_diagram.py
@@ -12,7 +12,7 @@ from typing import _GenericAlias
 import rustworkx as rx
 from typing_extensions import get_args, get_origin
 
-from krrood.utils import module_and_class_name, memoize
+from krrood.utils import module_and_class_name, memoize, get_generic_type_params
 
 try:
     from krrood.rustworkx_utils import RWXNode
@@ -37,7 +37,7 @@ from krrood.class_diagrams.attribute_introspector import (
     AttributeIntrospector,
     DataclassOnlyIntrospector,
 )
-from krrood.class_diagrams.utils import Role, get_generic_type_param, resolve_type
+from krrood.class_diagrams.utils import Role, resolve_type
 from krrood.class_diagrams.wrapped_field import WrappedField
 
 from krrood.class_diagrams.exceptions import ClassIsUnMappedInClassDiagram
@@ -640,7 +640,7 @@ class ClassDiagram:
                     is_role_subclass = False
 
                 if wrapped_field.is_role_taker and is_role_subclass:
-                    role_taker_type = get_generic_type_param(actual_cls, Role)[0]
+                    role_taker_type = get_generic_type_params(actual_cls, Role)[0]
                     if role_taker_type is target_type:
                         association_type = HasRoleTaker
 

--- a/krrood/src/krrood/class_diagrams/utils.py
+++ b/krrood/src/krrood/class_diagrams/utils.py
@@ -14,9 +14,12 @@ from typing_extensions import Callable, get_args, get_origin
 from typing_extensions import List, Type, Any, Dict, Tuple, Generic
 from typing_extensions import TypeVar
 
+from krrood import logger
 from krrood.class_diagrams.exceptions import CouldNotResolveType
-from krrood.entity_query_language.utils import ensure_hashable
-from krrood.utils import get_scope_from_imports
+from krrood.utils import (
+    ensure_hashable,
+    get_scope_from_imports,
+)
 
 
 def classes_of_module(module) -> List[Type]:

--- a/krrood/src/krrood/class_diagrams/utils.py
+++ b/krrood/src/krrood/class_diagrams/utils.py
@@ -15,6 +15,7 @@ from typing_extensions import List, Type, Any, Dict, Tuple, Generic
 from typing_extensions import TypeVar
 
 from krrood.class_diagrams.exceptions import CouldNotResolveType
+from krrood.entity_query_language.utils import ensure_hashable
 from krrood.utils import get_scope_from_imports
 
 
@@ -34,12 +35,12 @@ def classes_of_module(module) -> List[Type]:
 
 
 def behaves_like_a_built_in_class(
-        clazz: Type,
+    clazz: Type,
 ) -> bool:
     return (
-            is_builtin_class(clazz)
-            or clazz == UUID
-            or (inspect.isclass(clazz) and issubclass(clazz, Enum))
+        is_builtin_class(clazz)
+        or clazz == UUID
+        or (inspect.isclass(clazz) and issubclass(clazz, Enum))
     )
 
 
@@ -121,23 +122,6 @@ class Role(Generic[T]):
     """
 
 
-def get_generic_type_param(cls, generic_base):
-    """
-    Given a subclass and its generic base, return the concrete type parameter(s).
-
-    Example:
-        get_generic_type_param(Employee, Role) -> (<class '__main__.Person'>,)
-    """
-    orig_bases = cls.__orig_bases__ if hasattr(cls, "__orig_bases__") else []
-    for base in orig_bases:
-        base_origin = get_origin(base)
-        if base_origin is None:
-            continue
-        if issubclass(get_origin(base), generic_base):
-            return get_args(base)
-    return None
-
-
 def get_type_hint_of_keyword_argument(callable_: Callable, name: str):
     """
     :param callable_: A callable to inspect
@@ -177,7 +161,7 @@ class TypeHintResolutionResult:
 
 
 def get_and_resolve_generic_type_hints_of_object_using_substitutions(
-        object_: Any, substitution: Dict[TypeVar, Type]
+    object_: Any, substitution: Dict[TypeVar, Type]
 ) -> Dict[str, TypeHintResolutionResult]:
     """
     Resolve generic type hints of an object using a substitution dictionary.
@@ -191,8 +175,8 @@ def get_and_resolve_generic_type_hints_of_object_using_substitutions(
 
 
 def resolve_type(
-        type_to_resolve: Any,
-        substitution: Dict[TypeVar, Any],
+    type_to_resolve: Any,
+    substitution: Dict[TypeVar, Any],
 ) -> TypeHintResolutionResult:
     """
     Resolve type variables in a type.
@@ -203,10 +187,11 @@ def resolve_type(
     substitutions were made.
     """
     if isinstance(type_to_resolve, TypeVar):
-        if type_to_resolve not in substitution:
+        type_to_resolve_key = ensure_hashable(type_to_resolve)
+        if type_to_resolve_key not in substitution:
             return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)
         return TypeHintResolutionResult(
-            substitution[type_to_resolve], True, type_to_resolve
+            substitution[type_to_resolve_key], True, type_to_resolve
         )
 
     # If the type itself can be indexed (like List[T] or Optional[T])
@@ -222,14 +207,15 @@ def resolve_type(
                 new_params.append(param)
         subscript_param = new_params[0] if len(new_params) == 1 else tuple(new_params)
         return TypeHintResolutionResult(
-            type_to_resolve[subscript_param], resolved, type_to_resolve)
+            type_to_resolve[subscript_param], resolved, type_to_resolve
+        )
 
     return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)
 
 
 @lru_cache
 def get_type_hints_of_object(
-        object_: Any, namespace: Tuple[Tuple[str, Any], ...] = ()
+    object_: Any, namespace: Tuple[Tuple[str, Any], ...] = ()
 ) -> Dict[str, Any]:
     """
     Get the type hints of an object. This is a workaround for the fact that get_type_hints() does not work with objects
@@ -263,7 +249,7 @@ def get_type_hints_of_object(
 
 
 def get_object_by_name_from_another_object_in_same_module(
-        name: str, object_: Any
+    name: str, object_: Any
 ) -> Any:
     """
     Get the object with the given name from another object in the same module.
@@ -290,5 +276,5 @@ def get_object_by_name_from_another_object_in_same_module(
         raise CouldNotResolveType(
             name,
             extra_information=f"Could not find {name} in {source_path}, could be a deprecated import statement or "
-                              f"a type defined in a module that is not imported in the source file.",
+            f"a type defined in a module that is not imported in the source file.",
         )

--- a/krrood/src/krrood/entity_query_language/cache_data.py
+++ b/krrood/src/krrood/entity_query_language/cache_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from krrood.entity_query_language.utils import T, ensure_hashable
+from krrood.utils import T, ensure_hashable
 
 """
 Cache utilities.

--- a/krrood/src/krrood/entity_query_language/query/operations.py
+++ b/krrood/src/krrood/entity_query_language/query/operations.py
@@ -46,7 +46,8 @@ from krrood.entity_query_language.exceptions import (
 from krrood.entity_query_language.operators.set_operations import (
     MultiArityExpressionThatPerformsACartesianProduct,
 )
-from krrood.entity_query_language.utils import ensure_hashable, is_iterable
+from krrood.entity_query_language.utils import is_iterable
+from krrood.utils import ensure_hashable
 from krrood.entity_query_language.core.mapped_variable import MappedVariable
 from krrood.utils import memoize
 

--- a/krrood/src/krrood/entity_query_language/utils.py
+++ b/krrood/src/krrood/entity_query_language/utils.py
@@ -235,26 +235,3 @@ def convert_args_and_kwargs_into_hashable_key(
             v = tuple(v)
         key.append((k, v))
     return tuple(sorted(key))
-
-
-def ensure_hashable(obj) -> Hashable:
-    """
-    :return: The object itself if it is hashable, otherwise its id.
-    """
-    if not is_hashable(obj):
-        return id(obj)
-    return obj
-
-
-def is_hashable(obj) -> bool:
-    """
-    Checks if an object is hashable by attempting to compute its hash.
-
-    :param obj: The object to check.
-    :return: True if the object is hashable, False otherwise.
-    """
-    try:
-        hash(obj)
-        return True
-    except TypeError:
-        return False

--- a/krrood/src/krrood/exceptions.py
+++ b/krrood/src/krrood/exceptions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import types
 from dataclasses import dataclass, field
+from typing import Type, Tuple
 
 from typing_extensions import Optional
 
@@ -26,6 +27,37 @@ class InputError(DataclassException):
     """
     Raised when there is an error with user input.
     """
+
+
+@dataclass
+class MismatchingNumberOfGenericParametersAndResolvedTypes(DataclassException):
+    """
+    Raised when the number of generic parameters does not match the number of resolved types.
+    """
+
+    affected_class: Type
+    """
+    The class that has the generic parameters.
+    """
+
+    parameters: list[Type]
+    """
+    The generic parameters of the class.
+    """
+
+    resolved_types: Tuple[Type, ...]
+    """
+    The resolved types for the generic parameters.
+    """
+
+    def __post_init__(self):
+        self.message = (
+            f"The number of generic type parameters in {self.affected_class.__name__} "
+            f"({len(self.parameters)}) does not match the number of "
+            f"provided arguments ({len(self.resolved_types)})."
+            f"Parameters: {self.parameters}, resolved_types: {self.resolved_types}"
+        )
+        super().__post_init__()
 
 
 @dataclass

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -24,10 +24,10 @@ from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
     resolve_type,
 )
-from krrood.entity_query_language.utils import ensure_hashable
 from krrood.utils import (
     get_generic_type_params,
     T,
+    ensure_hashable,
 )
 
 if TYPE_CHECKING:
@@ -143,7 +143,22 @@ class AbstractSubClassSafeGeneric(ABC):
         if "_subclass_safe_substitutions" in cls.__dict__:
             return cls._subclass_safe_substitutions
 
-        substitutions = cls.get_superclass_generic_type_substitution()
+        substitutions = {}
+        for base in getattr(cls, "__orig_bases__", []):
+            base_origin, resolved_types = cls._resolve_base_origin_and_arguments(base)
+            if base_origin is None:
+                continue
+
+            # Map the root TypeVars of the base to the concrete arguments provided here
+            root_parameters = base_origin.get_generic_types()
+            for old_type, new_type in zip(root_parameters, resolved_types):
+                if old_type is not new_type and new_type is not None:
+                    substitutions[ensure_hashable(old_type)] = new_type
+
+            # Recursively pull substitutions already defined by the parent
+            if base_origin is not cls:
+                substitutions.update(base_origin._get_generic_type_substitutions())
+
         if substitutions:
             substitutions = cls._resolve_substitutions_transitively(substitutions)
 
@@ -175,36 +190,6 @@ class AbstractSubClassSafeGeneric(ABC):
         return resolved_substitutions
 
     @classmethod
-    def get_superclass_generic_type_substitution(cls) -> Dict[Type, Type]:
-        """
-        Retrieve generic type substitutions from superclasses.
-
-        :return: A mapping from each superclass generic type to the resolved type in this class.
-        """
-        substitutions = {}
-        if not hasattr(cls, "__orig_bases__"):
-            return substitutions
-
-        for base in cls.__orig_bases__:
-            base_origin, resolved_types = cls._resolve_base_origin_and_arguments(base)
-            if base_origin is None:
-                continue
-
-            # Map the root TypeVars of the base to the concrete arguments provided here
-            root_parameters = base_origin.get_generic_types(True, False)
-            if not root_parameters:
-                root_parameters = base_origin.get_generic_types(False, True)
-
-            for old_type, new_type in zip(root_parameters, resolved_types):
-                if old_type is not new_type and new_type is not None:
-                    substitutions[ensure_hashable(old_type)] = new_type
-
-            # Recursively pull substitutions already defined by the parent
-            if base_origin is not cls:
-                substitutions.update(base_origin._get_generic_type_substitutions())
-        return substitutions
-
-    @classmethod
     def _resolve_base_origin_and_arguments(
         cls, base: Any
     ) -> Tuple[Optional[Type], Tuple[Type, ...]]:
@@ -227,6 +212,7 @@ class AbstractSubClassSafeGeneric(ABC):
         return None, ()
 
     @classmethod
+    @lru_cache
     def get_generic_types(
         cls,
         from_root_generic_base: bool = True,

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -18,6 +18,7 @@ from typing_extensions import (
     List,
     get_origin,
     get_args,
+    assert_never,
 )
 
 from krrood.class_diagrams.utils import (
@@ -28,6 +29,7 @@ from krrood.utils import (
     get_generic_type_params,
     T,
     ensure_hashable,
+    memoize,
 )
 
 if TYPE_CHECKING:
@@ -148,14 +150,24 @@ class AbstractSubClassSafeGeneric(ABC):
                 continue
 
             # Map the root TypeVars of the base to the concrete arguments provided here
-            root_parameters = base_origin.get_generic_types()
-            for old_type, new_type in zip(root_parameters, resolved_types):
-                if old_type is not new_type and new_type is not None:
+            if resolved_types:
+                root_parameters = base_origin.get_generic_types(True, False)
+                if len(root_parameters) != len(resolved_types):
+                    assert_never(base)
+
+                for old_type, new_type in zip(root_parameters, resolved_types):
+                    if (
+                        not isinstance(old_type, TypeVar)
+                        or old_type is new_type
+                        or new_type is None
+                    ):
+                        continue
                     substitutions[ensure_hashable(old_type)] = new_type
 
             # Recursively pull substitutions already defined by the parent
-            if base_origin is not cls:
-                substitutions.update(base_origin._get_generic_type_substitutions())
+            if base_origin is cls:
+                continue
+            substitutions.update(base_origin._get_generic_type_substitutions())
 
         if substitutions:
             substitutions = cls._resolve_substitutions_transitively(substitutions)
@@ -210,20 +222,22 @@ class AbstractSubClassSafeGeneric(ABC):
         return None, ()
 
     @classmethod
-    @lru_cache
+    @memoize
     def get_generic_types(
         cls,
-        from_root_generic_base: bool = True,
-        from_specialized_generic_base: bool = True,
+        include_root_generic_base: bool = True,
+        include_specialized_generic_base: bool = True,
     ) -> List[Type]:
         """
+        :param include_root_generic_base: Whether to include type parameters the class gets from its own typing.Generic directly.
+        :param include_specialized_generic_base: Whether to include type parameters from superclasses that are generic, which are not typing.Generic.
         :return: The concrete generic type parameters bound for this class, in declaration order.
         """
         return get_generic_type_params(
             cls,
             AbstractSubClassSafeGeneric,
-            from_root_generic_base,
-            from_specialized_generic_base,
+            include_root_generic_base,
+            include_specialized_generic_base,
         )
 
 

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -47,8 +47,6 @@ class AbstractSubClassSafeGeneric(ABC):
     ``AbstractSubClassSafeGeneric`` similar to how it is done in ``SubClassSafeGeneric``.
     """
 
-    _subclass_safe_substitutions: ClassVar[Dict[Type, Type]] = {}
-
     def __init_subclass__(cls, **kwargs):
         """
         Automatically updates the field types that use the generic type parameters with the new
@@ -123,7 +121,8 @@ class AbstractSubClassSafeGeneric(ABC):
             return {}
 
         # Use a class-level cache to avoid redundant recursive calculations
-        if cls._subclass_safe_substitutions:
+        # Check ONLY the current class's dict to avoid using an inherited cache
+        if "_subclass_safe_substitutions" in cls.__dict__:
             return cls._subclass_safe_substitutions
 
         substitutions = {}
@@ -143,7 +142,11 @@ class AbstractSubClassSafeGeneric(ABC):
                     include_specialized_generic_base=False,
                 )
                 if len(root_parameters) != len(resolved_types):
-                    assert_never(base)
+                    raise TypeError(
+                        f"The number of generic type parameters in {base_origin} "
+                        f"({len(root_parameters)}) does not match the number of "
+                        f"provided arguments ({len(resolved_types)})."
+                    )
 
                 for old_type, new_type in zip(root_parameters, resolved_types):
                     if (

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -5,7 +5,7 @@ from copy import copy
 from dataclasses import dataclass, fields, Field, field
 from functools import lru_cache
 from inspect import isclass
-from typing import Union, Tuple, Hashable
+from typing import Tuple
 
 from typing_extensions import (
     Generic,
@@ -50,8 +50,6 @@ class AbstractSubClassSafeGeneric(ABC):
         Automatically updates the field types that use the generic type parameters with the new
         specified types, before the class is initialized.
         """
-        # if cls.__name__ != "SubClassGenericThatUpdatesGenericTypeToBuiltInType":
-        #     return
 
         substitutions = cls._get_generic_type_substitutions()
         if not substitutions:
@@ -121,11 +119,9 @@ class AbstractSubClassSafeGeneric(ABC):
         :return: The existing field if found, otherwise None.
         """
         for base in cls.__mro__:
-            if (
-                hasattr(base, "__dataclass_fields__")
-                and name in base.__dataclass_fields__
-            ):
-                return base.__dataclass_fields__[name]
+            fields = getattr(base, "__dataclass_fields__", None)
+            if fields and name in fields:
+                return fields[name]
         return None
 
     @classmethod
@@ -146,7 +142,9 @@ class AbstractSubClassSafeGeneric(ABC):
         substitutions = {}
         for base in getattr(cls, "__orig_bases__", []):
             base_origin, resolved_types = cls._resolve_base_origin_and_arguments(base)
-            if base_origin is None:
+            if base_origin is None or not issubclass(
+                base_origin, AbstractSubClassSafeGeneric
+            ):
                 continue
 
             # Map the root TypeVars of the base to the concrete arguments provided here

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -5,7 +5,7 @@ from copy import copy
 from dataclasses import dataclass, fields, Field, field
 from functools import lru_cache
 from inspect import isclass
-from typing import Tuple
+from typing import Tuple, ClassVar
 
 from typing_extensions import (
     Generic,
@@ -29,7 +29,7 @@ from krrood.utils import (
     get_generic_type_params,
     T,
     ensure_hashable,
-    memoize,
+    get_existing_field_by_name,
 )
 
 if TYPE_CHECKING:
@@ -46,6 +46,8 @@ class AbstractSubClassSafeGeneric(ABC):
     this class. Here it is important that in the inheritance order, ``Generic[...]`` is positioned before
     ``AbstractSubClassSafeGeneric`` similar to how it is done in ``SubClassSafeGeneric``.
     """
+
+    _subclass_safe_substitutions: ClassVar[Dict[Type, Type]] = {}
 
     def __init_subclass__(cls, **kwargs):
         """
@@ -77,7 +79,7 @@ class AbstractSubClassSafeGeneric(ABC):
         :param kwargs: Keyword arguments to update the field with.
         :param type_: The type of the field.
         """
-        existing_field = cls._get_existing_field(name)
+        existing_field = get_existing_field_by_name(cls, name)
 
         # Check if we should update an existing attribute or field on the current class
         target_field = None
@@ -95,11 +97,6 @@ class AbstractSubClassSafeGeneric(ABC):
             for key, value in kwargs.items():
                 setattr(new_field, key, value)
             setattr(cls, name, new_field)
-        else:
-            # Create a new field if it doesn't exist
-            field_kwargs = {k: v for k, v in kwargs.items() if k != "type"}
-            if field_kwargs:
-                setattr(cls, name, field(**field_kwargs))
 
         # Update annotations
         if "type" in kwargs:
@@ -113,20 +110,6 @@ class AbstractSubClassSafeGeneric(ABC):
         cls.__annotations__[name] = resolved_type
 
     @classmethod
-    def _get_existing_field(cls, name: str) -> Optional[Field]:
-        """
-        Find the existing field in the MRO if it exists.
-
-        :param name: The name of the field.
-        :return: The existing field if found, otherwise None.
-        """
-        for base in cls.__mro__:
-            fields = getattr(base, "__dataclass_fields__", None)
-            if fields and name in fields:
-                return fields[name]
-        return None
-
-    @classmethod
     def _get_generic_type_substitutions(cls) -> Dict[Type, Type]:
         """
         Get the generic type substitutions for this class.
@@ -134,11 +117,13 @@ class AbstractSubClassSafeGeneric(ABC):
         :return: A mapping from each old generic type (as declared on the parent class) to the
             new generic type used by this class, for every position whose binding changed.
         """
-        if cls is AbstractSubClassSafeGeneric:
+        if cls is AbstractSubClassSafeGeneric or not issubclass(
+            cls, AbstractSubClassSafeGeneric
+        ):
             return {}
 
         # Use a class-level cache to avoid redundant recursive calculations
-        if "_subclass_safe_substitutions" in cls.__dict__:
+        if cls._subclass_safe_substitutions:
             return cls._subclass_safe_substitutions
 
         substitutions = {}
@@ -151,7 +136,12 @@ class AbstractSubClassSafeGeneric(ABC):
 
             # Map the root TypeVars of the base to the concrete arguments provided here
             if resolved_types:
-                root_parameters = base_origin.get_generic_types(True, False)
+                root_parameters = get_generic_type_params(
+                    base_origin,
+                    AbstractSubClassSafeGeneric,
+                    include_root_generic_base=True,
+                    include_specialized_generic_base=False,
+                )
                 if len(root_parameters) != len(resolved_types):
                     assert_never(base)
 
@@ -201,7 +191,7 @@ class AbstractSubClassSafeGeneric(ABC):
 
     @classmethod
     def _resolve_base_origin_and_arguments(
-        cls, base: Any
+        cls, base: Type
     ) -> Tuple[Optional[Type], Tuple[Type, ...]]:
         """
         Resolve the origin and generic arguments for a base class.
@@ -220,25 +210,6 @@ class AbstractSubClassSafeGeneric(ABC):
             return origin, get_args(base)
 
         return None, ()
-
-    @classmethod
-    @memoize
-    def get_generic_types(
-        cls,
-        include_root_generic_base: bool = True,
-        include_specialized_generic_base: bool = True,
-    ) -> List[Type]:
-        """
-        :param include_root_generic_base: Whether to include type parameters the class gets from its own typing.Generic directly.
-        :param include_specialized_generic_base: Whether to include type parameters from superclasses that are generic, which are not typing.Generic.
-        :return: The concrete generic type parameters bound for this class, in declaration order.
-        """
-        return get_generic_type_params(
-            cls,
-            AbstractSubClassSafeGeneric,
-            include_root_generic_base,
-            include_specialized_generic_base,
-        )
 
 
 @dataclass

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -50,8 +50,6 @@ class AbstractSubClassSafeGeneric(ABC):
         Automatically updates the field types that use the generic type parameters with the new
         specified types, before the class is initialized.
         """
-        # if cls.__name__ != "HSRBGripper":
-        #     return
         # if cls.__name__ != "SubClassGenericThatUpdatesGenericTypeToBuiltInType":
         #     return
 
@@ -147,27 +145,20 @@ class AbstractSubClassSafeGeneric(ABC):
             generic_base_types = generic_base.get_generic_types(True, False)
             if not generic_base_types:
                 generic_base_types = generic_base.get_generic_types(False, True)
-
-            if not generic_base_types:
-                continue
-
-            generic_base_to_generic_type_map = (
-                cls._get_origin_base_to_generic_types_map()
-            )
-            generic_base_to_type_map.update(
-                cls.get_superclass_generic_type_substitution()
-            )
-            # if not len(root_generic_base_types) == len(
-            #     generic_base_to_generic_type_map[ensure_hashable(generic_base)]
-            # ):
-            #     raise ValueError(f"Lengths differ")
-            for old_type, new_type in zip(
-                generic_base_types,
-                generic_base_to_generic_type_map[ensure_hashable(generic_base)],
-            ):
-                if old_type is new_type or new_type is None:
-                    continue
-                generic_base_to_type_map[old_type] = new_type
+                generic_base_to_generic_type_map = (
+                    cls._get_origin_base_to_generic_types_map()
+                )
+                for old_type, new_type in zip(
+                    generic_base_types,
+                    generic_base_to_generic_type_map[ensure_hashable(generic_base)],
+                ):
+                    if old_type is new_type or new_type is None:
+                        continue
+                    generic_base_to_type_map[old_type] = new_type
+            else:
+                generic_base_to_type_map.update(
+                    cls.get_superclass_generic_type_substitution()
+                )
 
         # first resolve all generic types, then afterwards resolve union types
         for base_type, resolved_type in generic_base_to_type_map.items():

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from abc import ABC
 from copy import copy
-from dataclasses import dataclass, fields, Field, field
+from dataclasses import dataclass, fields, Field
 from functools import lru_cache
 from inspect import isclass
-from typing import Tuple, ClassVar
+from typing import Tuple
 
 from typing_extensions import (
     Generic,
@@ -15,15 +15,13 @@ from typing_extensions import (
     Optional,
     Dict,
     Any,
-    List,
     get_origin,
     get_args,
-    assert_never,
+    TypeAlias,
 )
 
 from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
-    resolve_type,
 )
 from krrood.exceptions import MismatchingNumberOfGenericParametersAndResolvedTypes
 from krrood.utils import (
@@ -35,6 +33,9 @@ from krrood.utils import (
 
 if TYPE_CHECKING:
     pass
+
+
+ResolvableType: TypeAlias = type | TypeVar | list["ResolvableType"] | Any
 
 
 @dataclass
@@ -109,7 +110,7 @@ class AbstractSubClassSafeGeneric(ABC):
         cls.__annotations__[name] = resolved_type
 
     @classmethod
-    def _get_generic_type_substitutions(cls) -> Dict[Type, Type]:
+    def _get_generic_type_substitutions(cls) -> Dict[Any, ResolvableType]:
         """
         Get the generic type substitutions for this class.
 
@@ -171,26 +172,49 @@ class AbstractSubClassSafeGeneric(ABC):
 
     @classmethod
     def _resolve_substitutions_transitively(
-        cls, substitutions: Dict[Type, Type]
-    ) -> Dict[Type, Type]:
+        cls, substitutions: Dict[Any, ResolvableType]
+    ) -> Dict[Any, ResolvableType]:
         """
-        Recursively resolve TypeVars in the substitution map to their most concrete form.
+        Recursively resolve TypeVars in the substitution map to their most concrete form
+        using cycle detection to handle complex generic hierarchies safely.
 
         :param substitutions: The substitution map to resolve.
         :return: A new substitution map with fully resolved types.
         """
         resolved_substitutions = {}
+
+        def _resolve_recursive(
+            current_type: ResolvableType, visited: set[Any]
+        ) -> ResolvableType:
+            if isinstance(current_type, TypeVar):
+                type_key = ensure_hashable(current_type)
+                if type_key in visited:
+                    return current_type
+
+                if type_key in substitutions:
+                    return _resolve_recursive(
+                        substitutions[type_key], visited | {type_key}
+                    )
+                return current_type
+
+            if isinstance(current_type, list):
+                return [_resolve_recursive(item, visited) for item in current_type]
+
+            origin = get_origin(current_type)
+            if origin is None:
+                return current_type
+
+            args = get_args(current_type)
+            resolved_args = tuple(_resolve_recursive(arg, visited) for arg in args)
+
+            if resolved_args == args:
+                return current_type
+
+            return origin[resolved_args]
+
         for old_type, new_type in substitutions.items():
-            current_type = new_type
-            # Limit iterations to avoid infinite loops in case of circular references
-            for _ in range(100):
-                resolution = resolve_type(current_type, substitutions)
-                if not resolution.resolved:
-                    break
-                if resolution.resolved_type is current_type:
-                    break
-                current_type = resolution.resolved_type
-            resolved_substitutions[old_type] = current_type
+            resolved_substitutions[old_type] = _resolve_recursive(new_type, set())
+
         return resolved_substitutions
 
     @classmethod
@@ -236,7 +260,7 @@ class SubClassSafeGeneric(Generic[T], AbstractSubClassSafeGeneric, ABC):
     @lru_cache
     def get_generic_type(cls) -> Optional[Type[T]]:
         """
-        :return: The type of the role taker.
+        :return: The type that is currently bound to the generic type parameter T for this class, or None if T is not bound.
         """
         generic_types = get_generic_type_params(cls, SubClassSafeGeneric)
         if not generic_types:

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -25,6 +25,7 @@ from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
     resolve_type,
 )
+from krrood.exceptions import MismatchingNumberOfGenericParametersAndResolvedTypes
 from krrood.utils import (
     get_generic_type_params,
     T,
@@ -142,10 +143,10 @@ class AbstractSubClassSafeGeneric(ABC):
                     include_specialized_generic_base=False,
                 )
                 if len(root_parameters) != len(resolved_types):
-                    raise TypeError(
-                        f"The number of generic type parameters in {base_origin} "
-                        f"({len(root_parameters)}) does not match the number of "
-                        f"provided arguments ({len(resolved_types)})."
+                    raise MismatchingNumberOfGenericParametersAndResolvedTypes(
+                        affected_class=base_origin,
+                        parameters=root_parameters,
+                        resolved_types=resolved_types,
                     )
 
                 for old_type, new_type in zip(root_parameters, resolved_types):
@@ -238,6 +239,6 @@ class SubClassSafeGeneric(Generic[T], AbstractSubClassSafeGeneric, ABC):
         :return: The type of the role taker.
         """
         generic_types = get_generic_type_params(cls, SubClassSafeGeneric)
-        for generic_type in generic_types:
-            return generic_type
-        return None
+        if not generic_types:
+            return None
+        return generic_types[0]

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -75,44 +75,58 @@ class AbstractSubClassSafeGeneric(ABC):
 
         :param name: The name of the field.
         :param kwargs: Keyword arguments to update the field with.
+        :param type_: The type of the field.
         """
-        existing_field = None
-        for base in cls.__mro__:
-            if hasattr(base, "__dataclass_fields__"):
-                if name in base.__dataclass_fields__:
-                    existing_field = base.__dataclass_fields__[name]
-                    break
+        existing_field = cls._get_existing_field(name)
+
+        # Check if we should update an existing attribute or field on the current class
+        target_field = None
         if hasattr(cls, name):
-            # First check if there's a new created field that is yet to be processed
-            attribute_value = getattr(cls, name)
-            if isinstance(attribute_value, Field):
-                new_attribute_value = copy(attribute_value)
-                for key, value in kwargs.items():
-                    setattr(new_attribute_value, key, value)
-            else:
-                non_type_kwargs = copy(kwargs)
-                non_type_kwargs.pop("type", None)
-                if non_type_kwargs:
-                    setattr(cls, name, field(**non_type_kwargs))
+            attr = getattr(cls, name)
+            if isinstance(attr, Field):
+                target_field = attr
+
+        # If no direct field, but we found one in MRO, we might need to copy it
+        if target_field is None and existing_field is not None:
+            target_field = existing_field
+
+        if target_field is not None:
+            new_field = copy(target_field)
+            for key, value in kwargs.items():
+                setattr(new_field, key, value)
+            setattr(cls, name, new_field)
         else:
-            if existing_field is not None:
-                new_field = copy(existing_field)
-                for key, value in kwargs.items():
-                    setattr(new_field, key, value)
-                setattr(cls, name, new_field)
-            else:
-                field_kwargs = copy(kwargs)
-                field_kwargs.pop("type", None)
-                if field_kwargs:
-                    setattr(cls, name, field(**field_kwargs))
+            # Create a new field if it doesn't exist
+            field_kwargs = {k: v for k, v in kwargs.items() if k != "type"}
+            if field_kwargs:
+                setattr(cls, name, field(**field_kwargs))
+
+        # Update annotations
         if "type" in kwargs:
-            cls.__annotations__[name] = kwargs["type"]
+            resolved_type = kwargs["type"]
         elif type_ is not None:
-            cls.__annotations__[name] = type_
+            resolved_type = type_
         elif existing_field is not None:
-            cls.__annotations__[name] = existing_field.type
+            resolved_type = existing_field.type
         else:
-            cls.__annotations__[name] = Any
+            resolved_type = Any
+        cls.__annotations__[name] = resolved_type
+
+    @classmethod
+    def _get_existing_field(cls, name: str) -> Optional[Field]:
+        """
+        Find the existing field in the MRO if it exists.
+
+        :param name: The name of the field.
+        :return: The existing field if found, otherwise None.
+        """
+        for base in cls.__mro__:
+            if (
+                hasattr(base, "__dataclass_fields__")
+                and name in base.__dataclass_fields__
+            ):
+                return base.__dataclass_fields__[name]
+        return None
 
     @classmethod
     def _get_unique_generic_bases(cls) -> List[Type[AbstractSubClassSafeGeneric]]:
@@ -141,40 +155,38 @@ class AbstractSubClassSafeGeneric(ABC):
         if not unique_generic_bases:
             return {}
         generic_base_to_type_map = {}
+
+        # Pre-calculate to avoid redundant calls
+        superclass_substitutions = cls.get_superclass_generic_type_substitution()
+        origin_base_to_generic_type_map = cls._get_origin_base_to_generic_types_map()
+
         for generic_base in unique_generic_bases:
             generic_base_types = generic_base.get_generic_types(True, False)
             if not generic_base_types:
                 generic_base_types = generic_base.get_generic_types(False, True)
-                generic_base_to_generic_type_map = (
-                    cls._get_origin_base_to_generic_types_map()
+                base_args = origin_base_to_generic_type_map.get(
+                    ensure_hashable(generic_base)
                 )
-                for old_type, new_type in zip(
-                    generic_base_types,
-                    generic_base_to_generic_type_map[ensure_hashable(generic_base)],
-                ):
-                    if old_type is new_type or new_type is None:
-                        continue
-                    generic_base_to_type_map[old_type] = new_type
+                if base_args:
+                    for old_type, new_type in zip(generic_base_types, base_args):
+                        if old_type is not new_type and new_type is not None:
+                            generic_base_to_type_map[old_type] = new_type
             else:
-                generic_base_to_type_map.update(
-                    cls.get_superclass_generic_type_substitution()
-                )
+                generic_base_to_type_map.update(superclass_substitutions)
 
-        # first resolve all generic types, then afterwards resolve union types
+        # resolve all generic types, then afterwards resolve union types
         for base_type, resolved_type in generic_base_to_type_map.items():
-            if get_origin(resolved_type) is not Union:
-                continue
-            generic_base_to_type_map[base_type] = resolve_union_type(
-                resolved_type, generic_base_to_type_map
-            )
+            if get_origin(resolved_type) is Union:
+                generic_base_to_type_map[base_type] = resolve_union_type(
+                    resolved_type, generic_base_to_type_map
+                )
 
         return generic_base_to_type_map
 
     @classmethod
     def _get_origin_base_to_generic_types_map(cls) -> Dict[Hashable, Tuple[Type, ...]]:
         """
-        :return: A mapping from each generic base of this class to the generic types it uses, for every generic base
-        that is a subclass of AbstractSubClassSafeGeneric or is declared with generic type parameters via Generic[...].
+        :return: A mapping from each generic base of this class to the generic types it uses.
         """
         origin_base_to_generic_type: Dict[Hashable, Tuple[Type, ...]] = {}
         for base in getattr(cls, "__orig_bases__", []):
@@ -189,26 +201,11 @@ class AbstractSubClassSafeGeneric(ABC):
         return origin_base_to_generic_type
 
     @classmethod
-    def get_generic_types(
-        cls,
-        from_root_generic_base: bool = True,
-        from_specialized_generic_base: bool = True,
-    ) -> List[Type]:
-        """
-        :return: The concrete generic type parameters bound for this class, in declaration order.
-        """
-        return get_generic_type_params(
-            cls,
-            AbstractSubClassSafeGeneric,
-            from_root_generic_base,
-            from_specialized_generic_base,
-        )
-
-    @classmethod
     def get_superclass_generic_type_substitution(cls) -> Dict[Type, Type]:
-
+        """
+        :return: A mapping from each superclass generic type to the resolved type in this class.
+        """
         substitutions = {}
-
         for base in getattr(cls, "__orig_bases__", []):
             if base is AbstractSubClassSafeGeneric:
                 continue
@@ -227,17 +224,31 @@ class AbstractSubClassSafeGeneric(ABC):
             for old_type, new_type in zip(
                 base_origin._get_unique_generic_bases(), specialized_base_types
             ):
-                if old_type is new_type or new_type is None:
-                    continue
+                if old_type is not new_type and new_type is not None:
+                    u_roots = old_type.get_generic_types(True, False)
+                    if u_roots:
+                        substitutions[ensure_hashable(u_roots[0])] = new_type
 
-                substitutions[
-                    ensure_hashable(old_type.get_generic_types(True, False)[0])
-                ] = new_type
             for old_type, new_type in zip(root_base_types, resolved_types):
-                if old_type is new_type or new_type is None:
-                    continue
-                substitutions[ensure_hashable(old_type)] = new_type
+                if old_type is not new_type and new_type is not None:
+                    substitutions[ensure_hashable(old_type)] = new_type
         return substitutions
+
+    @classmethod
+    def get_generic_types(
+        cls,
+        from_root_generic_base: bool = True,
+        from_specialized_generic_base: bool = True,
+    ) -> List[Type]:
+        """
+        :return: The concrete generic type parameters bound for this class, in declaration order.
+        """
+        return get_generic_type_params(
+            cls,
+            AbstractSubClassSafeGeneric,
+            from_root_generic_base,
+            from_specialized_generic_base,
+        )
 
 
 @dataclass

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -22,12 +22,12 @@ from typing_extensions import (
 
 from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
+    resolve_type,
 )
 from krrood.entity_query_language.utils import ensure_hashable
 from krrood.utils import (
     get_generic_type_params,
     T,
-    resolve_union_type,
 )
 
 if TYPE_CHECKING:
@@ -129,110 +129,102 @@ class AbstractSubClassSafeGeneric(ABC):
         return None
 
     @classmethod
-    def _get_unique_generic_bases(cls) -> List[Type[AbstractSubClassSafeGeneric]]:
-        """
-        :return: The unique generic bases of this class, excluding itself, AbstractSubClassSafeGeneric and object,
-        and excluding any base that is a superclass of another base or not a subclass of AbstractSubClassSafeGeneric.
-        """
-        unique_bases = []
-        for base in cls.__mro__:
-            if base in (cls, AbstractSubClassSafeGeneric, object):
-                continue
-            if not issubclass(base, AbstractSubClassSafeGeneric):
-                continue
-            if any(issubclass(other_base, base) for other_base in unique_bases):
-                continue
-            unique_bases.append(base)
-        return unique_bases
-
-    @classmethod
     def _get_generic_type_substitutions(cls) -> Dict[Type, Type]:
         """
+        Get the generic type substitutions for this class.
+
         :return: A mapping from each old generic type (as declared on the parent class) to the
             new generic type used by this class, for every position whose binding changed.
         """
-        unique_generic_bases = cls._get_unique_generic_bases()
-        if not unique_generic_bases:
+        if cls is AbstractSubClassSafeGeneric:
             return {}
-        generic_base_to_type_map = {}
 
-        # Pre-calculate to avoid redundant calls
-        superclass_substitutions = cls.get_superclass_generic_type_substitution()
-        origin_base_to_generic_type_map = cls._get_origin_base_to_generic_types_map()
+        # Use a class-level cache to avoid redundant recursive calculations
+        if "_subclass_safe_substitutions" in cls.__dict__:
+            return cls._subclass_safe_substitutions
 
-        for generic_base in unique_generic_bases:
-            generic_base_types = generic_base.get_generic_types(True, False)
-            if not generic_base_types:
-                generic_base_types = generic_base.get_generic_types(False, True)
-                base_args = origin_base_to_generic_type_map.get(
-                    ensure_hashable(generic_base)
-                )
-                if base_args:
-                    for old_type, new_type in zip(generic_base_types, base_args):
-                        if old_type is not new_type and new_type is not None:
-                            generic_base_to_type_map[old_type] = new_type
-            else:
-                generic_base_to_type_map.update(superclass_substitutions)
+        substitutions = cls.get_superclass_generic_type_substitution()
+        if substitutions:
+            substitutions = cls._resolve_substitutions_transitively(substitutions)
 
-        # resolve all generic types, then afterwards resolve union types
-        for base_type, resolved_type in generic_base_to_type_map.items():
-            if get_origin(resolved_type) is Union:
-                generic_base_to_type_map[base_type] = resolve_union_type(
-                    resolved_type, generic_base_to_type_map
-                )
-
-        return generic_base_to_type_map
+        cls._subclass_safe_substitutions = substitutions
+        return substitutions
 
     @classmethod
-    def _get_origin_base_to_generic_types_map(cls) -> Dict[Hashable, Tuple[Type, ...]]:
+    def _resolve_substitutions_transitively(
+        cls, substitutions: Dict[Type, Type]
+    ) -> Dict[Type, Type]:
         """
-        :return: A mapping from each generic base of this class to the generic types it uses.
+        Recursively resolve TypeVars in the substitution map to their most concrete form.
+
+        :param substitutions: The substitution map to resolve.
+        :return: A new substitution map with fully resolved types.
         """
-        origin_base_to_generic_type: Dict[Hashable, Tuple[Type, ...]] = {}
-        for base in getattr(cls, "__orig_bases__", []):
-            base_origin = get_origin(base)
-            if base_origin is None:
-                continue
-            if base_origin is not Generic and not issubclass(
-                base_origin, AbstractSubClassSafeGeneric
-            ):
-                continue
-            origin_base_to_generic_type[ensure_hashable(base_origin)] = get_args(base)
-        return origin_base_to_generic_type
+        resolved_substitutions = {}
+        for old_type, new_type in substitutions.items():
+            current_type = new_type
+            # Limit iterations to avoid infinite loops in case of circular references
+            for _ in range(100):
+                resolution = resolve_type(current_type, substitutions)
+                if not resolution.resolved:
+                    break
+                if resolution.resolved_type is current_type:
+                    break
+                current_type = resolution.resolved_type
+            resolved_substitutions[old_type] = current_type
+        return resolved_substitutions
 
     @classmethod
     def get_superclass_generic_type_substitution(cls) -> Dict[Type, Type]:
         """
+        Retrieve generic type substitutions from superclasses.
+
         :return: A mapping from each superclass generic type to the resolved type in this class.
         """
         substitutions = {}
-        for base in getattr(cls, "__orig_bases__", []):
-            if base is AbstractSubClassSafeGeneric:
-                continue
-            if isclass(base) and not issubclass(base, AbstractSubClassSafeGeneric):
-                continue
-            base_origin = get_origin(base)
-            if not base_origin or not issubclass(
-                base_origin, AbstractSubClassSafeGeneric
-            ):
+        if not hasattr(cls, "__orig_bases__"):
+            return substitutions
+
+        for base in cls.__orig_bases__:
+            base_origin, resolved_types = cls._resolve_base_origin_and_arguments(base)
+            if base_origin is None:
                 continue
 
-            specialized_base_types = base_origin.get_generic_types(False, True)
-            root_base_types = base_origin.get_generic_types(True, False)
-            resolved_types = get_args(base)
+            # Map the root TypeVars of the base to the concrete arguments provided here
+            root_parameters = base_origin.get_generic_types(True, False)
+            if not root_parameters:
+                root_parameters = base_origin.get_generic_types(False, True)
 
-            for old_type, new_type in zip(
-                base_origin._get_unique_generic_bases(), specialized_base_types
-            ):
-                if old_type is not new_type and new_type is not None:
-                    u_roots = old_type.get_generic_types(True, False)
-                    if u_roots:
-                        substitutions[ensure_hashable(u_roots[0])] = new_type
-
-            for old_type, new_type in zip(root_base_types, resolved_types):
+            for old_type, new_type in zip(root_parameters, resolved_types):
                 if old_type is not new_type and new_type is not None:
                     substitutions[ensure_hashable(old_type)] = new_type
+
+            # Recursively pull substitutions already defined by the parent
+            if base_origin is not cls:
+                substitutions.update(base_origin._get_generic_type_substitutions())
         return substitutions
+
+    @classmethod
+    def _resolve_base_origin_and_arguments(
+        cls, base: Any
+    ) -> Tuple[Optional[Type], Tuple[Type, ...]]:
+        """
+        Resolve the origin and generic arguments for a base class.
+
+        :param base: The base to resolve.
+        :return: A tuple of the origin class and its generic arguments.
+        """
+        origin = get_origin(base)
+        if origin is None:
+            if isclass(base) and issubclass(base, AbstractSubClassSafeGeneric):
+                return base, ()
+            return None, ()
+
+        # Ensure origin is a class before calling issubclass
+        if isclass(origin) and issubclass(origin, AbstractSubClassSafeGeneric):
+            return origin, get_args(base)
+
+        return None, ()
 
     @classmethod
     def get_generic_types(
@@ -274,6 +266,6 @@ class SubClassSafeGeneric(Generic[T], AbstractSubClassSafeGeneric, ABC):
         :return: The type of the role taker.
         """
         generic_types = get_generic_type_params(cls, SubClassSafeGeneric)
-        if generic_types:
-            return generic_types[0]
+        for generic_type in generic_types:
+            return generic_type
         return None

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -4,6 +4,8 @@ from abc import ABC
 from copy import copy
 from dataclasses import dataclass, fields, Field, field
 from functools import lru_cache
+from inspect import isclass
+from typing import Union, Tuple, Hashable
 
 from typing_extensions import (
     Generic,
@@ -14,14 +16,18 @@ from typing_extensions import (
     Dict,
     Any,
     List,
+    get_origin,
+    get_args,
 )
 
 from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
 )
+from krrood.entity_query_language.utils import ensure_hashable
 from krrood.utils import (
-    get_generic_type_param,
+    get_generic_type_params,
     T,
+    resolve_union_type,
 )
 
 if TYPE_CHECKING:
@@ -44,6 +50,11 @@ class AbstractSubClassSafeGeneric(ABC):
         Automatically updates the field types that use the generic type parameters with the new
         specified types, before the class is initialized.
         """
+        # if cls.__name__ != "HSRBGripper":
+        #     return
+        # if cls.__name__ != "SubClassGenericThatUpdatesGenericTypeToBuiltInType":
+        #     return
+
         substitutions = cls._get_generic_type_substitutions()
         if not substitutions:
             return
@@ -67,88 +78,175 @@ class AbstractSubClassSafeGeneric(ABC):
         :param name: The name of the field.
         :param kwargs: Keyword arguments to update the field with.
         """
-        field_ = next((f for f in fields(cls) if f.name == name), None)
+        existing_field = None
+        for base in cls.__mro__:
+            if hasattr(base, "__dataclass_fields__"):
+                if name in base.__dataclass_fields__:
+                    existing_field = base.__dataclass_fields__[name]
+                    break
         if hasattr(cls, name):
             # First check if there's a new created field that is yet to be processed
             attribute_value = getattr(cls, name)
             if isinstance(attribute_value, Field):
+                new_attribute_value = copy(attribute_value)
                 for key, value in kwargs.items():
-                    setattr(attribute_value, key, value)
+                    setattr(new_attribute_value, key, value)
             else:
                 non_type_kwargs = copy(kwargs)
                 non_type_kwargs.pop("type", None)
                 if non_type_kwargs:
                     setattr(cls, name, field(**non_type_kwargs))
         else:
-            # If not, check if there's an existing field that needs to be updated
-            field_ = copy(next((f for f in fields(cls) if f.name == name), None))
-            if field_ is not None:
+            if existing_field is not None:
+                new_field = copy(existing_field)
                 for key, value in kwargs.items():
-                    setattr(field_, key, value)
-                setattr(cls, field_.name, field_)
+                    setattr(new_field, key, value)
+                setattr(cls, name, new_field)
             else:
-                setattr(cls, name, field(**kwargs))
+                field_kwargs = copy(kwargs)
+                field_kwargs.pop("type", None)
+                if field_kwargs:
+                    setattr(cls, name, field(**field_kwargs))
         if "type" in kwargs:
             cls.__annotations__[name] = kwargs["type"]
         elif type_ is not None:
             cls.__annotations__[name] = type_
-        elif field_ is not None:
-            cls.__annotations__[name] = field_.type
+        elif existing_field is not None:
+            cls.__annotations__[name] = existing_field.type
         else:
             cls.__annotations__[name] = Any
 
     @classmethod
-    def _get_generic_base(cls) -> Optional[Type]:
+    def _get_unique_generic_bases(cls) -> List[Type[AbstractSubClassSafeGeneric]]:
         """
-        :return: The class that declares the generic parameters for this hierarchy, i.e. the
-            direct subclass of :class:`AbstractSubClassSafeGeneric` in the MRO.
+        :return: The unique generic bases of this class, excluding itself, AbstractSubClassSafeGeneric and object,
+        and excluding any base that is a superclass of another base or not a subclass of AbstractSubClassSafeGeneric.
         """
+        unique_bases = []
         for base in cls.__mro__:
             if base in (cls, AbstractSubClassSafeGeneric, object):
                 continue
             if not issubclass(base, AbstractSubClassSafeGeneric):
                 continue
-            if AbstractSubClassSafeGeneric in base.__bases__:
-                return base
-        return None
+            if any(issubclass(other_base, base) for other_base in unique_bases):
+                continue
+            unique_bases.append(base)
+        return unique_bases
 
     @classmethod
-    def _get_generic_type_substitutions(cls) -> Dict[Any, Any]:
+    def _get_generic_type_substitutions(cls) -> Dict[Type, Type]:
         """
         :return: A mapping from each old generic type (as declared on the parent class) to the
             new generic type used by this class, for every position whose binding changed.
         """
-        current_types = cls.get_generic_types()
-        if not current_types:
+        unique_generic_bases = cls._get_unique_generic_bases()
+        if not unique_generic_bases:
             return {}
-        generic_base = cls._get_generic_base()
-        if generic_base is None:
-            return {}
-        for base in cls.__bases__:
-            if not isinstance(base, type) or not issubclass(base, generic_base):
+        generic_base_to_type_map = {}
+        for generic_base in unique_generic_bases:
+            generic_base_types = generic_base.get_generic_types(True, False)
+            if not generic_base_types:
+                generic_base_types = generic_base.get_generic_types(False, True)
+
+            if not generic_base_types:
                 continue
-            base_types = base.get_generic_types()
-            if not base_types or len(base_types) != len(current_types):
-                continue
-            substitutions: Dict[Any, Any] = {}
-            for old_type, new_type in zip(base_types, current_types):
+
+            generic_base_to_generic_type_map = (
+                cls._get_origin_base_to_generic_types_map()
+            )
+            generic_base_to_type_map.update(
+                cls.get_superclass_generic_type_substitution()
+            )
+            # if not len(root_generic_base_types) == len(
+            #     generic_base_to_generic_type_map[ensure_hashable(generic_base)]
+            # ):
+            #     raise ValueError(f"Lengths differ")
+            for old_type, new_type in zip(
+                generic_base_types,
+                generic_base_to_generic_type_map[ensure_hashable(generic_base)],
+            ):
                 if old_type is new_type or new_type is None:
                     continue
-                substitutions[old_type] = new_type
-            if substitutions:
-                return substitutions
-        return {}
+                generic_base_to_type_map[old_type] = new_type
+
+        # first resolve all generic types, then afterwards resolve union types
+        for base_type, resolved_type in generic_base_to_type_map.items():
+            if get_origin(resolved_type) is not Union:
+                continue
+            generic_base_to_type_map[base_type] = resolve_union_type(
+                resolved_type, generic_base_to_type_map
+            )
+
+        return generic_base_to_type_map
 
     @classmethod
-    @lru_cache
-    def get_generic_types(cls) -> Optional[List[Type]]:
+    def _get_origin_base_to_generic_types_map(cls) -> Dict[Hashable, Tuple[Type, ...]]:
+        """
+        :return: A mapping from each generic base of this class to the generic types it uses, for every generic base
+        that is a subclass of AbstractSubClassSafeGeneric or is declared with generic type parameters via Generic[...].
+        """
+        origin_base_to_generic_type: Dict[Hashable, Tuple[Type, ...]] = {}
+        for base in getattr(cls, "__orig_bases__", []):
+            base_origin = get_origin(base)
+            if base_origin is None:
+                continue
+            if base_origin is not Generic and not issubclass(
+                base_origin, AbstractSubClassSafeGeneric
+            ):
+                continue
+            origin_base_to_generic_type[ensure_hashable(base_origin)] = get_args(base)
+        return origin_base_to_generic_type
+
+    @classmethod
+    def get_generic_types(
+        cls,
+        from_root_generic_base: bool = True,
+        from_specialized_generic_base: bool = True,
+    ) -> List[Type]:
         """
         :return: The concrete generic type parameters bound for this class, in declaration order.
         """
-        generic_base = cls._get_generic_base()
-        if generic_base is None:
-            return None
-        return get_generic_type_param(cls, generic_base)
+        return get_generic_type_params(
+            cls,
+            AbstractSubClassSafeGeneric,
+            from_root_generic_base,
+            from_specialized_generic_base,
+        )
+
+    @classmethod
+    def get_superclass_generic_type_substitution(cls) -> Dict[Type, Type]:
+
+        substitutions = {}
+
+        for base in getattr(cls, "__orig_bases__", []):
+            if base is AbstractSubClassSafeGeneric:
+                continue
+            if isclass(base) and not issubclass(base, AbstractSubClassSafeGeneric):
+                continue
+            base_origin = get_origin(base)
+            if not base_origin or not issubclass(
+                base_origin, AbstractSubClassSafeGeneric
+            ):
+                continue
+
+            specialized_base_types = base_origin.get_generic_types(False, True)
+            root_base_types = base_origin.get_generic_types(True, False)
+            resolved_types = get_args(base)
+
+            for old_type, new_type in zip(
+                base_origin._get_unique_generic_bases(), specialized_base_types
+            ):
+                if old_type is new_type or new_type is None:
+                    continue
+
+                substitutions[
+                    ensure_hashable(old_type.get_generic_types(True, False)[0])
+                ] = new_type
+            for old_type, new_type in zip(root_base_types, resolved_types):
+                if old_type is new_type or new_type is None:
+                    continue
+                substitutions[ensure_hashable(old_type)] = new_type
+        return substitutions
 
 
 @dataclass
@@ -173,7 +271,7 @@ class SubClassSafeGeneric(Generic[T], AbstractSubClassSafeGeneric, ABC):
         """
         :return: The type of the role taker.
         """
-        generic_types = get_generic_type_param(cls, SubClassSafeGeneric)
+        generic_types = get_generic_type_params(cls, SubClassSafeGeneric)
         if generic_types:
             return generic_types[0]
         return None

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -633,18 +633,26 @@ def get_generic_type_params(
     :return: A list of concrete type parameters
     """
     params = []
-    for base in getattr(cls, "__orig_bases__", []):
-        base_origin = get_origin(base)
-        if not base_origin:
-            continue
-        if not (include_root_generic_base or base_origin is Generic):
-            continue
-        if not (
-            include_specialized_generic_base or issubclass(base_origin, generic_base)
-        ):
-            continue
+    if include_root_generic_base:
+        # Use __parameters__ to get the class's own unbound TypeVars.
+        params.extend(list(getattr(cls, "__parameters__", [])))
 
-        params.extend(list(get_args(base)))
+    if include_specialized_generic_base:
+        for base in getattr(cls, "__orig_bases__", []):
+            base_origin = get_origin(base)
+            if (
+                not base_origin
+                or base_origin is Generic
+                or not issubclass(base_origin, generic_base)
+            ):
+                continue
+            for arg in get_args(base):
+                if not isinstance(arg, TypeVar):
+                    params.append(arg)
+                elif not include_root_generic_base:
+                    # If we specifically excluded root params, we might still want
+                    # TypeVars that are being passed to this specialized base.
+                    params.append(arg)
 
     return params
 

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -617,8 +617,8 @@ def run_subprocess_on_file(command: List[str]):
 def get_generic_type_params(
     cls,
     generic_base: Type,
-    from_root_generic_base: bool = True,
-    from_specialized_generic_base: bool = True,
+    include_root_generic_base: bool = True,
+    include_specialized_generic_base: bool = True,
 ) -> List[Type[T]]:
     """
     Given a subclass and its generic base, return the concrete type parameter(s).
@@ -628,19 +628,23 @@ def get_generic_type_params(
 
     :param cls: The subclass to check.
     :param generic_base: The generic base class to check against.
+    :param include_root_generic_base: Whether to include type parameters the class gets from its own typing.Generic directly.
+    :param include_specialized_generic_base: Whether to include type parameters from superclasses that are generic, which are not typing.Generic.
     :return: A list of concrete type parameters
     """
     params = []
     for base in getattr(cls, "__orig_bases__", []):
         base_origin = get_origin(base)
         if not base_origin:
-            if isclass(base) and issubclass(base, generic_base):
-                params.extend(get_generic_type_params(base, generic_base))
             continue
-        if from_root_generic_base and base_origin is Generic:
-            params.extend(list(get_args(base)))
-        elif from_specialized_generic_base and issubclass(base_origin, generic_base):
-            params.extend(list(get_args(base)))
+        if not (include_root_generic_base or base_origin is Generic):
+            continue
+        if not (
+            include_specialized_generic_base or issubclass(base_origin, generic_base)
+        ):
+            continue
+
+        params.extend(list(get_args(base)))
 
     return params
 

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -18,7 +18,7 @@ from inspect import isclass
 from os import PathLike
 from os.path import dirname
 from pathlib import Path
-from typing import Tuple, Generic
+from typing import Tuple, Generic, Hashable
 from typing import Union, Any
 
 from typing_extensions import TypeVar, Type, List, Optional, Callable
@@ -645,19 +645,27 @@ def get_generic_type_params(
     return params
 
 
-def resolve_union_type(union_type, substitution):
-    resolved_types = []
-    for arg in get_args(union_type):
-        if get_origin(arg) is Union:
-            resolved_types.append(resolve_union_type(arg, substitution))
-        elif arg in substitution:
-            resolved_types.append(substitution[arg])
-        else:
-            resolved_types.append(arg)
+def is_hashable(obj) -> bool:
+    """
+    Checks if an object is hashable by attempting to compute its hash.
 
-    # PyCharm flags this as `Invalid type argument`, but this works at runtime
-    new_union = Union[*resolved_types]
-    return new_union
+    :param obj: The object to check.
+    :return: True if the object is hashable, False otherwise.
+    """
+    try:
+        hash(obj)
+        return True
+    except TypeError:
+        return False
+
+
+def ensure_hashable(obj) -> Hashable:
+    """
+    :return: The object itself if it is hashable, otherwise its id.
+    """
+    if not is_hashable(obj):
+        return id(obj)
+    return obj
 
 
 def get_scope_from_imports(
@@ -867,16 +875,16 @@ def _handle_import_from_node(
     return package_name
 
 
-T = TypeVar("T", bound=Callable[..., Any])
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def memoize(function: T) -> T:
+def memoize(function: F) -> F:
     """
     Caches the return value of a function call at the instance level.
     """
 
     @wraps(function)
-    def wrapper(self, *args: Any, **kwargs: Any) -> T:
+    def wrapper(self, *args: Any, **kwargs: Any) -> Any:
         if not hasattr(self, "__memo__"):
             self.__memo__ = {}
         memo = self.__memo__
@@ -892,7 +900,7 @@ def memoize(function: T) -> T:
     return wrapper  # type: ignore
 
 
-def copy_memoize(function: T) -> T:
+def copy_memoize(function: F) -> F:
     """
     Caches the return value of a function call at the instance level but returns a deepcopy of the value.
     """

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -650,11 +650,28 @@ def get_generic_type_params(
                 if not isinstance(arg, TypeVar):
                     params.append(arg)
                 elif not include_root_generic_base:
-                    # If we specifically excluded root params, we might still want
-                    # TypeVars that are being passed to this specialized base.
+                    # If we specifically excluded root generic params, we might still want
+                    # TypeVars that are being passed to this specialized base
+                    # Example: For `class Child(Generic[T, U], Parent[T])`:
+                    # - `include_root_generic_base=True` returns `[T, U]` (captures all definitions, avoids duplicates).
+                    # - `include_root_generic_base=False` returns `[T]` (captures only what is specifically passed to `Parent`).
                     params.append(arg)
 
     return params
+
+
+def get_existing_field_by_name(cls, name: str) -> Optional[Field]:
+    """
+    Find the existing field in the MRO if it exists.
+
+    :param name: The name of the field.
+    :return: The existing field if found, otherwise None.
+    """
+    for base in cls.__mro__:
+        fields = getattr(base, "__dataclass_fields__", None)
+        if fields and name in fields:
+            return fields[name]
+    return None
 
 
 def is_hashable(obj) -> bool:
@@ -887,10 +904,10 @@ def _handle_import_from_node(
     return package_name
 
 
-F = TypeVar("F", bound=Callable[..., Any])
+TCallable = TypeVar("TCallable", bound=Callable[..., Any])
 
 
-def memoize(function: F) -> F:
+def memoize(function: TCallable) -> TCallable:
     """
     Caches the return value of a function call at the instance level.
     """
@@ -912,7 +929,7 @@ def memoize(function: F) -> F:
     return wrapper  # type: ignore
 
 
-def copy_memoize(function: F) -> F:
+def copy_memoize(function: TCallable) -> TCallable:
     """
     Caches the return value of a function call at the instance level but returns a deepcopy of the value.
     """

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -18,7 +18,7 @@ from inspect import isclass
 from os import PathLike
 from os.path import dirname
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Generic
 from typing import Union, Any
 
 from typing_extensions import TypeVar, Type, List, Optional, Callable
@@ -614,29 +614,50 @@ def run_subprocess_on_file(command: List[str]):
         raise SubprocessExecutionError(command, e.returncode, e.stdout, e.stderr) from e
 
 
-def get_generic_type_param(cls, generic_base: Type[T]) -> Optional[List[Type[T]]]:
+def get_generic_type_params(
+    cls,
+    generic_base: Type,
+    from_root_generic_base: bool = True,
+    from_specialized_generic_base: bool = True,
+) -> List[Type[T]]:
     """
     Given a subclass and its generic base, return the concrete type parameter(s).
 
     Example:
-        get_generic_type_param(Employee, Role) -> (<class '__main__.Person'>,)
+        get_generic_type_params(Employee, Role) -> (<class '__main__.Person'>,)
 
     :param cls: The subclass to check.
     :param generic_base: The generic base class to check against.
-    :return: A list of concrete type parameters, or None if not found.
+    :return: A list of concrete type parameters
     """
+    params = []
     for base in getattr(cls, "__orig_bases__", []):
         base_origin = get_origin(base)
-        if base_origin is None:
+        if not base_origin:
             if isclass(base) and issubclass(base, generic_base):
-                res = get_generic_type_param(base, generic_base)
-                if res:
-                    return res
+                params.extend(get_generic_type_params(base, generic_base))
             continue
-        if issubclass(base_origin, generic_base):
-            args = get_args(base)
-            return list(args) if args else None
-    return None
+        if from_root_generic_base and base_origin is Generic:
+            params.extend(list(get_args(base)))
+        elif from_specialized_generic_base and issubclass(base_origin, generic_base):
+            params.extend(list(get_args(base)))
+
+    return params
+
+
+def resolve_union_type(union_type, substitution):
+    resolved_types = []
+    for arg in get_args(union_type):
+        if get_origin(arg) is Union:
+            resolved_types.append(resolve_union_type(arg, substitution))
+        elif arg in substitution:
+            resolved_types.append(substitution[arg])
+        else:
+            resolved_types.append(arg)
+
+    # PyCharm flags this as `Invalid type argument`, but this works at runtime
+    new_union = Union[*resolved_types]
+    return new_union
 
 
 def get_scope_from_imports(

--- a/test/krrood_test/dataset/classes_with_generic.py
+++ b/test/krrood_test/dataset/classes_with_generic.py
@@ -85,6 +85,7 @@ class TwoGenericContainerBoundToBuiltIns(TwoGenericContainer[int, str]): ...
 
 @dataclass(eq=False)
 class GenericListClass(SubClassSafeGeneric[T], ABC):
+    generic_variable: T = field(default=None)
     generic_list: list[T] = field(default_factory=list)
 
 
@@ -110,6 +111,6 @@ class CombinedThreeGenericSubClassSafe(
 
 
 @dataclass(eq=False)
-class SpecificCombinedThreeGenericSubClassSafe(
+class ComplexCombinedThreeGenericSubClassSafe(
     CombinedThreeGenericSubClassSafe[ExampleClass, CombinedClass]
 ): ...

--- a/test/krrood_test/dataset/classes_with_generic.py
+++ b/test/krrood_test/dataset/classes_with_generic.py
@@ -114,3 +114,17 @@ class CombinedThreeGenericSubClassSafe(
 class ComplexCombinedThreeGenericSubClassSafe(
     CombinedThreeGenericSubClassSafe[ExampleClass, CombinedClass]
 ): ...
+
+
+@dataclass(eq=False)
+class CombinedThreeGenericSubClassSafeWithThirdType(
+    Generic[U, V], OneGenericSubClassSafe[int]
+):
+    combined_three_generic_first_argument: U
+    combined_three_generic_second_argument: V
+
+
+@dataclass(eq=False)
+class ComplexCombinedThreeGenericSubClassSafeWithThirdTypes(
+    CombinedThreeGenericSubClassSafeWithThirdType[ExampleClass, CombinedClass]
+): ...

--- a/test/krrood_test/dataset/classes_with_generic.py
+++ b/test/krrood_test/dataset/classes_with_generic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass, field
+from typing import Union
 
 from typing_extensions import List, TypeVar, Generic
 
@@ -80,3 +81,35 @@ class TwoGenericContainer(TwoGenericSubClassSafe[U, V]):
 
 @dataclass
 class TwoGenericContainerBoundToBuiltIns(TwoGenericContainer[int, str]): ...
+
+
+@dataclass(eq=False)
+class GenericListClass(SubClassSafeGeneric[T], ABC):
+    generic_list: list[T] = field(default_factory=list)
+
+
+@dataclass(eq=False)
+class ExampleClass: ...
+
+
+@dataclass(eq=False)
+class CombinedClass(ExampleClass, GenericListClass[str]): ...
+
+
+@dataclass(eq=False)
+class OneGenericSubClassSafe(Generic[T], AbstractSubClassSafeGeneric, ABC):
+    one_generic_first_argument: T
+
+
+@dataclass(eq=False)
+class CombinedThreeGenericSubClassSafe(
+    Generic[U, V], OneGenericSubClassSafe[Union[U, V]]
+):
+    combined_three_generic_first_argument: U
+    combined_three_generic_second_argument: V
+
+
+@dataclass(eq=False)
+class SpecificCombinedThreeGenericSubClassSafe(
+    CombinedThreeGenericSubClassSafe[ExampleClass, CombinedClass]
+): ...

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -564,6 +564,34 @@ class GenericClassDAO(
     }
 
 
+class GenericClass_floatDAO(
+    GenericClassDAO,
+    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
+):
+
+    __tablename__ = "GenericClass_floatDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GenericClassDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
+        use_existing_column=True
+    )
+
+    container: Mapped[typing.List[builtins.float]] = mapped_column(
+        JSON, nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GenericClass_floatDAO",
+        "inherit_condition": database_id == GenericClassDAO.database_id,
+    }
+
+
 class GenericClass_KRROODPositionDAO(
     GenericClassDAO,
     DataAccessObject[
@@ -612,34 +640,6 @@ class GenericClass_KRROODPositionDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "GenericClass_KRROODPositionDAO",
-        "inherit_condition": database_id == GenericClassDAO.database_id,
-    }
-
-
-class GenericClass_floatDAO(
-    GenericClassDAO,
-    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
-):
-
-    __tablename__ = "GenericClass_floatDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(GenericClassDAO.database_id),
-        primary_key=True,
-        use_existing_column=True,
-    )
-
-    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
-        use_existing_column=True
-    )
-
-    container: Mapped[typing.List[builtins.float]] = mapped_column(
-        JSON, nullable=False, use_existing_column=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "GenericClass_floatDAO",
         "inherit_condition": database_id == GenericClassDAO.database_id,
     }
 

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -564,34 +564,6 @@ class GenericClassDAO(
     }
 
 
-class GenericClass_floatDAO(
-    GenericClassDAO,
-    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
-):
-
-    __tablename__ = "GenericClass_floatDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(GenericClassDAO.database_id),
-        primary_key=True,
-        use_existing_column=True,
-    )
-
-    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
-        use_existing_column=True
-    )
-
-    container: Mapped[typing.List[builtins.float]] = mapped_column(
-        JSON, nullable=False, use_existing_column=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "GenericClass_floatDAO",
-        "inherit_condition": database_id == GenericClassDAO.database_id,
-    }
-
-
 class GenericClass_KRROODPositionDAO(
     GenericClassDAO,
     DataAccessObject[
@@ -640,6 +612,34 @@ class GenericClass_KRROODPositionDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "GenericClass_KRROODPositionDAO",
+        "inherit_condition": database_id == GenericClassDAO.database_id,
+    }
+
+
+class GenericClass_floatDAO(
+    GenericClassDAO,
+    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
+):
+
+    __tablename__ = "GenericClass_floatDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GenericClassDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
+        use_existing_column=True
+    )
+
+    container: Mapped[typing.List[builtins.float]] = mapped_column(
+        JSON, nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GenericClass_floatDAO",
         "inherit_condition": database_id == GenericClassDAO.database_id,
     }
 

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -20,7 +20,6 @@ import datetime
 import enum
 import krrood.adapters.json_serializer
 import krrood.entity_query_language.orm.model
-import krrood.entity_query_language.predicate
 import krrood.ormatic.custom_types
 import krrood.ormatic.data_access_objects.alternative_mappings
 import krrood.ormatic.type_dict
@@ -1968,22 +1967,6 @@ class ChildBaseMappingDAO(
     __mapper_args__ = {
         "polymorphic_identity": "ChildBaseMappingDAO",
         "inherit_condition": database_id == ParentBaseMappingDAO.database_id,
-    }
-
-
-class PredicateDAO(
-    SymbolDAO, DataAccessObject[krrood.entity_query_language.predicate.Predicate]
-):
-
-    __tablename__ = "PredicateDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(SymbolDAO.database_id), primary_key=True, use_existing_column=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "PredicateDAO",
-        "inherit_condition": database_id == SymbolDAO.database_id,
     }
 
 

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -153,6 +153,7 @@ def test_ComplexCombinedThreeGenericSubClassSafeWithThirdTypes():
     assert resolved_hints["combined_three_generic_second_argument"] == CombinedClass
     assert resolved_hints["one_generic_first_argument"] == int
 
+
 T = TypeVar("T")
 T2 = TypeVar("T2")
 U = TypeVar("U")
@@ -236,7 +237,7 @@ def test_multiple_generic_bases_map_failure():
     Test that multiple generic bases are correctly reconstructed in the substitution map.
     The current zip-based implementation is expected to fail.
     """
-    from krrood.entity_query_language.utils import ensure_hashable
+    from krrood.utils import ensure_hashable
 
     @dataclass
     class Base1(Generic[T, T2], AbstractSubClassSafeGeneric):

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -1,5 +1,6 @@
 import sys
 from dataclasses import fields
+from typing import Union
 
 from typing_extensions import (
     get_type_hints,
@@ -20,6 +21,9 @@ from ..dataset.classes_with_generic import (
     SubClassGenericThatRecreatesAFieldWithAnotherVar,
     SubClassGenericThatRecreatesAFieldWithNonBuiltInType,
     TwoGenericContainerBoundToBuiltIns,
+    CombinedClass,
+    SpecificCombinedThreeGenericSubClassSafe,
+    ExampleClass,
 )
 
 
@@ -114,4 +118,25 @@ def _assert_generic_type_is_resolved(cls):
     assert (
         get_origin(nested_generic_type) is list
         and get_args(nested_generic_type)[0] is generic_type
+    )
+
+
+def test_combined_class_with_generic_subclass_safe_generic_inheritance_second_doesnt_die_from_missing_type_and_is_still_updated():
+    cls = CombinedClass
+    resolved_hints = get_type_hints(cls, include_extras=True)
+    field_name = "generic_list"
+    assert resolved_hints[field_name] == list[str]
+
+    field_ = next(f for f in fields(cls) if f.name == field_name)
+    assert field_.type == list[str]
+
+
+def test_SpecificCombinedThreeGenericSubClassSafe():
+    cls = SpecificCombinedThreeGenericSubClassSafe
+    resolved_hints = get_type_hints(cls, include_extras=True)
+    assert resolved_hints["combined_three_generic_first_argument"] == ExampleClass
+    assert resolved_hints["combined_three_generic_second_argument"] == CombinedClass
+    assert (
+        resolved_hints["one_generic_first_argument"]
+        == Union[ExampleClass, CombinedClass]
     )

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -10,7 +10,7 @@ from typing_extensions import (
 
 from krrood.entity_query_language.factories import variable_from
 from krrood.patterns.subclass_safe_generic import SubClassSafeGeneric
-from krrood.utils import get_generic_type_param
+from krrood.utils import get_generic_type_params
 from ..dataset.classes_with_generic import (
     FirstGeneric,
     SubClassGenericThatUpdatesGenericTypeToBuiltInType,
@@ -22,7 +22,7 @@ from ..dataset.classes_with_generic import (
     SubClassGenericThatRecreatesAFieldWithNonBuiltInType,
     TwoGenericContainerBoundToBuiltIns,
     CombinedClass,
-    SpecificCombinedThreeGenericSubClassSafe,
+    ComplexCombinedThreeGenericSubClassSafe,
     ExampleClass,
 )
 
@@ -73,7 +73,7 @@ def assert_field_kwargs_are_preserved_when_resolving_generic_type(cls, kw_only=F
     assert get_origin(evaluated_type) is list
     assert (
         get_args(evaluated_type)[0]
-        is get_generic_type_param(cls, SubClassSafeGeneric)[0]
+        is get_generic_type_params(cls, SubClassSafeGeneric)[0]
     )
 
 
@@ -107,7 +107,7 @@ def test_resolve_two_generic_types_subclass_with_built_in_types():
 
 def _assert_generic_type_is_resolved(cls):
     resolved_hints = get_type_hints(cls, include_extras=True)
-    generic_type = get_generic_type_param(cls, SubClassSafeGeneric)[0]
+    generic_type = get_generic_type_params(cls, SubClassSafeGeneric)[0]
     assert (
         resolved_hints[variable_from(cls).attribute_using_generic._attribute_name_]
         is generic_type
@@ -131,8 +131,8 @@ def test_combined_class_with_generic_subclass_safe_generic_inheritance_second_do
     assert field_.type == list[str]
 
 
-def test_SpecificCombinedThreeGenericSubClassSafe():
-    cls = SpecificCombinedThreeGenericSubClassSafe
+def test_ComplexCombinedThreeGenericSubClassSafe():
+    cls = ComplexCombinedThreeGenericSubClassSafe
     resolved_hints = get_type_hints(cls, include_extras=True)
     assert resolved_hints["combined_three_generic_first_argument"] == ExampleClass
     assert resolved_hints["combined_three_generic_second_argument"] == CombinedClass

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -1,6 +1,16 @@
 import sys
+import pytest
 from dataclasses import fields, dataclass
-from typing import Union, TypeVar, Generic, List
+from typing import (
+    Union,
+    TypeVar,
+    Generic,
+    List,
+    Optional,
+    Callable,
+    Annotated,
+    Dict,
+)
 
 from typing_extensions import (
     get_type_hints,
@@ -292,3 +302,55 @@ def test_transitive_map_failure():
 
     res = resolve_type(List[T], subs)
     assert res.resolved_type == List[int]
+
+
+@pytest.mark.parametrize(
+    "type_hint, expected_resolved",
+    [
+        (Union[T, U], Union[int, str]),
+        ("float | T", float | int),
+        (Optional[U], Optional[str]),
+        (Callable[[T], U], Callable[[int], str]),
+        (Annotated[V, "metadata"], Annotated[float, "metadata"]),
+        (List[Union[T, Dict[str, U]]], List[Union[int, Dict[str, str]]]),
+    ],
+)
+def test_complex_type_resolution(type_hint, expected_resolved):
+    """
+    Test that complex types are correctly resolved when bound in a subclass.
+    """
+
+    @dataclass
+    class Base(Generic[T, U, V], AbstractSubClassSafeGeneric):
+        attribute: type_hint
+
+    @dataclass
+    class Final(Base[int, str, float]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["attribute"].type == expected_resolved
+
+
+def test_circular_reference_resolution():
+    """
+    Test that circular references in type substitutions are handled without infinite recursion.
+    """
+    T_local = TypeVar("T_local")
+    U_local = TypeVar("U_local")
+
+    # Direct cycle: T -> U, U -> T
+    substitutions = {T_local: U_local, U_local: T_local}
+    resolved = AbstractSubClassSafeGeneric._resolve_substitutions_transitively(
+        substitutions
+    )
+    assert resolved[T_local] in {T_local, U_local}
+    assert resolved[U_local] in {T_local, U_local}
+
+    # Indirect cycle: T -> List[U], U -> T
+    substitutions = {T_local: List[U_local], U_local: T_local}
+    resolved = AbstractSubClassSafeGeneric._resolve_substitutions_transitively(
+        substitutions
+    )
+    assert resolved[T_local] is not None
+    assert resolved[U_local] is not None

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -24,6 +24,7 @@ from ..dataset.classes_with_generic import (
     CombinedClass,
     ComplexCombinedThreeGenericSubClassSafe,
     ExampleClass,
+    ComplexCombinedThreeGenericSubClassSafeWithThirdTypes,
 )
 
 
@@ -140,3 +141,11 @@ def test_ComplexCombinedThreeGenericSubClassSafe():
         resolved_hints["one_generic_first_argument"]
         == Union[ExampleClass, CombinedClass]
     )
+
+
+def test_ComplexCombinedThreeGenericSubClassSafeWithThirdTypes():
+    cls = ComplexCombinedThreeGenericSubClassSafeWithThirdTypes
+    resolved_hints = get_type_hints(cls, include_extras=True)
+    assert resolved_hints["combined_three_generic_first_argument"] == ExampleClass
+    assert resolved_hints["combined_three_generic_second_argument"] == CombinedClass
+    assert resolved_hints["one_generic_first_argument"] == int

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -1,6 +1,6 @@
 import sys
-from dataclasses import fields
-from typing import Union
+from dataclasses import fields, dataclass
+from typing import Union, TypeVar, Generic, List
 
 from typing_extensions import (
     get_type_hints,
@@ -9,7 +9,10 @@ from typing_extensions import (
 )
 
 from krrood.entity_query_language.factories import variable_from
-from krrood.patterns.subclass_safe_generic import SubClassSafeGeneric
+from krrood.patterns.subclass_safe_generic import (
+    SubClassSafeGeneric,
+    AbstractSubClassSafeGeneric,
+)
 from krrood.utils import get_generic_type_params
 from ..dataset.classes_with_generic import (
     FirstGeneric,
@@ -149,3 +152,142 @@ def test_ComplexCombinedThreeGenericSubClassSafeWithThirdTypes():
     assert resolved_hints["combined_three_generic_first_argument"] == ExampleClass
     assert resolved_hints["combined_three_generic_second_argument"] == CombinedClass
     assert resolved_hints["one_generic_first_argument"] == int
+
+T = TypeVar("T")
+T2 = TypeVar("T2")
+U = TypeVar("U")
+V = TypeVar("V")
+
+
+def test_multiple_generic_parameters_specialization():
+    """
+    Test that when a base has multiple generic parameters and some are specialized
+    with concrete types while others stay generic, all are correctly handled.
+    The current implementation using u_roots[0] and zip(unique_bases, specialized_types)
+    is expected to fail here because it only maps the first parameter of the first base.
+    """
+
+    @dataclass
+    class MultiBase(Generic[T, T2], AbstractSubClassSafeGeneric):
+        attr1: T
+        attr2: T2
+
+    @dataclass
+    class Intermediate(Generic[U], MultiBase[U, int]):
+        pass
+
+    @dataclass
+    class Final(Intermediate[str]):
+        pass
+
+    field_dict = {f.name: f for f in fields(Final)}
+    assert field_dict["attr1"].type == str
+    assert field_dict["attr2"].type == int
+
+
+def test_deep_inheritance_substitution():
+    """
+    Test that substitutions are correctly propagated through deep inheritance.
+    """
+
+    @dataclass
+    class Base(Generic[T], AbstractSubClassSafeGeneric):
+        attr: T
+
+    @dataclass
+    class Intermediate(Generic[U], Base[U]):
+        pass
+
+    @dataclass
+    class Final(Intermediate[int]):
+        pass
+
+    field_dict = {f.name: f for f in fields(Final)}
+    assert field_dict["attr"].type == int
+
+
+def test_transitive_resolution_complex():
+    """
+    Test that transitive resolution works for complex types like List[T].
+    If T -> U and U -> int, then List[T] should become List[int].
+    """
+
+    @dataclass
+    class Base(Generic[T], AbstractSubClassSafeGeneric):
+        attr: List[T]
+
+    @dataclass
+    class Intermediate(Generic[U], Base[U]):
+        pass
+
+    @dataclass
+    class Final(Intermediate[int]):
+        pass
+
+    field_dict = {f.name: f for f in fields(Final)}
+    assert field_dict["attr"].type == List[int]
+
+
+W = TypeVar("W")
+
+
+def test_multiple_generic_bases_map_failure():
+    """
+    Test that multiple generic bases are correctly reconstructed in the substitution map.
+    The current zip-based implementation is expected to fail.
+    """
+    from krrood.entity_query_language.utils import ensure_hashable
+
+    @dataclass
+    class Base1(Generic[T, T2], AbstractSubClassSafeGeneric):
+        pass
+
+    @dataclass
+    class Base2(Generic[V], AbstractSubClassSafeGeneric):
+        pass
+
+    @dataclass
+    class Combined(Generic[U, W], Base1[U, int], Base2[W]):
+        pass
+
+    @dataclass
+    class Final(Combined[str, bool]):
+        pass
+
+    subs = Final._get_generic_type_substitutions()
+
+    # T2 should be mapped to int (via Combined)
+    assert subs.get(ensure_hashable(T2)) == int
+    # V should be mapped to W and then to bool, so resolved V should be bool
+    # We use subs.get because it might be missing or wrongly mapped
+
+    # In a perfect world, we should be able to resolve V to bool through the chain V -> W -> bool
+    from krrood.class_diagrams.utils import resolve_type
+
+    res = resolve_type(V, subs)
+    assert res.resolved_type == bool
+
+
+def test_transitive_map_failure():
+    """
+    Test that the substitution map itself is not transitively resolved.
+    If T -> U and U -> int, resolving List[T] should give List[int].
+    """
+
+    @dataclass
+    class Base(Generic[T], AbstractSubClassSafeGeneric):
+        pass
+
+    @dataclass
+    class Intermediate(Generic[U], Base[U]):
+        pass
+
+    @dataclass
+    class Final(Intermediate[int]):
+        pass
+
+    subs = Final._get_generic_type_substitutions()
+    from krrood.class_diagrams.utils import resolve_type
+
+    res = resolve_type(List[T], subs)
+    assert res.resolved_type == List[int]


### PR DESCRIPTION
# Feature: Improved Generic Type Handling and Robust `SubClassSafeGeneric`

This PR refactors `AbstractSubClassSafeGeneric` and related utilities to properly handle complex generic inheritance patterns, multiple generic parameters, and transitive type variable resolution. It also cleans up duplicated utility functions and ensures dataclass field metadata is preserved during type updates.

Theoretical Motivation:
Generic programming in Python's typing system can become complex when dealing with deep inheritance trees and multiple generic parameters. `SubClassSafeGeneric` aims to automate the update of dataclass field types based on bound generic arguments, but required a more robust mechanism to track substitutions across multiple bases and resolve them transitively.

Practical Reasoning:
Robot models and entity queries often involve complex generic structures (e.g., `CombinedThreeGenericSubClassSafe`). The previous implementation failed to correctly map types in these scenarios, leading to incorrect type hints and runtime issues in the entity query language. This PR ensures that type safety is maintained even in complex hierarchies.

## Highlights of This Pull-Request

- **Robust Generic Substitutions**: Supports multiple generic bases and multiple type parameters per base.
- **Transitive Type Resolution**: Correctly resolves chains of `TypeVar` (e.g., `T` -> `U` -> `int`) to their most concrete form.
- **Dataclass Field Preservation**: Updates field types while preserving existing metadata like `default_factory` and `kw_only`.

---

## Feature Improvements

### `krrood.patterns.subclass_safe_generic`

- Introduced `AbstractSubClassSafeGeneric` to encapsulate the substitution and field-update logic.
- Implemented `_get_generic_type_substitutions` with support for multiple `__orig_bases__`, mapping root `TypeVar`s to concrete arguments correctly.
- Added `_resolve_substitutions_transitively` to handle nested or chained generic parameters.
- Enhanced `_update_field_kwargs` to correctly handle inherited fields and ensure that both the field object and `__annotations__` are updated.

### `krrood.utils`

- Refactored `get_generic_type_param` into a more robust `get_generic_type_params`, which can now include or exclude root and specialized generic parameters.
- Centralized `is_hashable` and `ensure_hashable` from `entity_query_language.utils`.
- Improved `memoize` decorator to use a dedicated `TypeVar` (`F`) to avoid potential naming collisions with the commonly used `T`.

---

## Deprecated or Removed Features

- **`krrood.class_diagrams.utils.get_generic_type_param`**: Removed in favor of the centralized version in `krrood.utils`.

---

## Backwards Incompatible Changes

- **Renamed `get_generic_type_param` to `get_generic_type_params`**: The utility now returns a list of parameters and has an updated signature. Internal calls have been updated, but external consumers will need to adjust.
- **Moved `ensure_hashable` and `is_hashable`**: These were moved from `krrood.entity_query_language.utils` to `krrood.utils`.

---

## Other Changes

- Added comprehensive new tests in `test_subclass_safe_generic.py` covering multi-base, deep inheritance, and transitive resolution scenarios.
- Cleaned up imports and improved code style consistency across modified modules.

---

Credit: Layout inspired by [SciPy](https://docs.scipy.org/doc/scipy/release/1.15.0-notes.html)