### PR TITLE
Fix world leak from underspecified-action grounding iterator

### DIFF
--- a/coraplex/src/coraplex/plans/executables.py
+++ b/coraplex/src/coraplex/plans/executables.py
@@ -455,6 +455,7 @@ class UnderspecifiedExecutable(Executable):
         while self.node.advance():
             try:
                 self.node.current_candidate.parse().execute()
+                self.node.stop_grounding()
                 return
             except PlanFailure:
                 continue

--- a/coraplex/src/coraplex/plans/plan_node.py
+++ b/coraplex/src/coraplex/plans/plan_node.py
@@ -418,12 +418,28 @@ class UnderspecifiedNode(PlanNode):
 
         grounded_action = next(self._action_iterator, None)
         if grounded_action is None:
+            self._action_iterator = None
             return None
 
         candidate = ActionNode(designator=grounded_action)
         self.add_child(candidate)
         self.current_candidate = candidate
         return candidate
+
+    def stop_grounding(self) -> None:
+        """
+        Release the action iterator once no further candidate will be requested from it.
+
+        Between candidates the iterator is left suspended (rather than exhausted) so a later
+        retry can resume the search instead of restarting it; a suspended generator keeps every
+        value its frame holds alive, including resources a candidate generator only builds to
+        validate against (for example a location's deep-copied test world). Once a candidate is
+        accepted and no retry will happen, closing the iterator here releases those resources
+        immediately instead of retaining them for this node's whole lifetime.
+        """
+        if self._action_iterator is not None:
+            self._action_iterator.close()
+            self._action_iterator = None
 
     def notify(self):
         # Resolution is deferred to execution time: the underspecified statement can

--- a/krrood/src/krrood/entity_query_language/cache_data.py
+++ b/krrood/src/krrood/entity_query_language/cache_data.py
@@ -8,6 +8,7 @@ Cache utilities.
 This module provides caching datastructures and utilities.
 """
 from dataclasses import dataclass, field
+from itertools import islice
 from typing_extensions import Dict, Generic, Iterable, Iterator, List, Optional
 
 
@@ -222,8 +223,10 @@ class ReEnterableLazyIterable(Generic[T]):
         if self.iterable is not None:
             return
         recreated_source = (v for v in self._source)
-        for _ in range(len(self.materialized_values)):
-            next(recreated_source, None)
+        skip_count = len(self.materialized_values)
+        # itertools' "consume" recipe: an empty slice starting at skip_count still forces the
+        # underlying iterator to be advanced that many steps, entirely at C speed.
+        next(islice(recreated_source, skip_count, skip_count), None)
         self.iterable = recreated_source
 
     def _release_source(self) -> None:

--- a/krrood/src/krrood/entity_query_language/cache_data.py
+++ b/krrood/src/krrood/entity_query_language/cache_data.py
@@ -8,7 +8,7 @@ Cache utilities.
 This module provides caching datastructures and utilities.
 """
 from dataclasses import dataclass, field
-from typing_extensions import Dict, Generic, Iterable, List
+from typing_extensions import Dict, Generic, Iterable, Iterator, List, Optional
 
 
 @dataclass
@@ -93,19 +93,62 @@ class SeenSet:
 
 
 @dataclass
+class InstanceFilteredDomain(Generic[T]):
+    """
+    A re-iterable view over a domain that yields only the elements that are instances of a type.
+
+    Unlike :func:`filter`, which is a one-shot iterator that eagerly holds ``iter(domain)`` for its
+    whole lifetime, this creates a fresh underlying iterator on every iteration and holds none
+    between them. That keeps :class:`ReEnterableLazyIterable` able to release and recreate its
+    source, so a domain whose iterator only holds a heavy object in its suspended frame (for example
+    a location generator that deep-copied the world) is not pinned for the variable's whole life.
+    """
+
+    type_: type
+    """
+    The type each yielded element must be an instance of.
+    """
+    domain: Iterable[T]
+    """
+    The underlying domain to filter.
+    """
+
+    def __iter__(self) -> Iterator[T]:
+        return (element for element in self.domain if isinstance(element, self.type_))
+
+
+@dataclass
 class ReEnterableLazyIterable(Generic[T]):
     """
     A wrapper for an iterable that allows multiple iterations over its elements,
     materializing values as they are iterated over.
     """
 
