### PR TITLE
Say HasType's tuple of admissible types disjunctively

### DIFF
--- a/krrood/src/krrood/entity_query_language/predicate.py
+++ b/krrood/src/krrood/entity_query_language/predicate.py
@@ -328,7 +328,29 @@ class HasType(Triple):
             Noun(fields["variable"]),
             Copula(),
             Adjective("of type"),
-            Noun(fields["types_"]),
+            cls._types_listing(fields["types_"]),
+        )
+
+    @staticmethod
+    def _types_listing(types_field: VerbalizationField) -> Any:
+        """:return: the admissible types said DISJUNCTIVELY (*"Apple or Body"*) when the field holds
+        a tuple — ``isinstance`` over a tuple holds for any one of them, so *"and"* would claim an
+        impossible conjunction — else the field's own rendered fragment (a single type, or a
+        variable standing for one)."""
+        # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
+        from krrood.entity_query_language.verbalization.fragments.base import (
+            oxford_comma,
+            RoleFragment,
+        )
+        from krrood.entity_query_language.verbalization.vocabulary.english import (
+            Conjunctions,
+        )
+
+        if not isinstance(types_field.value, tuple):
+            return types_field
+        return oxford_comma(
+            [RoleFragment.for_type(type_) for type_ in types_field.value],
+            Conjunctions.OR.as_fragment(),
         )
 
 
@@ -397,4 +419,3 @@ class Is(Predicate):
 
     def __call__(self) -> bool:
         return self.first_entity is self.second_entity
-

--- a/krrood/src/krrood/entity_query_language/predicate.py
+++ b/krrood/src/krrood/entity_query_language/predicate.py
@@ -327,31 +327,49 @@ class HasType(Triple):
         return clause(
             Noun(fields["variable"]),
             Copula(),
-            Adjective("of type"),
-            cls._types_listing(fields["types_"]),
+            *cls._types_predicate(fields["types_"]),
         )
 
     @staticmethod
-    def _types_listing(types_field: VerbalizationField) -> Any:
-        """:return: the admissible types said DISJUNCTIVELY (*"Apple or Body"*) when the field holds
-        a tuple — ``isinstance`` over a tuple holds for any one of them, so *"and"* would claim an
-        impossible conjunction — else the field's own rendered fragment (a single type, or a
-        variable standing for one)."""
+    def _types_predicate(types_field: VerbalizationField) -> Any:
+        """:return: the *"of type …"* predicate tail. A tuple of admissible types is said
+        DISJUNCTIVELY (*"of type Apple or Body"*) — ``isinstance`` over a tuple holds for any one of
+        them, so *"and"* would claim an impossible conjunction. Past the membership cap the types
+        are summarised by count (*"of seven possible types"*) rather than spelled out. A single type
+        (or a variable standing for one) keeps the field's own rendered fragment."""
         # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
+        from krrood.entity_query_language.verbalization import morphology
         from krrood.entity_query_language.verbalization.fragments.base import (
             oxford_comma,
             RoleFragment,
+            WordFragment,
+        )
+        from krrood.entity_query_language.verbalization.microplanning.coordination import (
+            MAX_SET_MEMBERS,
         )
         from krrood.entity_query_language.verbalization.vocabulary.english import (
             Conjunctions,
         )
-
-        if not isinstance(types_field.value, tuple):
-            return types_field
-        return oxford_comma(
-            [RoleFragment.for_type(type_) for type_ in types_field.value],
-            Conjunctions.OR.as_fragment(),
+        from krrood.entity_query_language.verbalization.vocabulary.parts_of_speech import (
+            Adjective,
+            Noun,
         )
+
+        value = types_field.value
+        if not isinstance(value, tuple):
+            return [Adjective("of type"), Noun(types_field)]
+        if len(value) > MAX_SET_MEMBERS:
+            return [
+                Adjective("of"),
+                WordFragment(text=f"{morphology.cardinal(len(value))} possible types"),
+            ]
+        return [
+            Adjective("of type"),
+            oxford_comma(
+                [RoleFragment.for_type(type_) for type_ in value],
+                Conjunctions.OR.as_fragment(),
+            ),
+        ]
 
 
 @dataclass(eq=False)
@@ -370,22 +388,6 @@ class HasTypes(HasType):
     """
     A tuple containing Type objects that are associated with this instance.
     """
-
-    @classmethod
-    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
-        """Say membership over the admissible types — *"<variable> is one of A, B, or C"*. The
-        :class:`OneOf` element handles the bounded listing (linking, *"or"*, the count cap), so the
-        types are read from the field's value (an ``isinstance`` over the tuple is membership, not the
-        tuple value an equality would mean)."""
-        # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
-        from krrood.entity_query_language.verbalization.vocabulary.parts_of_speech import (
-            clause,
-            Copula,
-            Noun,
-            OneOf,
-        )
-
-        return clause(Noun(fields["variable"]), Copula(), OneOf(fields["types_"]))
 
 
 @symbolic_function

--- a/krrood/src/krrood/entity_query_language/predicate.py
+++ b/krrood/src/krrood/entity_query_language/predicate.py
@@ -317,9 +317,6 @@ class HasType(Triple):
         cls, fields: Mapping[str, VerbalizationFragment]
     ) -> VerbalizationFragment:
         # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
