### PR TITLE
Subclass safe generic typevartuple

### DIFF
--- a/krrood/src/krrood/class_diagrams/utils.py
+++ b/krrood/src/krrood/class_diagrams/utils.py
@@ -199,27 +199,29 @@ def resolve_type(
 
     # If the type itself can be indexed (like List[T] or Optional[T])
     parameters = getattr(type_to_resolve, "__parameters__", None)
-    if hasattr(type_to_resolve, "__getitem__") and parameters:
-        new_parameters = []
-        resolved: bool = False  # whether any substitutions were made
-        for parameter in parameters:
-            if parameter in substitution:
-                value = substitution[parameter]
-                if isinstance(parameter, TypeVarTuple) and isinstance(value, tuple):
-                    new_parameters.extend(value)
-                else:
-                    new_parameters.append(value)
-                resolved = True
-            else:
-                new_parameters.append(parameter)
-        subscript_parameter = (
-            new_parameters[0] if len(new_parameters) == 1 else tuple(new_parameters)
-        )
-        return TypeHintResolutionResult(
-            type_to_resolve[subscript_parameter], resolved, type_to_resolve
-        )
+    if not (hasattr(type_to_resolve, "__getitem__") and parameters):
+        return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)
 
-    return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)
+    new_parameters = []
+    resolved: bool = False
+    for parameter in parameters:
+        if parameter not in substitution:
+            new_parameters.append(parameter)
+            continue
+
+        value = substitution[parameter]
+        if isinstance(parameter, TypeVarTuple) and isinstance(value, tuple):
+            new_parameters.extend(value)
+        else:
+            new_parameters.append(value)
+        resolved = True
+
+    subscript_parameter = (
+        new_parameters[0] if len(new_parameters) == 1 else tuple(new_parameters)
+    )
+    return TypeHintResolutionResult(
+        type_to_resolve[subscript_parameter], resolved, type_to_resolve
+    )
 
 
 @lru_cache

--- a/krrood/src/krrood/class_diagrams/utils.py
+++ b/krrood/src/krrood/class_diagrams/utils.py
@@ -12,7 +12,7 @@ import builtins
 import typing_extensions
 from typing_extensions import Callable, get_args, get_origin
 from typing_extensions import List, Type, Any, Dict, Tuple, Generic
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, TypeVarTuple
 
 from krrood import logger
 from krrood.class_diagrams.exceptions import CouldNotResolveType
