### PR TITLE
Recognize a bare type annotation as a type-type field in ormatic

### DIFF
--- a/krrood/src/krrood/class_diagrams/wrapped_field.py
+++ b/krrood/src/krrood/class_diagrams/wrapped_field.py
@@ -218,7 +218,13 @@ class WrappedField:
 
     @cached_property
     def is_type_type(self) -> bool:
-        return get_origin(self.resolved_type) is type
+        """
+        ``True`` for both the parametrized form (``Type[X]``, whose origin is ``type``) and the bare
+        ``type`` / ``typing.Type`` annotation, which has no origin at all.
+        """
+        return (
+            self.resolved_type in (type, Type) or get_origin(self.resolved_type) is type
+        )
 
     @cached_property
     def is_enum(self) -> bool:
@@ -288,7 +294,9 @@ class WrappedField:
             owner = origin
         # The base ``Role`` declares ``role_taker`` as an abstract, unbound-generic slot; only a
         # concrete role subclass binds it to a real taker type.
-        if not (isinstance(owner, type) and issubclass(owner, Role) and owner is not Role):
+        if not (
+            isinstance(owner, type) and issubclass(owner, Role) and owner is not Role
+        ):
             return False
         return self.field.name == Role.role_taker_field_name()
 

--- a/test/krrood_test/dataset/example_classes.py
+++ b/test/krrood_test/dataset/example_classes.py
@@ -53,6 +53,11 @@ class KRROODPositionTypeWrapper(Symbol):
     position_type: Type[KRROODPosition]
 
 
+@dataclass
+class KRROODBarePositionTypeWrapper(Symbol):
+    position_type: type
+
+
 # check that flat classes work
 @dataclass(unsafe_hash=True)
 class KRROODPosition(Symbol):
@@ -196,6 +201,7 @@ class KRROODTorso(KRROODKinematicChain):
     """
     A collection of kinematic chains that are connected to the torso.
     """
+
 
 @dataclass
 class Parent(Symbol):

--- a/test/krrood_test/test_class_diagram/test_wrapped_field.py
+++ b/test/krrood_test/test_class_diagram/test_wrapped_field.py
@@ -14,6 +14,7 @@ from ..dataset.example_classes import (
     KRROODPose,
     KRROODPositions,
     KRROODPositionTypeWrapper,
+    KRROODBarePositionTypeWrapper,
     GenericClassAssociation,
     KRROODCup,
     KRROODBowl,
@@ -82,6 +83,18 @@ def test_is_type_type():
     wrapped_class = WrappedClass(clazz=KRROODPositionTypeWrapper)
     wrapped_field = WrappedField(
         wrapped_class, get_field_by_name(KRROODPositionTypeWrapper, "position_type")
+    )
+    assert wrapped_field.is_type_type
+
+
+def test_is_type_type_for_bare_type_annotation():
+    """A field annotated with the bare builtin ``type`` (not the parametrized ``Type[X]``) is also
+    a type-type field — ``get_origin(type)`` is ``None``, unlike ``get_origin(Type[X])``, so this is
+    a distinct case from :func:`test_is_type_type`."""
+    wrapped_class = WrappedClass(clazz=KRROODBarePositionTypeWrapper)
+    wrapped_field = WrappedField(
+        wrapped_class,
+        get_field_by_name(KRROODBarePositionTypeWrapper, "position_type"),
     )
     assert wrapped_field.is_type_type
 


### PR DESCRIPTION
WrappedField.is_type_type only recognised the parametrized Type[X] form, so a bare 'type' annotation fell through to the builtin-column path and ormatic emitted an invalid Mapped[type] annotation. Now also matches bare type/typing.Type. Full details: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/49