### PR TITLE
Fix/collison matrix apply_buffer

### DIFF
--- a/semantic_digital_twin/resources/collision_configs/pr2.srdf
+++ b/semantic_digital_twin/resources/collision_configs/pr2.srdf
@@ -1170,4 +1170,5 @@
   <disable_self_collision link1="t_torso_lift_side_item_profile_link" link2="t_torso_lift_side_item_profile_link" reason="Adjacent"/>
   <disable_self_collision link1="t_torso_lift_side_item_profile_link" link2="torso_lift_link" reason="Adjacent"/>
   <disable_self_collision link1="torso_lift_link" link2="torso_lift_link" reason="Adjacent"/>
+  <disable_self_collision link1="head_pan_link" link2="head_plate_frame" reason="Adjacent"/>
 </robot>

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_matrix.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_matrix.py
@@ -140,10 +140,14 @@ class CollisionMatrix:
         return hash(id(self))
 
     def apply_buffer(self, buffer: float):
-        for collision in self.collision_checks:
-            collision.distance = (
-                collision.distance + buffer if collision.distance else None
+        self.collision_checks = {
+            CollisionCheck(
+                check.body_a,
+                check.body_b,
+                check.distance + buffer if check.distance is not None else None,
             )
+            for check in self.collision_checks
+        }
 
     @classmethod
     def create_all_checks(cls, distance: float, world: World) -> Self:

--- a/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
+++ b/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
@@ -878,10 +878,9 @@ def test_collision_for_robot_with_static_base(tracy_world):
 
 
 def test_repeated_collision_pr2_apartment_does_not_increase_execution_time(
-    pr2_apartment_world, rclpy_node
+    pr2_apartment_world,
 ):
     world = deepcopy(pr2_apartment_world)
-    VizMarkerPublisher(_world=world, node=rclpy_node).with_tf_publisher()
 
     tool_frame = world.get_body_by_name("r_gripper_tool_frame")
     robot = PR2.from_world(world)

--- a/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
+++ b/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
@@ -3,6 +3,13 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
+import time
+
+from semantic_digital_twin.datastructures.definitions import StaticJointState
+from semantic_digital_twin.robots.pr2 import PR2
+from semantic_digital_twin.collision_checking.collision_rules import (
+    AllowCollisionBetweenGroups,
+)
 from giskardpy.executor import Executor, SimulationPacer
 from giskardpy.motion_statechart.context import MotionStatechartContext
 from giskardpy.motion_statechart.data_types import (
@@ -868,3 +875,66 @@ def test_collision_for_robot_with_static_base(tracy_world):
                 f"Gripper penetrated the obstacle (distance={contact.distance:.4f}m)."
                 "ExternalCollisionAvoidance is not avoiding the obstacle."
             )
+
+
+def test_repeated_collision_pr2_apartment_does_not_increase_execution_time(
+    pr2_apartment_world, rclpy_node
+):
+    world = deepcopy(pr2_apartment_world)
+    VizMarkerPublisher(_world=world, node=rclpy_node).with_tf_publisher()
+
+    tool_frame = world.get_body_by_name("r_gripper_tool_frame")
+    robot = PR2.from_world(world)
+
+    left_arm_park = robot.left_arm.get_joint_state_by_type(StaticJointState.PARK)
+    right_arm_park = robot.right_arm.get_joint_state_by_type(StaticJointState.PARK)
+    world.set_positions_1DOF_connection(dict(left_arm_park.items()))
+    world.set_positions_1DOF_connection(dict(right_arm_park.items()))
+
+    body = world.get_body_by_name("handle_cab11_t")
+
+    execution_times = []
+    for i in range(10):
+        msc = MotionStatechart()
+        msc.add_nodes(
+            [
+                UpdateTemporaryCollisionRules(
+                    temporary_rules=[
+                        AvoidExternalCollisions(robot=robot),
+                        AllowCollisionBetweenGroups(
+                            body_group_a=[
+                                b
+                                for b in robot.right_arm.manipulator.bodies
+                                if b.has_collision()
+                            ],
+                            body_group_b=[
+                                b
+                                for b in world.bodies
+                                if "apartment" in str(b.name) and b.has_collision()
+                            ],
+                        ),
+                    ]
+                ),
+                CartesianPose(
+                    root_link=world.root,
+                    tip_link=tool_frame,
+                    goal_pose=body.global_pose,
+                ),
+                ExternalCollisionAvoidance(robot=robot),
+                SelfCollisionAvoidance(robot=robot),
+            ]
+        )
+        msc.add_node(EndMotion.when_true(msc.nodes[1]))
+
+        kin_sim = Executor(
+            MotionStatechartContext(world=world),
+        )
+        kin_sim.compile(motion_statechart=msc)
+        with world.reset_state_context():
+            start_time = time.time()
+            kin_sim.tick_until_end(500)
+            end_time = time.time()
+            execution_times.append(end_time - start_time)
+
+    mean_execution_time = np.mean(execution_times)
+    np.testing.assert_allclose(execution_times, mean_execution_time, rtol=0.5)


### PR DESCRIPTION
when apply_buffer was called in a loop it would add buffer in place onto collision.distance. Causing collision distance to grow over time to multiple meters, which causes bullet to calculate collisions with everything in that range during motion execution, slowing motion execution down immensely with every additional call.

Added a test to replicate that.