@@ -189,7 +189,7 @@ def resolve_type(
     :return: A TypeHintResolutionResult object containing the resolved type and a boolean indicating whether any
     substitutions were made.
     """
-    if isinstance(type_to_resolve, TypeVar):
+    if isinstance(type_to_resolve, (TypeVar, TypeVarTuple)):
         type_to_resolve_key = ensure_hashable(type_to_resolve)
         if type_to_resolve_key not in substitution:
             return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)
@@ -198,19 +198,25 @@ def resolve_type(
         )
 
     # If the type itself can be indexed (like List[T] or Optional[T])
-    params = getattr(type_to_resolve, "__parameters__", None)
-    if hasattr(type_to_resolve, "__getitem__") and params:
-        new_params = []
+    parameters = getattr(type_to_resolve, "__parameters__", None)
+    if hasattr(type_to_resolve, "__getitem__") and parameters:
+        new_parameters = []
         resolved: bool = False  # whether any substitutions were made
-        for param in params:
-            if param in substitution:
-                new_params.append(substitution[param])
+        for parameter in parameters:
+            if parameter in substitution:
+                value = substitution[parameter]
+                if isinstance(parameter, TypeVarTuple) and isinstance(value, tuple):
+                    new_parameters.extend(value)
+                else:
+                    new_parameters.append(value)
                 resolved = True
             else:
-                new_params.append(param)
-        subscript_param = new_params[0] if len(new_params) == 1 else tuple(new_params)
+                new_parameters.append(parameter)
+        subscript_parameter = (
+            new_parameters[0] if len(new_parameters) == 1 else tuple(new_parameters)
+        )
         return TypeHintResolutionResult(
-            type_to_resolve[subscript_param], resolved, type_to_resolve
+            type_to_resolve[subscript_parameter], resolved, type_to_resolve
         )
 
     return TypeHintResolutionResult(type_to_resolve, False, type_to_resolve)

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -22,6 +22,7 @@ from typing_extensions import (
     Unpack,
 )
 
+from krrood.adapters.json_serializer import list_like_classes
 from krrood.class_diagrams.utils import (
     get_and_resolve_generic_type_hints_of_object_using_substitutions,
 )
@@ -169,6 +170,10 @@ class AbstractSubClassSafeGeneric(ABC):
     ) -> dict[Any, ResolvableType]:
         """
         Retrieves resolved type substitutions for a given base origin and resolved types.
+
+        :param base_origin: The base origin type for which substitutions are retrieved.
+        :param resolved_types: The resolved types to match against the base origin's generic parameters.
+        :return: A dictionary of resolved type substitutions.
         """
         root_parameters = get_generic_type_params(
             base_origin,
@@ -212,6 +217,10 @@ class AbstractSubClassSafeGeneric(ABC):
     ) -> bool:
         """
         Determines if a substitution condition is fulfilled based on the old and new types.
+
+        :param old_type: The old type to compare against.
+        :param new_type: The new type to compare with.
+        :return: True if the substitution condition is fulfilled, False otherwise.
         """
         if not isinstance(old_type, (TypeVar, TypeVarTuple)):
             return False
@@ -309,18 +318,17 @@ class AbstractSubClassSafeGeneric(ABC):
                     )
                 return current_type
 
-            if isinstance(current_type, list):
-                return [_resolve_recursive(item, visited) for item in current_type]
-
-            if isinstance(current_type, tuple):
+            if isinstance(current_type, list_like_classes):
                 resolved_items = []
                 for item in current_type:
                     result = _resolve_recursive(item, visited)
-                    if get_origin(item) is Unpack and isinstance(result, tuple):
+                    if get_origin(item) is Unpack and isinstance(
+                        result, list_like_classes
+                    ):
                         resolved_items.extend(result)
                     else:
                         resolved_items.append(result)
-                return tuple(resolved_items)
+                return type(current_type)(resolved_items)
 
             origin = get_origin(current_type)
             if origin is None:

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -146,90 +146,9 @@ class AbstractSubClassSafeGeneric(ABC):
 
             # Map the root TypeVars of the base to the concrete arguments provided here
             if resolved_types:
-                root_parameters = get_generic_type_params(
-                    base_origin,
-                    AbstractSubClassSafeGeneric,
-                    include_root_generic_base=True,
-                    include_specialized_generic_base=False,
+                substitutions.update(
+                    cls._get_resolved_type_substitutions(base_origin, resolved_types)
                 )
-                type_var_tuple_index = next(
-                    (
-                        index
-                        for index, parameter in enumerate(root_parameters)
-                        if isinstance(parameter, TypeVarTuple)
-                    ),
-                    -1,
-                )
-
-                if type_var_tuple_index == -1:
-                    if len(root_parameters) != len(resolved_types):
-                        raise MismatchingNumberOfGenericParametersAndResolvedTypes(
-                            affected_class=base_origin,
-                            parameters=root_parameters,
-                            resolved_types=resolved_types,
-                        )
-                    matched_pairs = zip(root_parameters, resolved_types)
-                else:
-                    prefix_length = type_var_tuple_index
-                    suffix_length = len(root_parameters) - type_var_tuple_index - 1
-                    if len(resolved_types) < prefix_length + suffix_length:
-                        raise MismatchingNumberOfGenericParametersAndResolvedTypes(
-                            affected_class=base_origin,
-                            parameters=root_parameters,
-                            resolved_types=resolved_types,
-                        )
-                    type_var_tuple_content_length = (
-                        len(resolved_types) - prefix_length - suffix_length
-                    )
-                    matched_pairs = [
-                        (root_parameters[index], resolved_types[index])
-                        for index in range(prefix_length)
-                    ]
-                    matched_pairs.append(
-                        (
-                            root_parameters[type_var_tuple_index],
-                            tuple(
-                                resolved_types[
-                                    prefix_length : prefix_length
-                                    + type_var_tuple_content_length
-                                ]
-                            ),
-                        )
-                    )
-                    for index in range(suffix_length):
-                        matched_pairs.append(
-                            (
-                                root_parameters[type_var_tuple_index + 1 + index],
-                                resolved_types[
-                                    prefix_length
-                                    + type_var_tuple_content_length
-                                    + index
-                                ],
-                            )
-                        )
-
-                for old_type, new_type in matched_pairs:
-                    if (
-                        not isinstance(old_type, (TypeVar, TypeVarTuple))
-                        or old_type is new_type
-                        or new_type is None
-                    ):
-                        continue
-
-                    # Skip redundant variadic pass-through: Ts -> (Unpack[Ts],)
-                    if (
-                        isinstance(old_type, TypeVarTuple)
-                        and isinstance(new_type, tuple)
-                        and len(new_type) == 1
-                    ):
-                        inner = new_type[0]
-                        if (
-                            get_origin(inner) is Unpack
-                            and get_args(inner)[0] is old_type
-                        ):
-                            continue
-
-                    substitutions[ensure_hashable(old_type)] = new_type
 
             # Recursively pull substitutions already defined by the parent
             if base_origin is cls:
@@ -241,6 +160,127 @@ class AbstractSubClassSafeGeneric(ABC):
 
         cls._subclass_safe_substitutions = substitutions
         return substitutions
+
+    @classmethod
+    def _get_resolved_type_substitutions(
+        cls,
+        base_origin: type,
+        resolved_types: tuple[type, ...],
+    ) -> dict[Any, ResolvableType]:
+        """
+        Retrieves resolved type substitutions for a given base origin and resolved types.
+        """
+        root_parameters = get_generic_type_params(
+            base_origin,
+            AbstractSubClassSafeGeneric,
+            include_root_generic_base=True,
+            include_specialized_generic_base=False,
+        )
+
+        type_var_tuple_index = next(
+            (i for i, p in enumerate(root_parameters) if isinstance(p, TypeVarTuple)),
+            -1,
+        )
+
+        if type_var_tuple_index == -1:
+            if len(root_parameters) != len(resolved_types):
+                raise MismatchingNumberOfGenericParametersAndResolvedTypes(
+                    affected_class=base_origin,
+                    parameters=root_parameters,
+                    resolved_types=resolved_types,
+                )
+            matched_pairs = zip(root_parameters, resolved_types)
+        else:
+            matched_pairs = cls._match_type_var_tuple_variable_to_resolved_type(
+                type_var_tuple_index,
+                root_parameters,
+                resolved_types,
+                base_origin,
+            )
+
+        return {
+            ensure_hashable(old_type): new_type
+            for old_type, new_type in matched_pairs
+            if cls._fulfills_substitution_condition(old_type, new_type)
+        }
+
+    @classmethod
+    def _fulfills_substitution_condition(
+        cls,
+        old_type: Any,
+        new_type: type | tuple[type, ...] | None,
+    ) -> bool:
+        """
+        Determines if a substitution condition is fulfilled based on the old and new types.
+        """
+        if not isinstance(old_type, (TypeVar, TypeVarTuple)):
+            return False
+
+        if old_type is new_type or new_type is None:
+            return False
+
+        if not (
+            isinstance(old_type, TypeVarTuple)
+            and isinstance(new_type, tuple)
+            and len(new_type) == 1
+        ):
+            return True
+
+        inner = new_type[0]
+        return not (get_origin(inner) is Unpack and get_args(inner)[0] is old_type)
+
+    @classmethod
+    def _match_type_var_tuple_variable_to_resolved_type(
+        cls,
+        type_var_tuple_index: int,
+        root_parameters: list[Any],
+        resolved_types: tuple[type, ...],
+        base_origin: type,
+    ) -> list[tuple[type, type]]:
+        """
+        Matches type variables in a tuple with resolved types, considering prefix and suffix lengths.
+
+        :param type_var_tuple_index: Index of the TypeVarTuple within root_parameters.
+        :param root_parameters: List of root parameters to match against resolved types.
+        :param resolved_types: Tuple of resolved types to match with root parameters.
+        :param base_origin: Base origin type for substitutions.
+        :return: List of matched type variable tuples.
+        """
+        prefix_length = type_var_tuple_index
+        suffix_length = len(root_parameters) - type_var_tuple_index - 1
+        if len(resolved_types) < prefix_length + suffix_length:
+            raise MismatchingNumberOfGenericParametersAndResolvedTypes(
+                affected_class=base_origin,
+                parameters=root_parameters,
+                resolved_types=resolved_types,
+            )
+        type_var_tuple_content_length = (
+            len(resolved_types) - prefix_length - suffix_length
+        )
+        matched_pairs = [
+            (root_parameters[index], resolved_types[index])
+            for index in range(prefix_length)
+        ]
+        matched_pairs.append(
+            (
+                root_parameters[type_var_tuple_index],
+                tuple(
+                    resolved_types[
+                        prefix_length : prefix_length + type_var_tuple_content_length
+                    ]
+                ),
+            )
+        )
+        for index in range(suffix_length):
+            matched_pairs.append(
+                (
+                    root_parameters[type_var_tuple_index + 1 + index],
+                    resolved_types[
+                        prefix_length + type_var_tuple_content_length + index
+                    ],
+                )
+            )
+        return matched_pairs
 
     @classmethod
     def _resolve_substitutions_transitively(

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -18,6 +18,8 @@ from typing_extensions import (
     get_origin,
     get_args,
     TypeAlias,
+    TypeVarTuple,
+    Unpack,
 )
 
 from krrood.class_diagrams.utils import (
@@ -35,7 +37,14 @@ if TYPE_CHECKING:
     pass
 
 
-ResolvableType: TypeAlias = type | TypeVar | list["ResolvableType"] | Any
+ResolvableType: TypeAlias = (
+    type
+    | TypeVar
+    | TypeVarTuple
+    | list["ResolvableType"]
+    | tuple["ResolvableType", ...]
+    | Any
+)
 
 
 @dataclass
@@ -143,20 +152,84 @@ class AbstractSubClassSafeGeneric(ABC):
                     include_root_generic_base=True,
                     include_specialized_generic_base=False,
                 )
-                if len(root_parameters) != len(resolved_types):
-                    raise MismatchingNumberOfGenericParametersAndResolvedTypes(
-                        affected_class=base_origin,
-                        parameters=root_parameters,
-                        resolved_types=resolved_types,
-                    )
+                type_var_tuple_index = next(
+                    (
+                        index
+                        for index, parameter in enumerate(root_parameters)
+                        if isinstance(parameter, TypeVarTuple)
+                    ),
+                    -1,
+                )
 
-                for old_type, new_type in zip(root_parameters, resolved_types):
+                if type_var_tuple_index == -1:
+                    if len(root_parameters) != len(resolved_types):
+                        raise MismatchingNumberOfGenericParametersAndResolvedTypes(
+                            affected_class=base_origin,
+                            parameters=root_parameters,
+                            resolved_types=resolved_types,
+                        )
+                    matched_pairs = zip(root_parameters, resolved_types)
+                else:
+                    prefix_length = type_var_tuple_index
+                    suffix_length = len(root_parameters) - type_var_tuple_index - 1
+                    if len(resolved_types) < prefix_length + suffix_length:
+                        raise MismatchingNumberOfGenericParametersAndResolvedTypes(
+                            affected_class=base_origin,
+                            parameters=root_parameters,
+                            resolved_types=resolved_types,
+                        )
+                    type_var_tuple_content_length = (
+                        len(resolved_types) - prefix_length - suffix_length
+                    )
+                    matched_pairs = []
+                    for index in range(prefix_length):
+                        matched_pairs.append(
+                            (root_parameters[index], resolved_types[index])
+                        )
+                    matched_pairs.append(
+                        (
+                            root_parameters[type_var_tuple_index],
+                            tuple(
+                                resolved_types[
+                                    prefix_length : prefix_length
+                                    + type_var_tuple_content_length
+                                ]
+                            ),
+                        )
+                    )
+                    for index in range(suffix_length):
+                        matched_pairs.append(
+                            (
+                                root_parameters[type_var_tuple_index + 1 + index],
+                                resolved_types[
+                                    prefix_length
+                                    + type_var_tuple_content_length
+                                    + index
+                                ],
+                            )
+                        )
+
+                for old_type, new_type in matched_pairs:
                     if (
-                        not isinstance(old_type, TypeVar)
+                        not isinstance(old_type, (TypeVar, TypeVarTuple))
                         or old_type is new_type
                         or new_type is None
                     ):
                         continue
+
+                    # Skip redundant variadic pass-through: Ts -> (Unpack[Ts],)
+                    if (
+                        isinstance(old_type, TypeVarTuple)
+                        and isinstance(new_type, tuple)
+                        and len(new_type) == 1
+                    ):
+                        inner = new_type[0]
+                        if (
+                            get_origin(inner) is Unpack
+                            and get_args(inner)[0] is old_type
+                        ):
+                            continue
+
                     substitutions[ensure_hashable(old_type)] = new_type
 
             # Recursively pull substitutions already defined by the parent
@@ -186,7 +259,7 @@ class AbstractSubClassSafeGeneric(ABC):
         def _resolve_recursive(
             current_type: ResolvableType, visited: set[Any]
         ) -> ResolvableType:
-            if isinstance(current_type, TypeVar):
+            if isinstance(current_type, (TypeVar, TypeVarTuple)):
                 type_key = ensure_hashable(current_type)
                 if type_key in visited:
                     return current_type
@@ -200,12 +273,36 @@ class AbstractSubClassSafeGeneric(ABC):
             if isinstance(current_type, list):
                 return [_resolve_recursive(item, visited) for item in current_type]
 
+            if isinstance(current_type, tuple):
+                resolved_items = []
+                for item in current_type:
+                    result = _resolve_recursive(item, visited)
+                    if get_origin(item) is Unpack and isinstance(result, tuple):
+                        resolved_items.extend(result)
+                    else:
+                        resolved_items.append(result)
+                return tuple(resolved_items)
+
             origin = get_origin(current_type)
             if origin is None:
                 return current_type
 
+            if origin is Unpack:
+                inner_arg = get_args(current_type)[0]
+                resolved_inner = _resolve_recursive(inner_arg, visited)
+                if isinstance(resolved_inner, tuple):
+                    return resolved_inner
+                return Unpack[resolved_inner]
+
             args = get_args(current_type)
-            resolved_args = tuple(_resolve_recursive(arg, visited) for arg in args)
+            resolved_args = []
+            for arg in args:
+                result = _resolve_recursive(arg, visited)
+                if get_origin(arg) is Unpack and isinstance(result, tuple):
+                    resolved_args.extend(result)
+                else:
+                    resolved_args.append(result)
+            resolved_args = tuple(resolved_args)
 
             if resolved_args == args:
                 return current_type

--- a/krrood/src/krrood/patterns/subclass_safe_generic.py
+++ b/krrood/src/krrood/patterns/subclass_safe_generic.py
@@ -181,11 +181,10 @@ class AbstractSubClassSafeGeneric(ABC):
                     type_var_tuple_content_length = (
                         len(resolved_types) - prefix_length - suffix_length
                     )
-                    matched_pairs = []
-                    for index in range(prefix_length):
-                        matched_pairs.append(
-                            (root_parameters[index], resolved_types[index])
-                        )
+                    matched_pairs = [
+                        (root_parameters[index], resolved_types[index])
+                        for index in range(prefix_length)
+                    ]
                     matched_pairs.append(
                         (
                             root_parameters[type_var_tuple_index],

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -21,7 +21,15 @@ from pathlib import Path
 from typing import Tuple, Generic, Hashable
 from typing import Union, Any
 
-from typing_extensions import TypeVar, Type, List, Optional, Callable
+from typing_extensions import (
+    TypeVar,
+    Type,
+    List,
+    Optional,
+    Callable,
+    TypeVarTuple,
+    Unpack,
+)
 from typing_extensions import (
     _SpecialForm,
     Iterable,
@@ -632,10 +640,10 @@ def get_generic_type_params(
     :param include_specialized_generic_base: Whether to include type parameters from superclasses that are generic, which are not typing.Generic.
     :return: A list of concrete type parameters
     """
-    params = []
+    parameters = []
     if include_root_generic_base:
         # Use __parameters__ to get the class's own unbound TypeVars.
-        params.extend(list(getattr(cls, "__parameters__", [])))
+        parameters.extend(list(getattr(cls, "__parameters__", [])))
 
     if include_specialized_generic_base:
         for base in getattr(cls, "__orig_bases__", []):
@@ -646,18 +654,18 @@ def get_generic_type_params(
                 or not issubclass(base_origin, generic_base)
             ):
                 continue
-            for arg in get_args(base):
-                if not isinstance(arg, TypeVar):
-                    params.append(arg)
+            for argument in get_args(base):
+                if not isinstance(argument, (TypeVar, TypeVarTuple)):
+                    parameters.append(argument)
                 elif not include_root_generic_base:
-                    # If we specifically excluded root generic params, we might still want
+                    # If we specifically excluded root generic parameters, we might still want
                     # TypeVars that are being passed to this specialized base
                     # Example: For `class Child(Generic[T, U], Parent[T])`:
                     # - `include_root_generic_base=True` returns `[T, U]` (captures all definitions, avoids duplicates).
                     # - `include_root_generic_base=False` returns `[T]` (captures only what is specifically passed to `Parent`).
-                    params.append(arg)
+                    parameters.append(argument)
 
-    return params
+    return parameters
 
 
 def get_existing_field_by_name(cls, name: str) -> Optional[Field]:

--- a/test/krrood_test/dataset/ormatic_interface.py
+++ b/test/krrood_test/dataset/ormatic_interface.py
@@ -593,34 +593,6 @@ class GenericClassDAO(
     }
 
 
-class GenericClass_floatDAO(
-    GenericClassDAO,
-    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
-):
-
-    __tablename__ = "GenericClass_floatDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(GenericClassDAO.database_id),
-        primary_key=True,
-        use_existing_column=True,
-    )
-
-    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
-        use_existing_column=True
-    )
-
-    container: Mapped[typing.List[builtins.float]] = mapped_column(
-        JSON, nullable=False, use_existing_column=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "GenericClass_floatDAO",
-        "inherit_condition": database_id == GenericClassDAO.database_id,
-    }
-
-
 class GenericClass_KRROODPositionDAO(
     GenericClassDAO,
     DataAccessObject[
@@ -669,6 +641,34 @@ class GenericClass_KRROODPositionDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "GenericClass_KRROODPositionDAO",
+        "inherit_condition": database_id == GenericClassDAO.database_id,
+    }
+
+
+class GenericClass_floatDAO(
+    GenericClassDAO,
+    DataAccessObject[test.krrood_test.dataset.example_classes.GenericClass[float]],
+):
+
+    __tablename__ = "GenericClass_floatDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GenericClassDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    value: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    optional_value: Mapped[typing.Optional[builtins.float]] = mapped_column(
+        use_existing_column=True
+    )
+
+    container: Mapped[typing.List[builtins.float]] = mapped_column(
+        JSON, nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GenericClass_floatDAO",
         "inherit_condition": database_id == GenericClassDAO.database_id,
     }
 

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -238,8 +238,8 @@ def test_transitive_resolution_complex():
     class Final(Intermediate[int]):
         pass
 