-        from krrood.entity_query_language.verbalization.fragments.features import (
-            Definiteness,
-        )
         from krrood.entity_query_language.verbalization.vocabulary.english import (
             Prepositions,
         )
@@ -338,7 +335,7 @@ class HasType(Triple):
             Noun(fields["variable"]),
             Copula(),
             Prepositions.OF,
-            Noun("type", definiteness=Definiteness.BARE),
+            Noun.bare("type"),
             Or(fields["types_"]),
         )
 

--- a/krrood/src/krrood/entity_query_language/predicate.py
+++ b/krrood/src/krrood/entity_query_language/predicate.py
@@ -317,59 +317,30 @@ class HasType(Triple):
         cls, fields: Mapping[str, VerbalizationFragment]
     ) -> VerbalizationFragment:
         # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
+        from krrood.entity_query_language.verbalization.fragments.features import (
+            Definiteness,
+        )
+        from krrood.entity_query_language.verbalization.vocabulary.english import (
+            Prepositions,
+        )
         from krrood.entity_query_language.verbalization.vocabulary.parts_of_speech import (
-            Adjective,
             clause,
             Copula,
             Noun,
+            Or,
         )
 
+        # "<variable> is of type A, B, or C" -- the admissible types are said DISJUNCTIVELY
+        # (``isinstance`` over a tuple holds for ANY one of them, so "and" would claim an impossible
+        # conjunction). The listing is the vocabulary's :class:`Or` element, not a bespoke tail;
+        # "type" is a bare noun ("of type", not "of a type").
         return clause(
             Noun(fields["variable"]),
             Copula(),
-            *cls._types_predicate(fields["types_"]),
+            Prepositions.OF,
+            Noun("type", definiteness=Definiteness.BARE),
+            Or(fields["types_"]),
         )
-
-    @staticmethod
-    def _types_predicate(types_field: VerbalizationField) -> Any:
-        """:return: the *"of type …"* predicate tail. A tuple of admissible types is said
-        DISJUNCTIVELY (*"of type Apple or Body"*) — ``isinstance`` over a tuple holds for any one of
-        them, so *"and"* would claim an impossible conjunction. Past the membership cap the types
-        are summarised by count (*"of seven possible types"*) rather than spelled out. A single type
-        (or a variable standing for one) keeps the field's own rendered fragment."""
-        # Imported locally to avoid the core → verbalization import cycle (see :class:`Triple`).
-        from krrood.entity_query_language.verbalization import morphology
-        from krrood.entity_query_language.verbalization.fragments.base import (
-            oxford_comma,
-            RoleFragment,
-            WordFragment,
-        )
-        from krrood.entity_query_language.verbalization.microplanning.coordination import (
-            MAX_SET_MEMBERS,
-        )
-        from krrood.entity_query_language.verbalization.vocabulary.english import (
-            Conjunctions,
-        )
-        from krrood.entity_query_language.verbalization.vocabulary.parts_of_speech import (
-            Adjective,
-            Noun,
-        )
-
-        value = types_field.value
-        if not isinstance(value, tuple):
-            return [Adjective("of type"), Noun(types_field)]
-        if len(value) > MAX_SET_MEMBERS:
-            return [
-                Adjective("of"),
-                WordFragment(text=f"{morphology.cardinal(len(value))} possible types"),
-            ]
-        return [
-            Adjective("of type"),
-            oxford_comma(
-                [RoleFragment.for_type(type_) for type_ in value],
-                Conjunctions.OR.as_fragment(),
-            ),
-        ]
 
 
 @dataclass(eq=False)

--- a/krrood/src/krrood/entity_query_language/verbalization/fragments/base.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/fragments/base.py
@@ -242,6 +242,20 @@ class RoleFragment(HasText, HasNumber, HasPolarity, VerbalizationFragment):
         return cls(text=value_phrase(value), role=SemanticRole.LITERAL)
 
     @classmethod
