### PR TITLE
Resolve conditions-root ambiguity via evaluation-scoped state, not attachment order

### DIFF
--- a/krrood/src/krrood/entity_query_language/core/base_expressions.py
+++ b/krrood/src/krrood/entity_query_language/core/base_expressions.py
@@ -316,22 +316,29 @@ class SymbolicExpression(ABC):
         # True. "Active" is an evaluation-scoped fact, not a structural one: a node reused as the
         # condition of more than one Filter has no single correct root, so this is resolved by
         # which evaluation is currently running (see ActiveConditionsRoot), not by the node's
-        # construction history.
+        # construction history. When no evaluation context is active (this method is only ever
+        # reached from inside _evaluate_'s own thread, but a caller may drive evaluation from a
+        # thread that never had one set up — contextvars.ContextVar values do not propagate into a
+        # plain threading.Thread), fall back to the structural check: it is the only signal left.
         evaluation_context = get_evaluation_context()
-        if (
-            not evaluation_context.active_conditions_root.is_active_root(self)
-            or current_result.is_false
-        ):
+        if evaluation_context is not None:
+            is_active_root = evaluation_context.active_conditions_root.is_active_root(
+                self
+            )
+        else:
+            is_active_root = self._conditions_root_ is self
+        if not is_active_root or current_result.is_false:
             return current_result
         for conclusion in self._conclusions_:
             current_result.bindings = next(
                 conclusion._evaluate_(current_result)
             ).bindings
 
-        evaluation_context.on_conclusions_processed(
-            expression=self,
-            result=current_result,
-        )
+        if evaluation_context is not None:
+            evaluation_context.on_conclusions_processed(
+                expression=self,
+                result=current_result,
+            )
         return current_result
 
     @abstractmethod

--- a/krrood/src/krrood/entity_query_language/core/base_expressions.py
+++ b/krrood/src/krrood/entity_query_language/core/base_expressions.py
@@ -277,6 +277,7 @@ class SymbolicExpression(ABC):
 
             evaluation_context = create_default_evaluation_context()
             context_token = set_evaluation_context(evaluation_context)
+            evaluation_context.active_conditions_root.claim(self._conditions_root_)
         try:
             evaluation_context.on_evaluate_enter(expression=self, sources=sources)
             # Normalize sources: always work with an OperationResult
@@ -310,21 +311,27 @@ class SymbolicExpression(ABC):
 
         :param current_result: The current result of this expression.
         """
-        # Only evaluate the conclusions at the root condition expression (i.e. after all conditions have been evaluated)
-        # and when the result truth value is True.
-        if not (self._conditions_root_ is self) or current_result.is_false:
+        # Only evaluate the conclusions at the active conditions root of the current evaluation
+        # pass (i.e. after all conditions have been evaluated) and when the result truth value is
+        # True. "Active" is an evaluation-scoped fact, not a structural one: a node reused as the
+        # condition of more than one Filter has no single correct root, so this is resolved by
+        # which evaluation is currently running (see ActiveConditionsRoot), not by the node's
+        # construction history.
+        evaluation_context = get_evaluation_context()
+        if (
+            not evaluation_context.active_conditions_root.is_active_root(self)
+            or current_result.is_false
+        ):
             return current_result
         for conclusion in self._conclusions_:
             current_result.bindings = next(
                 conclusion._evaluate_(current_result)
             ).bindings
 
-        evaluation_context = get_evaluation_context()
-        if evaluation_context is not None:
-            evaluation_context.on_conclusions_processed(
-                expression=self,
-                result=current_result,
-            )
+        evaluation_context.on_conclusions_processed(
+            expression=self,
+            result=current_result,
+        )
         return current_result
 
     @abstractmethod

--- a/krrood/src/krrood/entity_query_language/enums.py
+++ b/krrood/src/krrood/entity_query_language/enums.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum, auto, StrEnum
+from enum import Enum, auto
 
 
 class InferMode(Enum):
@@ -53,30 +53,4 @@ class DomainSource(Enum):
     GROUPING = auto()
     """
     Derived from grouping operations.
