### PR TITLE
fix FileUriResolver with no base_directory

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/package_resolver.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/package_resolver.py
@@ -4,7 +4,7 @@ import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
-from typing_extensions import List
+from typing_extensions import List, Optional
 
 from semantic_digital_twin.exceptions import (
     ParsingError,
@@ -127,7 +127,7 @@ class FileUriResolver(PathResolver):
     Resolves file:// URIs and plain filesystem paths.
     """
 
-    base_directory: str = None
+    base_directory: Optional[str] = None
     """
     The base directory to resolve relative paths from.
     """
@@ -144,7 +144,7 @@ class FileUriResolver(PathResolver):
         else:
             path = uri
 
-        if not os.path.isabs(path):
+        if self.base_directory and not os.path.isabs(path):
             path = os.path.join(self.base_directory, path)
 
         return os.path.abspath(path)


### PR DESCRIPTION
breaking when no base_directory is given and a relative path should be resolved.

The default FileUriResolver created for a CompositePathResolver has no base_directory, and `os.path.join(self.base_directory, path)` in the FileUriResolver errors when self.base_directory is None.
This PR fixes this by only doing the join operation when base_directory is not None.