+    def for_member(cls, value: Any) -> RoleFragment:
+        """Build a fragment for one admissible member of a set or disjunction: a class renders as a
+        source-linked type reference (:meth:`for_type`), any other value as a literal
+        (:meth:`for_literal`). Lets the set/disjunction elements render members uniformly without
+        branching on whether they are types.
+
+        >>> RoleFragment.for_member(int).text
+        'Integer'
+        >>> RoleFragment.for_member(42).text
+        '42'
+        """
+        return cls.for_type(value) if isinstance(value, type) else cls.for_literal(value)
+
+    @classmethod
     def for_operator(cls, label: str) -> RoleFragment:
         """
         Build a fragment for an operator or copula (no source link).

--- a/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
@@ -14,6 +14,7 @@ from krrood.entity_query_language.verbalization.fragments.base import (
     PhraseFragment,
     RoleFragment,
     WordFragment,
+    oxford_comma,
 )
 from krrood.entity_query_language.verbalization.fragments.features import (
     Definiteness,
@@ -25,6 +26,7 @@ from krrood.entity_query_language.verbalization.microplanning.coordination impor
     one_of,
 )
 from krrood.entity_query_language.verbalization.vocabulary.english import (
+    Conjunctions,
     Copulas,
     Prepositions,
     SetMembership,
@@ -176,6 +178,44 @@ class OneOf(ClauseElement):
                 WordFragment(text=morphology.cardinal(len(members))),
                 WordFragment(text="types" if are_types else "values"),
             ]
+        )
+
+
+@dataclass(frozen=True)
+class Or(ClauseElement):
+    """A disjunctive listing of admissible values — *"A, B, or C"* — over a collection.
+
+    The vocabulary-level oxford-comma disjunction: each member renders as a linked type reference when
+    it is a class, else as a literal value, joined with *"or"*. An author writes ``Or(field)`` rather
+    than reaching for the low-level :func:`~…fragments.base.oxford_comma` / :class:`Conjunctions`
+    builders. A field bound to a single (non-tuple) value keeps that value's own rendered fragment.
+    """
+
+    members: Union[Iterable, VerbalizationField]
+    """The admissible values — a predicate :class:`~krrood.entity_query_language.predicate.VerbalizationField`
+    bound to a collection (or a single value), or a collection directly. Classes render as linked type
+    references, other values as literals."""
+
+    def as_fragment(self) -> VerbalizationFragment:
+        """:return: the disjunction phrase *"A, B, or C"*, or a single member's own fragment.
+
+        >>> from krrood.entity_query_language.verbalization.fragments.base import (
+        ...     flatten_fragment_to_plain_text,
+        ... )
+        >>> flatten_fragment_to_plain_text(Or((int, str)).as_fragment())
+        'Integer or Text'
+        """
+        value = (
+            self.members.value
+            if isinstance(self.members, VerbalizationField)
+            else self.members
+        )
+        if not isinstance(value, tuple):
+            return Noun(self.members).as_fragment()
+        are_types = bool(value) and all(isinstance(member, type) for member in value)
+        render = RoleFragment.for_type if are_types else RoleFragment.for_literal
+        return oxford_comma(
+            [render(member) for member in value], Conjunctions.OR.as_fragment()
         )
 
 

--- a/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
@@ -83,6 +83,15 @@ class Noun(ClauseElement):
         """
         return cls(head, definiteness=Definiteness.DEFINITE)
 
+    @classmethod
+    def bare(cls, head: str) -> "Noun":
+        """:return: a bare literal noun with no article (*"of type"*, not *"of a type"*).
+
+        >>> Noun.bare("type").as_fragment().definiteness
+        <Definiteness.BARE: 'bare'>
+        """
+        return cls(head, definiteness=Definiteness.BARE)
+
 
 @dataclass(frozen=True)
 class Verb(ClauseElement):

--- a/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/vocabulary/parts_of_speech.py
@@ -174,13 +174,16 @@ class OneOf(ClauseElement):
             if isinstance(self.members, VerbalizationField)
             else self.members
         )
+        listed = one_of(
+            [RoleFragment.for_member(member) for member in members[: MAX_SET_MEMBERS + 1]]
+        )
+        if listed is not None:
+            return listed
+        # Past the cap the members are summarised by count; the category noun still distinguishes a
+        # set of types from a set of plain values.
         are_types = bool(members) and all(
             isinstance(member, type) for member in members
         )