-    """
-
-
-class EvaluationContextKey(StrEnum):
-    """
-    Enumeration of keys used in the evaluation context's data dictionary.
-    """
-
-    SATISFIED_IDS_KEY = "satisfied_condition_ids"
-    """
-    A reserved key in the evaluation context's data dictionary for tracking the set of satisfied condition expression IDs
-    during the current evaluation iteration.
-    """
-
-    EVALUATED_IDS_KEY = "evaluated_expression_ids"
-    """
-    A reserved key in the evaluation context's data dictionary for tracking the cumulative set of all expression IDs
-    evaluated so far during the current evaluation.
-    """
-
-    EVALUATED_SNAPSHOT_KEY = "evaluated_expression_ids_snapshot"
-    """
-    A reserved key caching the most recent immutable snapshot of the evaluated-id set as a
-    ``(length, snapshot)`` pair. Because the evaluated-id set only grows, its length is a valid
-    version key: results yielded while the set has a given length share one snapshot instead of
-    each copying the whole set.
     """

--- a/krrood/src/krrood/entity_query_language/evaluation.py
+++ b/krrood/src/krrood/entity_query_language/evaluation.py
@@ -99,13 +99,13 @@ class SatisfiedConditionTracker(EvaluationObserver):
         if isinstance(sources, OperationResult):
             satisfied = sources.satisfied_condition_ids
         if satisfied is not None:
-            evaluation_context.satisfied_condition_ids.set(satisfied)
+            evaluation_context.satisfied_condition_ids = satisfied
 
     def on_result_yielded(self, expression, result):
         evaluation_context = get_evaluation_context()
         if evaluation_context is None:
             return
-        satisfied = evaluation_context.satisfied_condition_ids.get()
+        satisfied = evaluation_context.satisfied_condition_ids
         if satisfied is not None and result.satisfied_condition_ids is None:
             result.satisfied_condition_ids = satisfied
 
@@ -150,7 +150,7 @@ class SatisfiedConditionTracker(EvaluationObserver):
                     satisfied.add(expr_id)
 
         result.satisfied_condition_ids = satisfied
-        evaluation_context.satisfied_condition_ids.set(satisfied)
+        evaluation_context.satisfied_condition_ids = satisfied
 
 
 class InferenceRecorder(EvaluationObserver):

--- a/krrood/src/krrood/entity_query_language/evaluation.py
+++ b/krrood/src/krrood/entity_query_language/evaluation.py
@@ -16,7 +16,6 @@ from krrood.entity_query_language.core.base_expressions import (
     TruthValueOperator,
 )
 from krrood.entity_query_language.core.variable import InstantiatedVariable
-from krrood.entity_query_language.enums import EvaluationContextKey
 from krrood.entity_query_language.evaluation_context import (
     EvaluationContext,
     EvaluationObserver,
@@ -67,51 +66,21 @@ class EvaluationTracker(EvaluationObserver):
         evaluation_context = get_evaluation_context()
         if evaluation_context is None:
             return
-        evaluated = evaluation_context.data.setdefault(
-            EvaluationContextKey.EVALUATED_IDS_KEY, OrderedSet()
-        )
-        evaluated.add(expression._id_)
+        evaluation_context.evaluated_expression_ids.record(expression._id_)
 
         if isinstance(sources, OperationResult) and sources.evaluated_expression_ids:
-            evaluated.update(sources.evaluated_expression_ids)
+            evaluation_context.evaluated_expression_ids.merge(
+                sources.evaluated_expression_ids
+            )
 
     def on_result_yielded(self, expression, result):
         evaluation_context = get_evaluation_context()
         if evaluation_context is None:
             return
-        evaluated = evaluation_context.data.get(EvaluationContextKey.EVALUATED_IDS_KEY)
-        if evaluated is not None and result.evaluated_expression_ids is None:
-            result.evaluated_expression_ids = self._snapshot_evaluated(
-                evaluation_context, evaluated
+        if result.evaluated_expression_ids is None:
+            result.evaluated_expression_ids = (
+                evaluation_context.evaluated_expression_ids.snapshot()
             )
-
-    @staticmethod
-    def _snapshot_evaluated(evaluation_context, evaluated):
-        """
-        Return an immutable snapshot of the cumulative *evaluated* id set, reusing the cached one
-        when the set has not grown since it was taken.
-
-        The evaluated-id set is only ever extended (never reduced), so its length uniquely
-        identifies its contents. Caching the snapshot keyed on that length collapses the previous
-        per-result copy (O(n) each, O(n^2) overall) into one copy per growth event. The returned
-        snapshot is shared between results and must be treated as read-only.
-
-        :param evaluation_context: The active evaluation context whose ``data`` holds the cache.
-        :param evaluated: The live cumulative :class:`OrderedSet` of evaluated expression ids.
-        :return: A snapshot :class:`OrderedSet` safe to stamp onto a result.
-        """
-        cached = evaluation_context.data.get(
-            EvaluationContextKey.EVALUATED_SNAPSHOT_KEY
-        )
-        current_length = len(evaluated)
-        if cached is None or cached[0] != current_length:
-            snapshot = OrderedSet(evaluated)
-            evaluation_context.data[EvaluationContextKey.EVALUATED_SNAPSHOT_KEY] = (
-                current_length,
-                snapshot,
-            )
-            return snapshot
-        return cached[1]
 
 
 class SatisfiedConditionTracker(EvaluationObserver):
@@ -130,33 +99,27 @@ class SatisfiedConditionTracker(EvaluationObserver):
         if isinstance(sources, OperationResult):
             satisfied = sources.satisfied_condition_ids
         if satisfied is not None:
-            evaluation_context.data[EvaluationContextKey.SATISFIED_IDS_KEY] = satisfied
+            evaluation_context.satisfied_condition_ids.set(satisfied)
 
     def on_result_yielded(self, expression, result):
         evaluation_context = get_evaluation_context()
         if evaluation_context is None:
             return
-        satisfied = evaluation_context.data.get(EvaluationContextKey.SATISFIED_IDS_KEY)
+        satisfied = evaluation_context.satisfied_condition_ids.get()
         if satisfied is not None and result.satisfied_condition_ids is None:
             result.satisfied_condition_ids = satisfied
 
     def on_conclusions_processed(self, expression, result):
-
-        if expression._conditions_root_ is not expression:
-            return
+        # The caller (_evaluate_conclusions_and_update_bindings_) already established that
+        # `expression` is the active conditions root for this evaluation pass before invoking
+        # this hook, so no re-check is needed here.
         if result.is_false:
             return
         if expression._conditions_root_ is expression._root_:
             return
 
         evaluation_context = get_evaluation_context()
-        evaluated = (
-            evaluation_context.data.get(EvaluationContextKey.EVALUATED_IDS_KEY)
-            if evaluation_context is not None
-            else None
-        )
-        if evaluated is None:
-            return
+        evaluated = evaluation_context.evaluated_expression_ids
 
         # Build a truth map from the OperationResult chain: operand_id -> is_false.
         # This reflects the actual truth values from this specific evaluation path,
@@ -187,8 +150,7 @@ class SatisfiedConditionTracker(EvaluationObserver):
                     satisfied.add(expr_id)
 
         result.satisfied_condition_ids = satisfied
-        if evaluation_context is not None:
-            evaluation_context.data[EvaluationContextKey.SATISFIED_IDS_KEY] = satisfied
+        evaluation_context.satisfied_condition_ids.set(satisfied)
 
 
 class InferenceRecorder(EvaluationObserver):

--- a/krrood/src/krrood/entity_query_language/evaluation_context.py
+++ b/krrood/src/krrood/entity_query_language/evaluation_context.py
@@ -133,22 +133,6 @@ class EvaluatedExpressionIds:
 
 
 @dataclass
-class SatisfiedConditionIds:
-    """Holds the set of satisfied condition-expression ids for the current evaluation iteration."""
-
-    _ids: Optional[OrderedSet] = field(default=None, init=False)
-    """The satisfied condition ids for the current iteration, or ``None`` if unset."""
-
-    def set(self, ids: OrderedSet) -> None:
-        """Record *ids* as the satisfied condition ids for the current iteration."""
-        self._ids = ids
-
-    def get(self) -> Optional[OrderedSet]:
-        """:return: The satisfied condition ids for the current iteration, or ``None`` if unset."""
-        return self._ids
-
-
-@dataclass
 class EvaluationContext:
     """Carries observer state through the evaluation pipeline."""
 
@@ -164,10 +148,8 @@ class EvaluationContext:
         default_factory=EvaluatedExpressionIds
     )
     """Tracks every expression id evaluated so far during the current evaluation pass."""
-    satisfied_condition_ids: SatisfiedConditionIds = field(
-        default_factory=SatisfiedConditionIds
-    )
-    """Holds the set of satisfied condition-expression ids for the current evaluation iteration."""
+    satisfied_condition_ids: Optional[OrderedSet] = field(default=None)
+    """The satisfied condition-expression ids for the current evaluation iteration, or ``None`` if unset."""
 
     def on_evaluate_enter(
         self,

--- a/krrood/src/krrood/entity_query_language/evaluation_context.py
+++ b/krrood/src/krrood/entity_query_language/evaluation_context.py
@@ -8,13 +8,13 @@ circular dependency chain it carries.
 
 from __future__ import annotations
 
+import uuid
 from abc import ABC
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 
-from typing_extensions import Any, Dict, List, Optional, TYPE_CHECKING
-
-from krrood.entity_query_language.enums import EvaluationContextKey
+from ordered_set import OrderedSet
+from typing_extensions import Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from krrood.entity_query_language.core.base_expressions import (
@@ -70,6 +70,85 @@ class EvaluationObserver(ABC):
 
 
 @dataclass
+class ActiveConditionsRoot:
+    """Tracks which node is the active conditions root for the current evaluation pass.
+
+    A node reused as the condition of more than one ``Filter`` has no single correct "root" —
+    the right answer depends on which evaluation is currently running, not on the node's
+    construction history. The first node to claim this during a pass wins; nested evaluations
+    within the same pass never reassign it.
+    """
+
+    _root_id: Optional[uuid.UUID] = field(default=None, init=False)
+    """Identifier of the claimed root, or ``None`` before any node has claimed one this pass."""
+
+    def claim(self, root: SymbolicExpression) -> None:
+        """Claim *root* as the active conditions root for this pass, if none is claimed yet.
+
+        :param root: The node to claim, normally ``self._conditions_root_`` of whichever
+            expression is starting a fresh (context-less) evaluation.
+        """
+        if self._root_id is None:
+            self._root_id = root._id_
+
+    def is_active_root(self, node: SymbolicExpression) -> bool:
+        """:return: ``True`` if *node* is the active conditions root for this pass."""
+        return self._root_id == node._id_
+
+
+@dataclass
+class EvaluatedExpressionIds:
+    """Tracks every expression id evaluated so far during the current evaluation pass.
+
+    Used to distinguish evaluated-from-skipped logical operators (for example, short-circuited
+    OR/AND branches) when building inference explanations.
+    """
+
+    _ids: OrderedSet = field(default_factory=OrderedSet, init=False)
+    """The expression ids recorded as evaluated so far this pass."""
+    _snapshot: Optional[Tuple[int, OrderedSet]] = field(default=None, init=False)
+    """Cached ``(length, snapshot)`` pair. The id set is append-only, so its length is a valid
+    version key: a snapshot taken while the set has a given length is reused instead of copying
+    the whole set again."""
+
+    def record(self, expression_id: uuid.UUID) -> None:
+        """Record *expression_id* as evaluated during the current pass."""
+        self._ids.add(expression_id)
+
+    def merge(self, other: OrderedSet) -> None:
+        """Merge *other* into the recorded ids (for example, ids evaluated by an earlier stage
+        of the same result chain)."""
+        self._ids.update(other)
+
+    def __iter__(self) -> Iterator[uuid.UUID]:
+        return iter(self._ids)
+
+    def snapshot(self) -> OrderedSet:
+        """:return: An immutable snapshot of the ids recorded so far, reusing the cached one
+        when the set has not grown since it was last taken."""
+        current_length = len(self._ids)
+        if self._snapshot is None or self._snapshot[0] != current_length:
+            self._snapshot = (current_length, OrderedSet(self._ids))
+        return self._snapshot[1]
+
+
+@dataclass
+class SatisfiedConditionIds:
+    """Holds the set of satisfied condition-expression ids for the current evaluation iteration."""
+
+    _ids: Optional[OrderedSet] = field(default=None, init=False)
+    """The satisfied condition ids for the current iteration, or ``None`` if unset."""
+
+    def set(self, ids: OrderedSet) -> None:
+        """Record *ids* as the satisfied condition ids for the current iteration."""
+        self._ids = ids
+
+    def get(self) -> Optional[OrderedSet]:
+        """:return: The satisfied condition ids for the current iteration, or ``None`` if unset."""
+        return self._ids
+
+
+@dataclass
 class EvaluationContext:
     """Carries observer state through the evaluation pipeline."""
 
@@ -77,12 +156,18 @@ class EvaluationContext:
     """
     List of observers to notify of evaluation events.
     """
-    data: Dict[EvaluationContextKey, Any] = field(default_factory=dict)
-    """
-    Arbitrary data storage for observers to share information across events during evaluation.
-    Observers should use well-known keys defined in :class:`~krrood.entity_query_language.enums.EvaluationContextKey`
-    to avoid collisions.
-    """
+    active_conditions_root: ActiveConditionsRoot = field(
+        default_factory=ActiveConditionsRoot
+    )
+    """Tracks which node is the active conditions root for the current evaluation pass."""
+    evaluated_expression_ids: EvaluatedExpressionIds = field(
+        default_factory=EvaluatedExpressionIds
+    )
+    """Tracks every expression id evaluated so far during the current evaluation pass."""
+    satisfied_condition_ids: SatisfiedConditionIds = field(
+        default_factory=SatisfiedConditionIds
+    )
+    """Holds the set of satisfied condition-expression ids for the current evaluation iteration."""
 
     def on_evaluate_enter(
         self,

--- a/test/krrood_test/test_eql/test_core/test_evaluation_context.py
+++ b/test/krrood_test/test_eql/test_core/test_evaluation_context.py
@@ -7,7 +7,6 @@ from ordered_set import OrderedSet
 from krrood.entity_query_language.evaluation_context import (
     ActiveConditionsRoot,
     EvaluatedExpressionIds,
-    SatisfiedConditionIds,
 )
 
 
@@ -93,14 +92,3 @@ def test_evaluated_expression_ids_snapshot_refreshes_after_growth():
 
     assert fresh_snapshot is not stale_snapshot
     assert len(fresh_snapshot) == 2
-
-
-def test_satisfied_condition_ids_defaults_to_none_until_set():
-    holder = SatisfiedConditionIds()
-
-    assert holder.get() is None
-
-    ids = OrderedSet([uuid.uuid4()])
-    holder.set(ids)
-
-    assert holder.get() is ids

--- a/test/krrood_test/test_eql/test_core/test_evaluation_context.py
+++ b/test/krrood_test/test_eql/test_core/test_evaluation_context.py
@@ -1,0 +1,106 @@
+"""Tests for the typed per-pass state collaborators on EvaluationContext."""
+
+import uuid
+
+from ordered_set import OrderedSet
+
+from krrood.entity_query_language.evaluation_context import (
+    ActiveConditionsRoot,
+    EvaluatedExpressionIds,
+    SatisfiedConditionIds,
+)
+
+
+class _NodeStub:
+    """Minimal stand-in for a SymbolicExpression: only ``_id_`` is needed by these collaborators."""
+
+    def __init__(self):
+        self._id_ = uuid.uuid4()
+
+
+def test_active_conditions_root_claims_first_node_and_ignores_later_claims():
+    tracking = ActiveConditionsRoot()
+    first = _NodeStub()
+    second = _NodeStub()
+
+    tracking.claim(first)
+    tracking.claim(second)
+
+    assert tracking.is_active_root(first)
+    assert not tracking.is_active_root(second)
+
+
+def test_active_conditions_root_resolves_by_claim_not_by_construction_order():
+    """The whole point of this class: whichever node claims the pass first is the active root,
+    regardless of any other node's structural/construction history."""
+    tracking = ActiveConditionsRoot()
+    node = _NodeStub()
+
+    assert not tracking.is_active_root(node), "unclaimed pass must not match any node"
+    tracking.claim(node)
+    assert tracking.is_active_root(node)
+
+
+def test_evaluated_expression_ids_records_and_iterates():
+    tracked = EvaluatedExpressionIds()
+    first, second = uuid.uuid4(), uuid.uuid4()
+
+    tracked.record(first)
+    tracked.record(second)
+
+    assert set(tracked) == {first, second}
+
+
+def test_evaluated_expression_ids_merges_ids_from_another_set():
+    tracked = EvaluatedExpressionIds()
+    tracked.record(uuid.uuid4())
+    other_ids = OrderedSet([uuid.uuid4(), uuid.uuid4()])
+
+    tracked.merge(other_ids)
+
+    assert other_ids.issubset(set(tracked))
+
+
+def test_evaluated_expression_ids_snapshot_reflects_recorded_ids():
+    tracked = EvaluatedExpressionIds()
+    first = uuid.uuid4()
+    tracked.record(first)
+
+    snapshot = tracked.snapshot()
+
+    assert set(snapshot) == {first}
+
+
+def test_evaluated_expression_ids_snapshot_is_reused_while_set_is_unchanged():
+    """The id set only grows, so its length is a valid version key: two snapshots taken
+    without an intervening record() share the same cached object."""
+    tracked = EvaluatedExpressionIds()
+    tracked.record(uuid.uuid4())
+
+    first_snapshot = tracked.snapshot()
+    second_snapshot = tracked.snapshot()
+
+    assert first_snapshot is second_snapshot
+
+
+def test_evaluated_expression_ids_snapshot_refreshes_after_growth():
+    tracked = EvaluatedExpressionIds()
+    tracked.record(uuid.uuid4())
+    stale_snapshot = tracked.snapshot()
+
+    tracked.record(uuid.uuid4())
+    fresh_snapshot = tracked.snapshot()
+
+    assert fresh_snapshot is not stale_snapshot
+    assert len(fresh_snapshot) == 2
+
+
+def test_satisfied_condition_ids_defaults_to_none_until_set():
+    holder = SatisfiedConditionIds()
+
+    assert holder.get() is None
+
+    ids = OrderedSet([uuid.uuid4()])
+    holder.set(ids)
+
+    assert holder.get() is ids