-    iterable: Iterable[T] = field(default_factory=list)
+    iterable: Optional[Iterator[T]] = field(default=None)
     """
-    The iterable to wrap.
+    The live source iterator currently feeding new values, or ``None`` when it has been released. It
+    is recreated on demand from :attr:`_source` so releasing it never loses values still to come.
     """
     materialized_values: List[T] = field(default_factory=list)
     """
     The materialized values of the iterable.
+    """
+    _source: Optional[Iterable[T]] = field(default=None, init=False, repr=False)
+    """
+    The original iterable, kept so a released source iterator can be recreated for a later iteration.
+    """
+    _source_is_re_iterable: bool = field(default=False, init=False)
+    """
+    Whether iterating :attr:`_source` yields a fresh iterator each time; only then can the live source
+    be released early and recreated without losing values.
+    """
+    _source_exhausted: bool = field(default=False, init=False)
+    """
+    Whether the source has been fully materialized; once true, iterations serve only from the buffer.
+    """
+    _active_iteration_count: int = field(default=0, init=False, repr=False)
+    """
+    How many iterations are currently in flight, so the source is only released when none remain.
     """
 
     def set_iterable(self, iterable):
@@ -116,31 +159,86 @@ class ReEnterableLazyIterable(Generic[T]):
         weakref instances die, the iterable would have None values for them. But if we wrap it in a generator,
         they are actually removed, and the generator doesn't find them, which is the wanted behavior.
         """
+        self._source = iterable
+        # A source is re-iterable when ``iter(source)`` returns a fresh iterator rather than the
+        # source itself (as one-shot iterators like generators and ``filter`` do). The probe iterator
+        # is discarded without being advanced.
+        self._source_is_re_iterable = iter(iterable) is not iterable
         self.iterable = (v for v in iterable)
+        self.materialized_values = []
+        self._source_exhausted = False
 
     def __iter__(self):
         """
         Iterate over the values, materializing them as they are iterated over. This allows multiple iterations over
         the iterable simultaneously, and it also allows for efficient access to previously materialized values.
 
+        When a re-iterable source has no iteration left in flight its live iterator is released, so a source that only
+        holds a heavy object in its suspended frame (for example a location generator that deep-copied the world)
+        does not keep it alive; a later iteration recreates the source and skips the already-materialized values.
+
         :return: An iterator over the values.
         """
         index = 0
-        while True:
-            if index < len(self.materialized_values):
-                yield self.materialized_values[index]
-                index += 1
-            else:
-                try:
-                    v = next(self.iterable)
-                    self.materialized_values.append(v)
-                    yield v
+        self._active_iteration_count += 1
+        try:
+            while True:
+                if index < len(self.materialized_values):
+                    yield self.materialized_values[index]
                     index += 1
-                except StopIteration:
+                    continue
+                if self._source_exhausted:
                     return
+                self._ensure_source()
+                try:
+                    value = next(self.iterable)
+                except StopIteration:
+                    self._source_exhausted = True
+                    self._release_source()
+                    return
+                self.materialized_values.append(value)
+                yield value
+                index += 1
+        finally:
+            self._active_iteration_count -= 1
+            self._release_source_if_idle()
+
+    def _release_source_if_idle(self) -> None:
+        """
+        Release the live source once nothing is iterating it, but only when it can be recreated
+        without losing values (a re-iterable source that is not yet exhausted).
+        """
+        if (
+            self._active_iteration_count == 0
+            and self._source_is_re_iterable
+            and not self._source_exhausted
+        ):
+            self._release_source()
+
+    def _ensure_source(self) -> None:
+        """
+        Recreate the live source iterator if it was released, skipping the values already materialized.
+        """
+        if self.iterable is not None:
+            return
+        recreated_source = (v for v in self._source)
+        for _ in range(len(self.materialized_values)):
+            next(recreated_source, None)
+        self.iterable = recreated_source
+
+    def _release_source(self) -> None:
+        """
+        Close and drop the live source iterator so its suspended frame (and anything it holds) is freed.
+        """
+        released_source = self.iterable
+        self.iterable = None
+        if released_source is not None:
+            released_source.close()
 
     def __bool__(self):
         """
         Return True if the iterable has values, False otherwise.
         """
-        return bool(self.materialized_values) or bool(self.iterable)
+        return bool(self.materialized_values) or (
+            not self._source_exhausted and self._source is not None
+        )

--- a/krrood/src/krrood/entity_query_language/factories.py
+++ b/krrood/src/krrood/entity_query_language/factories.py
@@ -26,6 +26,7 @@ from krrood.entity_query_language.core.variable import (
     Literal,
     ExternallySetVariable,
 )
+from krrood.entity_query_language.cache_data import InstanceFilteredDomain
 from krrood.entity_query_language.enums import DomainSource
 from krrood.entity_query_language.exceptions import UnsupportedExpressionTypeForDistinct
 from krrood.entity_query_language.operators.aggregators import (
@@ -174,7 +175,7 @@ def variable(
     """
     # Determine the domain source
     if is_iterable(domain):