-        render = RoleFragment.for_type if are_types else RoleFragment.for_literal
-        listed = one_of([render(member) for member in members[: MAX_SET_MEMBERS + 1]])
-        if listed is not None:
-            return listed
         return PhraseFragment(
             parts=[
                 SetMembership.ONE_OF.as_fragment(),
@@ -194,16 +197,16 @@ class OneOf(ClauseElement):
 class Or(ClauseElement):
     """A disjunctive listing of admissible values — *"A, B, or C"* — over a collection.
 
-    The vocabulary-level oxford-comma disjunction: each member renders as a linked type reference when
-    it is a class, else as a literal value, joined with *"or"*. An author writes ``Or(field)`` rather
-    than reaching for the low-level :func:`~…fragments.base.oxford_comma` / :class:`Conjunctions`
-    builders. A field bound to a single (non-tuple) value keeps that value's own rendered fragment.
+    The vocabulary-level oxford-comma disjunction over any iterable of members, each rendered by
+    :meth:`~…fragments.base.RoleFragment.for_member` (a class as a linked type reference, any other
+    value as a literal) and joined with *"or"*. An author writes ``Or(field)`` rather than reaching
+    for the low-level :func:`~…fragments.base.oxford_comma` / :class:`Conjunctions` builders. A field
+    bound to a single (non-iterable) value keeps that value's own rendered fragment.
     """
 
     members: Union[Iterable, VerbalizationField]
     """The admissible values — a predicate :class:`~krrood.entity_query_language.predicate.VerbalizationField`
-    bound to a collection (or a single value), or a collection directly. Classes render as linked type
-    references, other values as literals."""
+    bound to an iterable (or a single value), or an iterable directly."""
 
     def as_fragment(self) -> VerbalizationFragment:
         """:return: the disjunction phrase *"A, B, or C"*, or a single member's own fragment.
@@ -219,12 +222,11 @@ class Or(ClauseElement):
             if isinstance(self.members, VerbalizationField)
             else self.members
         )
-        if not isinstance(value, tuple):
+        if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
             return Noun(self.members).as_fragment()
-        are_types = bool(value) and all(isinstance(member, type) for member in value)
-        render = RoleFragment.for_type if are_types else RoleFragment.for_literal
         return oxford_comma(
-            [render(member) for member in value], Conjunctions.OR.as_fragment()
+            [RoleFragment.for_member(member) for member in value],
+            Conjunctions.OR.as_fragment(),
         )
 
 

--- a/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
@@ -1438,6 +1438,17 @@ def test_verbalize_has_type_tuple_of_types():
     assert "Body" in text
 
 
+def test_has_type_lists_a_tuple_of_types_disjunctively():
+    """``isinstance`` over a tuple holds when the value is ANY of the types, so the listing joins
+    with *"or"* — *"is of type Apple or Body"*, never the conjunctive *"and"* (a value cannot be of
+    both types at once)."""
+    fruit = variable(Body, [])
+    assert (
+        verbalize_expression(HasType(fruit, (Apple, Body)))
+        == "a Body is of type Apple or Body"
+    )
+
+
 def test_verbalize_contains_type():
     fruit_box = variable(FruitBox, [])
     predicate = ContainsType(fruit_box.fruits, Apple)

--- a/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
@@ -223,12 +223,12 @@ def test_verbalize_literal_tuple_of_types_is_a_value_not_membership():
 
 
 def test_verbalize_has_types_is_membership():
-    """The type-membership predicate reads as the bounded *"one of A, B, or C"* set — the same
-    surface a domain-constrained variable uses — over its admissible types."""
+    """The type-membership predicate reads through the same *"is of type A or B"* surface as
+    ``HasType``, its admissible types listed disjunctively."""
     subject = variable(Body, [])
     assert (
         verbalize_expression(HasTypes(subject, (Apple, Cabinet)))
-        == "a Body is one of Apple or Cabinet"
+        == "a Body is of type Apple or Cabinet"
     )
 
 
@@ -246,7 +246,7 @@ def test_verbalize_has_types_too_many_is_not_spelled():
     )
     text = verbalize_expression(HasTypes(subject, many))
     assert "Apple" not in text
-    assert text == "a Body is one of seven types"
+    assert text == "a Body is of seven possible types"
 
 
 # ── Unit tests: MappedVariable chain ──────────────────────────────────────────

--- a/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_verbalization.py
@@ -232,8 +232,9 @@ def test_verbalize_has_types_is_membership():
     )
 
 
-def test_verbalize_has_types_too_many_is_not_spelled():
-    """Past the membership cap the admissible types are summarised by count, not spelled out."""
+def test_verbalize_has_types_lists_all_admissible_types():
+    """Every admissible type is listed disjunctively -- ``isinstance`` over the tuple holds for ANY of
+    them -- joined by the :class:`Or` element with an oxford comma before the final *"or"*."""
     subject = variable(Body, [])
     many = (
         Apple,
@@ -245,8 +246,10 @@ def test_verbalize_has_types_too_many_is_not_spelled():
         PrismaticConnection,
     )
     text = verbalize_expression(HasTypes(subject, many))
-    assert "Apple" not in text
-    assert text == "a Body is of seven possible types"
+    assert text == (
+        "a Body is of type Apple, Cabinet, Container, Drawer, "
+        "FixedConnection, Handle, or PrismaticConnection"
+    )
 
 
 # ── Unit tests: MappedVariable chain ──────────────────────────────────────────


### PR DESCRIPTION
`HasType` over a tuple verbalized conjunctively ("is of type Integer and Text") though isinstance holds on ANY match — an impossible both-at-once reading. Now listed with "or". TDD, all HasType verbalization tests pass.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/51