### PR TITLE
Ignore generated graph/RDR-tree visualization artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,17 @@ doc/doc_out
 /.ijwb/
 /.aswb/
 /.clwb/
+
+# Generated visualization artifacts: graph / class-diagram renders and RDR rule
+# trees written into the working tree by visualize(), render_tree() and
+# render_evaluated_rule_tree() during tests and doc builds. None are committed.
+pdf_graph.pdf
+query_graph.pdf
+class_diagram.pdf
+*_explanation.pdf
+*_read_tree.dot
+*_read_tree.svg
+*_evaluated_tree.dot
+*_evaluated_tree.svg
+*_rdr.dot
+*_rdr.svg


### PR DESCRIPTION
visualize(), render_tree() and render_evaluated_rule_tree() write PDF/DOT/SVG renders into the working tree during tests and doc builds (e.g. pdf_graph.pdf, query_graph.pdf, *_read_tree.dot/.svg, *_evaluated_tree.dot/.svg). None of these are committed, so ignore them to keep the working tree clean.