-        domain = filter(lambda x: isinstance(x, type_), domain)
+        domain = InstanceFilteredDomain(type_, domain)
     elif domain is None and issubclass(type_, Symbol):
         domain = SymbolGraph().get_instances_of_type(type_)
     else:

--- a/test/coraplex_test/test_designator/test_underspecified_designator.py
+++ b/test/coraplex_test/test_designator/test_underspecified_designator.py
@@ -45,6 +45,11 @@ def test_underspecified_action(apartment_world_pr2_copy_with_context):
     candidate = plan.root.children[0]
     assert isinstance(candidate.designator, NavigateAction)
     assert plan.root.parse() is not None
+    assert plan.root._action_iterator is None, (
+        "the action iterator must be released once grounding succeeds, so any resources a "
+        "candidate generator only holds to validate against (for example a location's "
+        "deep-copied test world) are not retained for the node's whole lifetime"
+    )
 
 
 def test_underspecified_action_with_ellipsis(apartment_world_pr2_copy_with_context):

--- a/test/krrood_test/test_eql/test_domain_iteration_release.py
+++ b/test/krrood_test/test_eql/test_domain_iteration_release.py
@@ -1,0 +1,79 @@
+"""Tests that a variable's lazy domain does not permanently pin objects a domain generator only
+holds in its suspended frame.
+
+Some domains build a heavy object as a local inside their ``__iter__`` (for example a coraplex
+location that deep-copies the world to test candidate poses) and yield values that do not reference
+it. Grounding consumes only the first value, leaving the domain generator suspended with that heavy
+local alive. Because a query keeps its variables reachable, the suspended frame must be released so
+the heavy object is collected once the domain is no longer being iterated.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+from dataclasses import dataclass, field
+from typing_extensions import Iterator, List
+
+from krrood.entity_query_language.cache_data import ReEnterableLazyIterable
+from krrood.entity_query_language.factories import an, entity, variable
+
+
+@dataclass
+class FrameLocalHeavyObject:
+    """Stand-in for a resource a domain generator holds only as a frame local (e.g. a deep-copied
+    world)."""
+
+    payload: bytes = field(default_factory=lambda: bytes(2048))
+
+
+@dataclass
+class FrameBuildingLazyDomain:
+    """A domain whose ``__iter__`` builds a heavy object as a frame local and yields values that do
+    not reference it, mirroring a location generator that deep-copies the world only to validate
+    candidates."""
+
+    value_count: int
+    built_object_references: List[weakref.ReferenceType] = field(default_factory=list)
+    """Weak references to every heavy object built, so tests can observe their collection."""
+
+    def __iter__(self) -> Iterator[int]:
+        heavy_object = FrameLocalHeavyObject()
+        self.built_object_references.append(weakref.ref(heavy_object))
+        for value in range(self.value_count):
+            yield value
+
+
+def test_retained_variable_releases_partially_consumed_domain_frame():
+    """A retained variable whose domain was only partially consumed must not keep the domain
+    generator's frame (and its heavy local) alive."""
+    domain = FrameBuildingLazyDomain(value_count=5)
+    query = an(entity(variable(int, domain)))
+
+    first_value = query.first()
+    assert first_value == 0
+
+    del first_value
+    gc.collect()
+
+    assert domain.built_object_references[0]() is None
+
+
+def test_re_enterable_lazy_iterable_replays_after_source_release():
+    """Releasing the underlying source must not truncate results: re-iterating still yields the full
+    domain."""
+    lazy_iterable = ReEnterableLazyIterable()
+    lazy_iterable.set_iterable([0, 1, 2, 3])
+
+    partial = []
+    for value in lazy_iterable:
+        partial.append(value)
+        if len(partial) == 2:
+            break
+    assert partial == [0, 1]
+
+    gc.collect()
+
+    assert list(lazy_iterable) == [0, 1, 2, 3]
+    assert list(lazy_iterable) == [0, 1, 2, 3]


### PR DESCRIPTION
Releases the underspecified-action grounding iterator once grounding succeeds, closing a world-entity leak. Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/42