-    field_dict = {f.name: f for f in fields(Final)}
-    assert field_dict["attr"].type == List[int]
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["attr"].type == List[int]
 
 
 W = TypeVar("W")
@@ -268,18 +268,18 @@ def test_multiple_generic_bases_map_failure():
     class Final(Combined[str, bool]):
         pass
 
-    subs = Final._get_generic_type_substitutions()
+    substitutions = Final._get_generic_type_substitutions()
 
     # T2 should be mapped to int (via Combined)
-    assert subs.get(ensure_hashable(T2)) == int
+    assert substitutions.get(ensure_hashable(T2)) == int
     # V should be mapped to W and then to bool, so resolved V should be bool
-    # We use subs.get because it might be missing or wrongly mapped
+    # We use substitutions.get because it might be missing or wrongly mapped
 
     # In a perfect world, we should be able to resolve V to bool through the chain V -> W -> bool
     from krrood.class_diagrams.utils import resolve_type
 
-    res = resolve_type(V, subs)
-    assert res.resolved_type == bool
+    result = resolve_type(V, substitutions)
+    assert result.resolved_type == bool
 
 
 def test_transitive_map_failure():
@@ -300,11 +300,11 @@ def test_transitive_map_failure():
     class Final(Intermediate[int]):
         pass
 
