### PR TITLE
fix: setup_workspace.py not being found by setup_ros_workspace.sh

### DIFF
--- a/scripts/setup_workspace.py
+++ b/scripts/setup_workspace.py
@@ -1,0 +1,1 @@
+../.github/docker/setup_workspace.py


### PR DESCRIPTION
The current installation guide fails at this step:
```
./scripts/setup_ros_workspace.sh
python3: can't open file '/home/fmuehlis/Git/Github/cognitive_robot_abstract_machine/scripts/setup_workspace.py': [Errno 2] No such file or directory
```

This PR fixes that problem by also linking the `setup_workspace.py` script to the scripts directory.