### PR TITLE
Keep a shared node's primary parent stable across the DAG

### DIFF
--- a/krrood/src/krrood/entity_query_language/core/base_expressions.py
+++ b/krrood/src/krrood/entity_query_language/core/base_expressions.py
@@ -196,11 +196,17 @@ class SymbolicExpression(ABC):
         """
         Remove the parent relationship between this expression and the given parent expression.
 
+        When the removed parent is the primary one, another remaining parent is promoted so a node
+        that still lives elsewhere in the DAG keeps a valid primary parent.
+
         :param parent: The parent expression to remove.
         """
-        self._parents_.remove(parent)
+        if parent in self._parents_:
+            self._parents_.remove(parent)
+        if self._id_ in [child._id_ for child in parent._children_]:
+            parent._children_.remove(self)
         if parent is self._parent__:
-            self._parent_ = None
+            self._parent__ = self._parents_[-1] if self._parents_ else None
 
     def _update_children_(
             self, *children: SymbolicExpression
@@ -353,20 +359,24 @@ class SymbolicExpression(ABC):
         if value is self:
             return
 
-        if value is None and self._parent__ is not None:
-            if self._id_ in [v._id_ for v in self._parent__._children_]:
-                self._parent__._children_.remove(self)
-            if self._parent__ in self._parents_:
-                self._parents_.remove(self._parent__)
+        if value is None:
+            if self._parent__ is not None:
+                self._remove_parent_(self._parent__)
+            return
 
-        self._parent__ = value
-
-        if value is not None and value._id_ not in [v._id_ for v in self._parents_]:
+        if value._id_ not in [v._id_ for v in self._parents_]:
             self._parents_.append(value)
             value._ensure_children_ids_are_cached_(self)
 
-        if value is not None and self._id_ not in [v._id_ for v in value._children_]:
+        if self._id_ not in [v._id_ for v in value._children_]:
             value._children_.append(self)
+
+        # Keep the first structural parent as the primary one: a node reused as an operand
+        # elsewhere in the DAG records the extra parent above but must not have its primary
+        # parent hijacked. Structural re-parenting removes the old parent first (see
+        # ``_replace_child_``), so the promotion in ``_remove_parent_`` re-establishes the primary.
+        if self._parent__ is None:
+            self._parent__ = value
 
     @property
     def _conditions_root_(self) -> Optional[SymbolicExpression]:

--- a/test/krrood_test/test_eql/test_core/test_rules.py
+++ b/test/krrood_test/test_eql/test_core/test_rules.py
@@ -516,9 +516,10 @@ def test_rule_tree_anchors_when_where_condition_is_reused_in_a_sibling():
     """A node used as the bare WHERE condition and reused inside a sibling branch must still anchor.
 
     ``drawer.correct`` is a shared node: it is the WHERE condition and also appears in the
-    ``alternative`` condition ``drawer.correct == False``. Building that comparator reassigns the
-    shared node's single ``_parent_`` pointer, so structural navigation that trusts ``_parent_``
-    loses the anchor. The rule tree must locate the anchor from the full parent structure instead.
+    ``alternative`` condition ``drawer.correct == False``. Building that comparator adds it as an
+    extra parent of the shared node. Its primary ``_parent_`` must stay the structural (WHERE)
+    parent so rule-tree splicing still finds the anchor; when the reuse overwrote ``_parent_``
+    the splice navigated from the comparator instead and failed.
     """
     correct_drawer = Drawer(
         handle=Handle("Handle1"), container=Container("Container1"), correct=True

--- a/test/krrood_test/test_eql/test_core/test_rules.py
+++ b/test/krrood_test/test_eql/test_core/test_rules.py
@@ -510,3 +510,36 @@ def test_doc_example(rule_tree_doc_example_connections, alternative_code, result
     results = query.tolist()
     assert len(results) == len(result_set)
     assert set(results) == result_set
+
+
+def test_rule_tree_anchors_when_where_condition_is_reused_in_a_sibling():
+    """A node used as the bare WHERE condition and reused inside a sibling branch must still anchor.
+
+    ``drawer.correct`` is a shared node: it is the WHERE condition and also appears in the
+    ``alternative`` condition ``drawer.correct == False``. Building that comparator reassigns the
+    shared node's single ``_parent_`` pointer, so structural navigation that trusts ``_parent_``
+    loses the anchor. The rule tree must locate the anchor from the full parent structure instead.
+    """
+    correct_drawer = Drawer(
+        handle=Handle("Handle1"), container=Container("Container1"), correct=True
+    )
+    incorrect_drawer = Drawer(
+        handle=Handle("Handle2"), container=Container("Container2"), correct=False
+    )
+    drawer = variable(Drawer, domain=[correct_drawer, incorrect_drawer])
+    views = deduced_variable(View)
+    query = an(entity(views).where(drawer.correct))
+
+    with query:
+        add(views, inference(Door)(handle=drawer.handle, body=drawer.container))
+        with alternative(drawer.correct == False):
+            add(views, inference(Door)(handle=drawer.handle, body=drawer.container))
+
+    all_solutions = list(query.evaluate())
+    assert (
+        len(all_solutions) == 2
+    ), "The base branch and its reused-condition alternative must both fire."
+    assert {(door.handle.name, door.body.name) for door in all_solutions} == {
+        ("Handle1", "Container1"),
+        ("Handle2", "Container2"),
+    }


### PR DESCRIPTION
Fixes a DAG parent-pointer bug: reusing an expression node (e.g. drawer.correct in two branches) clobbered its structural rule-tree parent, causing AttributeError: 'NoneType' object has no attribute '_replace_child_' during rule-tree construction. Fix: the primary parent is now the first structural parent, kept stable, while the full DAG is still recorded. New regression test added; full test_eql suite passes (948 passed, 3 skipped).

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/47