--- a/test/krrood_test/test_eql/test_core/test_rules.py
+++ b/test/krrood_test/test_eql/test_core/test_rules.py
@@ -12,6 +12,7 @@ from krrood.entity_query_language.factories import (
     deduced_variable,
     add,
 )
+from krrood.entity_query_language.core.base_expressions import OperationResult
 from krrood.entity_query_language.predicate import HasType
 from krrood.entity_query_language.rules.conclusion import Add
 from ...dataset.eql_rule_tree_doc_example import (
@@ -544,3 +545,44 @@ def test_rule_tree_anchors_when_where_condition_is_reused_in_a_sibling():
         ("Handle1", "Container1"),
         ("Handle2", "Container2"),
     }
+
+
+def test_conclusions_fire_without_an_active_evaluation_context(
+    handles_and_containers_world,
+):
+    """A conclusion must still fire when no ``EvaluationContext`` is active.
+
+    ``_evaluate_conclusions_and_update_bindings_`` is normally only reached from inside
+    ``_evaluate_``, which has already set one up. But real-world callers can drive evaluation
+    from a code path where no context was ever created for the current thread (for example,
+    resuming a query from a thread that does not share the caller's ``contextvars.Context`` --
+    Python's ``ContextVar`` values do not propagate into a plain ``threading.Thread`` by
+    default). This calls the raw, double-underscore ``_evaluate__`` directly (bypassing
+    ``_evaluate_``'s context setup entirely) to prove the conclusion-firing check falls back to
+    a purely structural one instead of assuming a context always exists.
+    """
+    world = handles_and_containers_world
+    container = variable(Container, domain=world.bodies)
+    handle = variable(Handle, domain=world.bodies)
+    fixed_connection = variable(FixedConnection, domain=world.connections)
+    drawers = variable(Drawer, domain=[])
+    condition = and_(
+        container == fixed_connection.parent,
+        handle == fixed_connection.child,
+    )
+
+    with condition:
+        Add(drawers, inference(Drawer)(handle=handle, container=container))
+
+    assert condition._conditions_root_ is condition
+
+    raw_result = next(
+        result
+        for result in condition._evaluate__(OperationResult({}))
+        if not result.is_false
+    )
+
+    processed_result = condition._evaluate_conclusions_and_update_bindings_(raw_result)
+
+    assert drawers._id_ in processed_result.bindings
+    assert isinstance(processed_result.bindings[drawers._id_], Drawer)


### PR DESCRIPTION
_evaluate_conclusions_and_update_bindings_ was answering an evaluation-scoped question (which Filter pass is currently running) by recomputing a structural one (_conditions_root_), which is ambiguous when a node is reused as the WHERE condition of two separate Filters. Adds ActiveConditionsRoot to evaluation_context.py so evaluation asks the evaluation-scoped question directly, and replaces the generic EvaluationContext data grab-bag with typed collaborators. Full test_eql suite: 956 passed, 3 skipped, 0 failures.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/48