-    subs = Final._get_generic_type_substitutions()
+    substitutions = Final._get_generic_type_substitutions()
     from krrood.class_diagrams.utils import resolve_type
 
-    res = resolve_type(List[T], subs)
-    assert res.resolved_type == List[int]
+    result = resolve_type(List[T], substitutions)
+    assert result.resolved_type == List[int]
 
 
 @pytest.mark.parametrize(
@@ -434,3 +434,83 @@ def test_typevartuple_unpack_in_different_positions():
     fields_by_name = {field.name: field for field in fields(Final)}
     # Expected: Tuple[int, str, bool, float]
     assert fields_by_name["attribute"].type == Tuple[int, str, bool, float]
+
+
+def test_typevartuple_at_start():
+    """
+    Test TypeVarTuple at the start of Generic declaration.
+    """
+
+    @dataclass
+    class Base(Generic[Unpack[Ts], T], AbstractSubClassSafeGeneric):
+        first: Tuple[Unpack[Ts]]
+        last: T
+
+    @dataclass
+    class Final(Base[int, str, float]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["first"].type == Tuple[int, str]
+    assert fields_by_name["last"].type == float
+
+
+def test_typevartuple_in_middle():
+    """
+    Test TypeVarTuple in the middle of Generic declaration.
+    """
+
+    @dataclass
+    class Base(Generic[T, Unpack[Ts], U], AbstractSubClassSafeGeneric):
+        first: T
+        middle: Tuple[Unpack[Ts]]
+        last: U
+
+    @dataclass
+    class Final(Base[int, str, float, bool]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["first"].type == int
+    assert fields_by_name["middle"].type == Tuple[str, float]
+    assert fields_by_name["last"].type == bool
+
+
+def test_typevartuple_empty_middle():
+    """
+    Test TypeVarTuple in the middle with empty arguments for it.
+    """
+
+    @dataclass
+    class Base(Generic[T, Unpack[Ts], U], AbstractSubClassSafeGeneric):
+        first: T
+        middle: Tuple[Unpack[Ts]]
+        last: U
+
+    @dataclass
+    class Final(Base[int, bool]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["first"].type == int
+    assert fields_by_name["middle"].type == Tuple[()]
+    assert fields_by_name["last"].type == bool
+
+
+def test_typevartuple_multiple_usage_in_fields():
+    """
+    Test that TypeVarTuple can be used in multiple fields.
+    """
+
+    @dataclass
+    class Base(Generic[Unpack[Ts]], AbstractSubClassSafeGeneric):
+        first: Tuple[Unpack[Ts]]
+        second: List[Tuple[Unpack[Ts]]]
+
+    @dataclass
+    class Final(Base[int, str]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["first"].type == Tuple[int, str]
+    assert fields_by_name["second"].type == List[Tuple[int, str]]

--- a/test/krrood_test/test_patterns/test_subclass_safe_generic.py
+++ b/test/krrood_test/test_patterns/test_subclass_safe_generic.py
@@ -10,12 +10,15 @@ from typing import (
     Callable,
     Annotated,
     Dict,
+    Tuple,
 )
 
 from typing_extensions import (
     get_type_hints,
     get_args,
     get_origin,
+    TypeVarTuple,
+    Unpack,
 )
 
 from krrood.entity_query_language.factories import variable_from
@@ -354,3 +357,80 @@ def test_circular_reference_resolution():
     )
     assert resolved[T_local] is not None
     assert resolved[U_local] is not None
+
+
+Ts = TypeVarTuple("Ts")
+
+
+def test_typevartuple_basic_substitution():
+    """
+    Test that TypeVarTuple is correctly substituted when bound in a subclass.
+    """
+
+    @dataclass
+    class Base(Generic[Unpack[Ts]], AbstractSubClassSafeGeneric):
+        attribute: Tuple[Unpack[Ts]]
+
+    @dataclass
+    class Final(Base[int, str]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["attribute"].type == Tuple[int, str]
+
+
+def test_typevartuple_mixed_with_typevar():
+    """
+    Test that TypeVarTuple mixed with normal TypeVar is correctly substituted.
+    """
+
+    @dataclass
+    class Base(Generic[T, Unpack[Ts]], AbstractSubClassSafeGeneric):
+        attribute: Tuple[T, Unpack[Ts]]
+
+    @dataclass
+    class Final(Base[float, int, str]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["attribute"].type == Tuple[float, int, str]
+
+
+def test_typevartuple_multiple_subclasses():
+    """
+    Test that TypeVarTuple resolution works through multiple levels of inheritance.
+    """
+
+    @dataclass
+    class Base(Generic[Unpack[Ts]], AbstractSubClassSafeGeneric):
+        attribute: Tuple[Unpack[Ts]]
+
+    @dataclass
+    class Intermediate(Generic[T, Unpack[Ts]], Base[Unpack[Ts]]):
+        other: T
+
+    @dataclass
+    class Final(Intermediate[bool, int, str]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    assert fields_by_name["attribute"].type == Tuple[int, str]
+    assert fields_by_name["other"].type == bool
+
+
+def test_typevartuple_unpack_in_different_positions():
+    """
+    Test Unpack[Ts] in different positions within a Tuple or other generic.
+    """
+
+    @dataclass
+    class Base(Generic[Unpack[Ts]], AbstractSubClassSafeGeneric):
+        attribute: Tuple[int, Unpack[Ts], float]
+
+    @dataclass
+    class Final(Base[str, bool]):
+        pass
+
+    fields_by_name = {field.name: field for field in fields(Final)}
+    # Expected: Tuple[int, str, bool, float]
+    assert fields_by_name["attribute"].type == Tuple[int, str, bool, float]


### PR DESCRIPTION
I got the reasonable feedback that im abusing union too much when putting them into generic types in https://github.com/cram2/cognitive_robot_abstract_machine/pull/290 

Subsequently i found TypeVarTuple which basically does a similar thing, but better, and less abusive.
But AbstractSubclassSafeGeneric did not support this yet. so here we are