### PR TITLE
Fix redundant recompute and warning spam in circular-import type-hint…

### DIFF
--- a/krrood/src/krrood/class_diagrams/utils.py
+++ b/krrood/src/krrood/class_diagrams/utils.py
@@ -311,11 +311,53 @@ def _cached_scope_from_imports(source_path: str) -> Dict[str, Any]:
     return _scope_from_imports_by_mtime(source_path, mtime)
 
 
+def _count_of_modules_that_finished_initializing() -> int:
+    """
+    Count the modules in ``sys.modules`` that have finished executing.
+
+    This only grows as modules complete loading, so two calls returning the same value guarantee
+    that nothing relevant to an in-progress circular import could have changed in between.
+
+    :return: The current count of fully initialized modules in ``sys.modules``.
+    """
+    return sum(
+        1
+        for module in tuple(sys.modules.values())
+        if not getattr(getattr(module, "__spec__", None), "_initializing", False)
+    )
+
+
+@lru_cache(maxsize=None)
+def _fallback_scope_for_import_generation(
+    source_path: str, generation: int
+) -> Dict[str, Any]:
+    """
+    Recompute *source_path*'s import scope from scratch, memoized per import-system generation.
+
+    A ``TYPE_CHECKING`` name whose module is still mid-import fails identically on every retry
+    until that module finishes loading. Keying this on *generation*
+    (:func:`_count_of_modules_that_finished_initializing`) means the expensive, uncached
+    :func:`~krrood.utils.get_scope_from_imports` recompute only actually runs again once something
+    has genuinely changed, instead of once per failed lookup: many dataclasses across a codebase can
+    independently need the same still-unavailable name while a dependency is mid-import, and without
+    this every one of those lookups would re-parse the file and re-import everything it references.
+
+    :param source_path: The file whose import scope is recomputed.
+    :param generation: The import-system generation the recompute is valid for.
+    :return: The freshly computed import scope for *source_path*.
+    """
+    return get_scope_from_imports(file_path=source_path)
+
+
 def get_object_by_name_from_another_object_in_same_module(
     name: str, object_: Any
 ) -> Any:
     """
     Get the object with the given name from another object in the same module.
+
+    If the cached import scope for the object's module was built while a dependency was still
+    partially initialized (a circular import during module load), the recovered names are merged
+    back into that cached scope so later lookups do not repeat the uncached recomputation.
 
     :param name: The name of the type to get.
     :param object_: The object to get the type from.
@@ -338,9 +380,15 @@ def get_object_by_name_from_another_object_in_same_module(
     # The cached scope can be incomplete if it was first built while a dependency was only partially
     # initialized (a circular import during module load), which makes a TYPE_CHECKING import such as
     # ``World`` silently unresolvable and that absence gets cached. Recompute the scope without the
-    # cache now that imports may have completed before giving up.
-    fresh_scope = get_scope_from_imports(file_path=source_path)
+    # long-lived cache now that imports may have completed before giving up, but memoized per import
+    # generation so many lookups failing for the same reason at the same moment share one recompute
+    # instead of each re-parsing and re-importing the file from scratch. Merge the recovered names
+    # into the memoized scope so later lookups reuse them instead of repeating this forever.
+    fresh_scope = _fallback_scope_for_import_generation(
+        source_path, _count_of_modules_that_finished_initializing()
+    )
     if name in fresh_scope:
+        scope.update(fresh_scope)
         return fresh_scope[name]
     raise CouldNotResolveType(
         name,

--- a/krrood/src/krrood/utils.py
+++ b/krrood/src/krrood/utils.py
@@ -828,6 +828,31 @@ def _handle_import_node(
         scope[asname] = module
 
 
+@lru_cache(maxsize=None)
+def _warn_about_unresolvable_type_checking_import_once(
+    resolved_module_name: Optional[str], name: str, file_path: Optional[str], error_message: str
+) -> None:
+    """
+    Log, at most once per process for a given ``(resolved_module_name, name, file_path)`` triple,
+    that a name could not be imported while extracting a file's imports.
+
+    A dataclass field annotated under ``if TYPE_CHECKING:`` with a name from a module involved in a
+    circular import can be re-resolved many times while that module is still initializing (once per
+    class needing it, and once per lookup attempt). Every attempt raises the exact same, already
+    self-diagnosing ``AttributeError`` and is otherwise harmless, so repeating the warning for each
+    attempt only floods the log without adding information; the ``lru_cache`` collapses repeats of
+    the identical triple to a single log line.
+
+    :param resolved_module_name: The module the failed import targeted.
+    :param name: The attribute name that could not be found on the module.
+    :param file_path: The path of the file whose imports were being extracted.
+    :param error_message: The message of the ``AttributeError`` that was raised.
+    """
+    logger.warning(
+        f"Could not import {resolved_module_name}: {error_message} while extracting imports from {file_path}"
+    )
+
+
 def _handle_import_from_node(
     node: ast.ImportFrom,
     scope: Dict[str, Any],
@@ -875,8 +900,8 @@ def _handle_import_from_node(
             else:
                 scope[asname] = getattr(module, name)
         except AttributeError as e:
-            logger.warning(
-                f"Could not import {resolved_module_name}: {e} while extracting imports from {file_path}"
+            _warn_about_unresolvable_type_checking_import_once(
+                resolved_module_name, name, file_path, str(e)
             )
 
     return package_name

--- a/test/krrood_test/dataset/latebound_annotation_owner.py
+++ b/test/krrood_test/dataset/latebound_annotation_owner.py
@@ -6,10 +6,12 @@ from typing_extensions import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .latebound_annotation_type import LateBoundAnnotationType
+    from .latebound_annotation_secondary_type import LateBoundAnnotationSecondaryType
 
 
 @dataclass
 class OwnerWithLateBoundAnnotation:
-    """A dataclass annotated with a ``TYPE_CHECKING``-only type from another module."""
+    """A dataclass annotated with ``TYPE_CHECKING``-only types from other modules."""
 
     value: Optional[LateBoundAnnotationType] = field(default=None)
+    secondary_value: Optional[LateBoundAnnotationSecondaryType] = field(default=None)

--- a/test/krrood_test/dataset/latebound_annotation_secondary_type.py
+++ b/test/krrood_test/dataset/latebound_annotation_secondary_type.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LateBoundAnnotationSecondaryType:
+    """A second field type imported only under ``TYPE_CHECKING`` by the same owner module.
+
+    Paired with :class:`~test.krrood_test.dataset.latebound_annotation_type.LateBoundAnnotationType`
+    to mimic a single module with more than one ``TYPE_CHECKING``-only annotation poisoned by the
+    same circular-import event, such as ``world_entity.py``'s ``World`` and
+    ``GenericSemanticAnnotation`` references.
+    """
+
+    label: str = ""

--- a/test/krrood_test/test_class_diagram/test_partial_init_scope_recovery.py
+++ b/test/krrood_test/test_class_diagram/test_partial_init_scope_recovery.py
@@ -5,9 +5,11 @@ import types
 from typing_extensions import Optional
 
 from krrood.class_diagrams import utils as class_diagram_utils
+from krrood.class_diagrams.exceptions import CouldNotResolveType
 from krrood.class_diagrams.utils import get_type_hints_of_object
 
 from ..dataset.latebound_annotation_type import LateBoundAnnotationType
+from ..dataset.latebound_annotation_secondary_type import LateBoundAnnotationSecondaryType
 from ..dataset.latebound_annotation_owner import OwnerWithLateBoundAnnotation
 
 
@@ -45,3 +47,169 @@ def test_type_resolution_recovers_when_scope_cache_poisoned_during_partial_init(
     resolved_type_hints = get_type_hints_of_object(OwnerWithLateBoundAnnotation)
 
     assert resolved_type_hints["value"] == Optional[LateBoundAnnotationType]
+
+
+def test_recovered_scope_is_healed_and_not_rebuilt_on_every_lookup(monkeypatch):
+    """Once a ``TYPE_CHECKING``-only name recovers from a circular-import cache-poisoning event,
+    later lookups of that same name must reuse the recovered scope instead of repeating the
+    expensive, uncached AST walk and real-import fallback on every single call.
+
+    This reproduces what happens when ``semantic_digital_twin.world`` is imported: dozens of
+    dataclass fields across the codebase reference ``World``/``GenericSemanticAnnotation`` under
+    ``TYPE_CHECKING``, and the very first scope build for their owning module happens while
+    ``world`` is still mid-import (a legitimate, unavoidable circular reference). The permanent
+    ``lru_cache`` entry never gets corrected once ``world`` finishes loading, so every one of those
+    fields falls back to :func:`~krrood.utils.get_scope_from_imports` again, uncached, re-parsing
+    and re-importing the whole file from scratch thousands of times over process startup.
+    """
+    owner_source = inspect.getsourcefile(OwnerWithLateBoundAnnotation)
+    provider_module = "test.krrood_test.dataset.latebound_annotation_type"
+
+    class_diagram_utils._scope_from_imports_by_mtime.cache_clear()
+    class_diagram_utils._fallback_scope_for_import_generation.cache_clear()
+    saved_module = sys.modules.pop(provider_module, None)
+    sys.modules[provider_module] = types.ModuleType(provider_module)
+    try:
+        poisoned_scope = class_diagram_utils._cached_scope_from_imports(owner_source)
+        assert "LateBoundAnnotationType" not in poisoned_scope
+    finally:
+        if saved_module is not None:
+            sys.modules[provider_module] = saved_module
+        else:
+            sys.modules.pop(provider_module, None)
+
+    call_count = 0
+    original_get_scope_from_imports = class_diagram_utils.get_scope_from_imports
+
+    def counting_get_scope_from_imports(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_get_scope_from_imports(*args, **kwargs)
+
+    monkeypatch.setattr(
+        class_diagram_utils, "get_scope_from_imports", counting_get_scope_from_imports
+    )
+
+    for _ in range(5):
+        resolved = class_diagram_utils.get_object_by_name_from_another_object_in_same_module(
+            "LateBoundAnnotationType", OwnerWithLateBoundAnnotation
+        )
+        assert resolved is LateBoundAnnotationType
+
+    assert call_count == 1
+
+
+def test_recovering_one_poisoned_name_heals_other_poisoned_names_in_same_scope():
+    """Recovering one ``TYPE_CHECKING``-only name must heal every other name poisoned by the same
+    circular-import event in that module's cached scope, not just the one that was looked up.
+
+    ``world_entity.py`` has both ``World`` and ``GenericSemanticAnnotation`` poisoned together by the
+    same partially initialised ``world`` module. Fixing only the queried name would leave the other
+    one paying the same uncached-recompute cost on its own first lookup.
+    """
+    owner_source = inspect.getsourcefile(OwnerWithLateBoundAnnotation)
+    primary_provider = "test.krrood_test.dataset.latebound_annotation_type"
+    secondary_provider = "test.krrood_test.dataset.latebound_annotation_secondary_type"
+
+    class_diagram_utils._scope_from_imports_by_mtime.cache_clear()
+    class_diagram_utils._fallback_scope_for_import_generation.cache_clear()
+    saved_primary = sys.modules.pop(primary_provider, None)
+    saved_secondary = sys.modules.pop(secondary_provider, None)
+    sys.modules[primary_provider] = types.ModuleType(primary_provider)
+    sys.modules[secondary_provider] = types.ModuleType(secondary_provider)
+    try:
+        poisoned_scope = class_diagram_utils._cached_scope_from_imports(owner_source)
+        assert "LateBoundAnnotationType" not in poisoned_scope
+        assert "LateBoundAnnotationSecondaryType" not in poisoned_scope
+    finally:
+        for provider, saved in (
+            (primary_provider, saved_primary),
+            (secondary_provider, saved_secondary),
+        ):
+            if saved is not None:
+                sys.modules[provider] = saved
+            else:
+                sys.modules.pop(provider, None)
+
+    resolved = class_diagram_utils.get_object_by_name_from_another_object_in_same_module(
+        "LateBoundAnnotationType", OwnerWithLateBoundAnnotation
+    )
+    assert resolved is LateBoundAnnotationType
+
+    healed_scope = class_diagram_utils._cached_scope_from_imports(owner_source)
+    assert healed_scope["LateBoundAnnotationSecondaryType"] is LateBoundAnnotationSecondaryType
+
+
+def test_fallback_recompute_is_shared_across_lookups_within_the_same_import_generation(
+    monkeypatch,
+):
+    """While a dependency stays mid-import (an unchanged "import generation"), repeated failed
+    lookups of the same poisoned name must share a single uncached recompute instead of each
+    re-parsing and re-importing the file from scratch.
+
+    This is the case the healing fix (see
+    ``test_recovered_scope_is_healed_and_not_rebuilt_on_every_lookup``) cannot cover: many classes
+    across a codebase needing a name from a module that is *still* mid-import (never resolves
+    during the window being measured). Reproduced live: importing ``semantic_digital_twin.world``
+    triggers 2154 uncached recomputes of just 8 files (805 alone for a single file), accounting for
+    most of an 8.8s import. Only once the import generation actually advances should a fresh
+    recompute run again.
+    """
+    owner_source = inspect.getsourcefile(OwnerWithLateBoundAnnotation)
+    provider_module = "test.krrood_test.dataset.latebound_annotation_type"
+
+    class_diagram_utils._scope_from_imports_by_mtime.cache_clear()
+    class_diagram_utils._fallback_scope_for_import_generation.cache_clear()
+    saved_module = sys.modules.pop(provider_module, None)
+    sys.modules[provider_module] = types.ModuleType(provider_module)
+    try:
+        poisoned_scope = class_diagram_utils._cached_scope_from_imports(owner_source)
+        assert "LateBoundAnnotationType" not in poisoned_scope
+
+        call_count = 0
+        original_get_scope_from_imports = class_diagram_utils.get_scope_from_imports
+
+        def counting_get_scope_from_imports(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original_get_scope_from_imports(*args, **kwargs)
+
+        monkeypatch.setattr(
+            class_diagram_utils, "get_scope_from_imports", counting_get_scope_from_imports
+        )
+        monkeypatch.setattr(
+            class_diagram_utils, "_count_of_modules_that_finished_initializing", lambda: 100
+        )
+
+        # The provider module stays poisoned for every one of these lookups: each must fail, but
+        # they all share the same import generation, so only the first should actually recompute.
+        for _ in range(5):
+            try:
+                class_diagram_utils.get_object_by_name_from_another_object_in_same_module(
+                    "LateBoundAnnotationType", OwnerWithLateBoundAnnotation
+                )
+                assert False, "resolution should still fail while the provider stays poisoned"
+            except CouldNotResolveType:
+                pass
+
+        assert call_count == 1
+
+        # Advancing the generation (something elsewhere finished initializing) makes it worth
+        # trying again, even though this particular lookup still fails.
+        monkeypatch.setattr(
+            class_diagram_utils, "_count_of_modules_that_finished_initializing", lambda: 101
+        )
+        try:
+            class_diagram_utils.get_object_by_name_from_another_object_in_same_module(
+                "LateBoundAnnotationType", OwnerWithLateBoundAnnotation
+            )
+            assert False, "resolution should still fail while the provider stays poisoned"
+        except CouldNotResolveType:
+            pass
+
+        assert call_count == 2
+    finally:
+        if saved_module is not None:
+            sys.modules[provider_module] = saved_module
+        else:
+            sys.modules.pop(provider_module, None)

--- a/test/krrood_test/test_utils/test_get_type_checking_imports.py
+++ b/test/krrood_test/test_utils/test_get_type_checking_imports.py
@@ -1,8 +1,10 @@
 import os
+import types
 from pathlib import Path
 from collections import defaultdict
 import sys
-from krrood.utils import get_scope_from_imports
+import krrood.utils as krrood_utils
+from krrood.utils import get_scope_from_imports, _warn_about_unresolvable_type_checking_import_once
 
 
 def test_get_type_checking_imports(tmp_path):
@@ -59,3 +61,45 @@ if TYPE_CHECKING:
 
     scope = get_scope_from_imports(str(test_file))
     assert scope["json"] == json
+
+
+def test_repeated_unresolvable_type_checking_import_warns_only_once(tmp_path, monkeypatch):
+    """A ``TYPE_CHECKING`` import that keeps failing because its module is still partially
+    initialized (an active circular import) must not flood the log: the same
+    ``(module, name, file)`` failure repeats identically on every attempt, so only the first one
+    should be logged.
+
+    This reproduces what happens when many dataclasses across a codebase each need to resolve the
+    same ``TYPE_CHECKING``-only name from a module still mid-import: every one of those attempts
+    raises an identical, already self-diagnosing ``AttributeError`` and previously logged its own
+    warning, flooding the log with thousands of duplicate lines for a single, known-transient cause.
+    """
+    _warn_about_unresolvable_type_checking_import_once.cache_clear()
+    provider_module = "test.krrood_test.dataset.latebound_annotation_type"
+
+    warning_calls = []
+    monkeypatch.setattr(
+        krrood_utils.logger, "warning", lambda message: warning_calls.append(message)
+    )
+
+    source = f"""
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from {provider_module} import LateBoundAnnotationType
+"""
+    test_file = tmp_path / "test_repeated_poisoned_import.py"
+    test_file.write_text(source)
+
+    saved_module = sys.modules.pop(provider_module, None)
+    sys.modules[provider_module] = types.ModuleType(provider_module)
+    try:
+        for _ in range(5):
+            scope = get_scope_from_imports(str(test_file))
+            assert "LateBoundAnnotationType" not in scope
+    finally:
+        if saved_module is not None:
+            sys.modules[provider_module] = saved_module
+        else:
+            sys.modules.pop(provider_module, None)
+
+    assert len(warning_calls) == 1


### PR DESCRIPTION
## Summary

  Fixes a set of related bugs in krrood's static import-scope resolution (used to resolve `TYPE_CHECKING`-only forward references for dataclass type hints) that caused `import
  semantic_digital_twin.world` to log **4320 warning lines** and take **8.78s**, most of it wasted on redundant work.

  ### Root cause

  `world.py` imports `world_entity.py` unconditionally; `world_entity.py` imports `World`/`GenericSemanticAnnotation` back only under `if TYPE_CHECKING:` — the standard, correct way to break
  a circular dependency. krrood's `get_scope_from_imports` deliberately performs *real* imports into `TYPE_CHECKING` blocks to resolve these forward references for dataclass field type
  hints. When this fires reentrantly while `world.py` is itself still mid-import, it correctly detects a partially-initialized module — but three separate bugs in how that condition was
  handled caused massive redundant work and log spam.

  ### Fixes (each landed with a failing test first, TDD)

  1. **Cache never healed on successful recovery** (`krrood/class_diagrams/utils.py`)
     `get_object_by_name_from_another_object_in_same_module` had a fallback that recomputed the import scope, uncached, when the cached scope was poisoned by a circular import. On success it
  never wrote the result back, so every later lookup of the same name re-paid the full cost forever. Now the recovered scope is merged back into the memoized cache in place.

  2. **Warning spam** (`krrood/utils.py`)
     The same self-diagnosing, harmless `AttributeError` ("partially initialized module ... most likely due to a circular import") was logged on every single occurrence — once per class
  needing the name, per lookup attempt. Added `_warn_about_unresolvable_type_checking_import_once`, an `lru_cache`-backed log call keyed on `(module, name, file)`, so each distinct failure
  is logged exactly once per process.

  3. **Redundant recompute while genuinely still blocked** (`krrood/class_diagrams/utils.py`)
     Even when recovery legitimately couldn't succeed yet (the dependency truly hadn't finished initializing), every failed lookup re-parsed the whole file and re-imported every module it
  references from scratch. Added `_fallback_scope_for_import_generation`, memoized by a cheap, monotonically increasing "count of modules that finished initializing in `sys.modules`" — the
  expensive recompute now only actually runs again once something has genuinely c Jump to bottom (ctrl+End) ↓ ailed lookup.

### Impact

  | | Before | After |
  |---|---|---|
  | `import semantic_digital_twin.world` time | 8.78s | 2.23s |
  | Warning lines logged | 4320 | 12 (one per genuinely distinct module/attribute/file combination) |

  ### Testing

  - New/updated tests in `test/krrood_test/test_class_diagram/test_partial_init_scope_recovery.py` and `test/krrood_test/test_utils/test_get_type_checking_imports.py`, each proven red→green
  by reverting the corresponding fix and confirming the test fails.
  - Two small dataset additions reused for these tests: `latebound_annotation_secondary_type.py` and an extra field on `latebound_annotation_owner.py`, following the existing mimic-class
  conventions (no dependency on `semantic_digital_twin`).
  - Full krrood suite: 290 tests passing (`test_class_diagram`, `test_utils`, `test_ormatic`, `test_patterns`).
  - Full `semantic_digital_twin` suite: 769 passed / 1 failed / 1 error / 7 skipped / 1 xfailed — the single failure/error is a pre-existing, unrelated environment gap (missing
  `iai_dlr_rollin_justin` ROS package on this machine), reproducible independent of this change.
  - Manually verified `World`, `WorldEntity`, and their type hints still resolve to the real classes (not placeholders) after the fix.

  ### Files changed

  - `krrood/src/krrood/utils.py`
  - `krrood/src/krrood/class_diagrams/utils.py`
  - `test/krrood_test/test_utils/test_get_type_checking_imports.py`
  - `test/krrood_test/test_class_diagram/test_partial_init_scope_recovery.py`
  - `test/krrood_test/dataset/latebound_annotation_owner.py`
  - `test/krrood_test/dataset/latebound_annotation_secondary_type.py` (new)