### PR TITLE
[GitHub CI] Added to-lowercase to the build_all_docs.yml/build_docs_reusable.yml

### DIFF
--- a/.github/workflows/build_all_docs.yml
+++ b/.github/workflows/build_all_docs.yml
@@ -7,7 +7,16 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  to-lowercase:
+    runs-on: ubuntu-latest
+    outputs:
+      repo_lowercase: ${{ steps.lowercase.outputs.repository }}
+    steps:
+      - id: lowercase
+        run: |
+          echo "repository=ghcr.io/${GITHUB_REPOSITORY,,}:jazzy" >> $GITHUB_OUTPUT
   build-docs:
+    needs: [to-lowercase]
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +47,7 @@ jobs:
       doc_path: ${{ matrix.doc_path }}
       artifact_name: ${{ matrix.artifact_name }}
       use_container: ${{ matrix.use_container }}
+      repo_lowercase: ${{ needs.to-lowercase.outputs.repo_lowercase }}
 
   deploy-all-docs:
     needs: [build-docs]

--- a/.github/workflows/build_doc_reusable.yml
+++ b/.github/workflows/build_doc_reusable.yml
@@ -20,13 +20,17 @@ on:
         required: false
         type: boolean
         default: false
+      repo_lowercase:
+        description: "(optional) fully qualified lowercase container image (e.g. ghcr.io/owner/repo:jazzy). If provided it will be used for container.image"
+        required: false
+        type: string
 
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.use_container && format('ghcr.io/{0}:jazzy', github.repository) || '' }}
+      image: ${{ inputs.use_container && inputs.repo_lowercase || '' }}
     defaults:
       run:
         shell: ${{ inputs.use_container && 'bash -ieo pipefail {0}' || 'bash' }}
@@ -118,7 +122,7 @@ jobs:
           path: "${{ inputs.lib }}/${{ inputs.doc_path }}/_build/html"
 
       - name: Upload artifact (Container)
-        if: ${{ inputs.use_container && (github.event_name == 'push' || github.event_name == 'workflow_call') }}
+        if: ${{ inputs.use_container && (github.event_name == 'push' || github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}


### PR DESCRIPTION
Uppercase GitHub user names caused issues while building the docs for SemDT.
Added 'workflow_dispatch' to `Upload artifact (Container)` to allow the docs to be built via GitHub actions that where started manually.
(Also the update_docker workflow should be working again after the changes in [iai_robots](https://github.com/code-iai/iai_robots/pull/49) and [iai_weiss_wpg_300-120-gripper](https://github.com/code-iai/iai_weiss_wpg_300-120-gripper/pull/2))

[Working docs workflow after fixes](https://github.com/MideDay/cognitive_robot_abstract_machine/actions/runs/28589281624)
[Working update_docker after PRs](https://github.com/MideDay/cognitive_robot_abstract_machine/actions/runs/28585768241)

For previous error see: [Failing workflow run](https://github.com/MideDay/cognitive_robot_abstract_machine/actions/runs/28506297185) | [raw logs](https://productionresultssa19.blob.core.windows.net/actions-results/306fc148-f205-4d98-822a-03ccb6daa11a/workflow-job-run-259e3d3e-bc32-5a6d-81ff-210f2853370a/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-07-02T10%3A52%3A35Z&sig=3y705s33cKTTKBUvAghXEMJ1tb%2BqSOP1XlIJFJFi37g%3D&ske=2026-07-02T13%3A32%3A41Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-07-02T09%3A32%3A41Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-07-02T10%3A42%3A30Z&sv=2025-11-05)

> `2026-07-01T09:05:50.7404013Z ##[command]/usr/bin/docker --config /home/runner/work/_temp/.docker_8ddc16b6-758e-45a7-8030-8c1dadba162e pull ghcr.io/MideDay/cognitive_robot_abstract_machine:jazzy
> 2026-07-01T09:05:50.7524174Z invalid reference format: repository name (MideDay/cognitive_robot_abstract_machine) must be lowercase
> 2026-07-01T09:05:50.7629748Z ##[error]Docker pull failed with exit code 1`