### PR TITLE
Add uv.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,10 @@ qtcreator-*
 
 # Catkin custom files
 CATKIN_IGNORE
+
+# Package Managers
 poetry.lock
+uv.lock
 
 # Created during tests
 file::memory:


### PR DESCRIPTION
Just added uv.lock to the gitignore so it's not shown in the git status message and not accidentally commited.