### PR TITLE
Fix doubled determiner in IsSameSemanticEntity verbalization

### DIFF
--- a/krrood/src/krrood/patterns/role_predicates.py
+++ b/krrood/src/krrood/patterns/role_predicates.py
@@ -55,7 +55,7 @@ class IsSameSemanticEntity(Predicate):
         return clause(
             Noun(fields["entity_1"]),
             Copula(),
-            Noun("the same entity"),
+            Noun.the("same entity"),
             Prepositions.AS,
             Noun(fields["entity_2"]),
         )

--- a/test/krrood_test/test_eql/test_verbalization/test_role_predicate_verbalization.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_role_predicate_verbalization.py
@@ -1,0 +1,28 @@
+"""
+Wording tests for the role predicates' verbalization surfaces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from krrood.entity_query_language.factories import variable
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
+from krrood.patterns.role_predicates import IsSameSemanticEntity
+
+
+@dataclass
+class Document:
+    """A minimal entity the identity predicate is verbalized over."""
+
+    name: str
+
+
+def test_is_same_semantic_entity_reads_with_a_single_determiner():
+    """The identity clause reads *"… is the same entity as …"* — the complement carries exactly one
+    determiner (the definite article), not a doubled *"a the same entity"*."""
+    first, second = variable(Document, []), variable(Document, [])
+    assert (
+        verbalize_expression(IsSameSemanticEntity(first, second))
+        == "Document 1 is the same entity as Document 2"
+    )


### PR DESCRIPTION
IsSameSemanticEntity verbalized as 'a the same entity' due to a literal-head Noun defaulting to indefinite. Fixed with Noun.the(...). Full details: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/50