### PR TITLE
ci: stop uv double-storing packages that exhausts the runner disk

### DIFF
--- a/.github/workflows/ci_reusable.yml
+++ b/.github/workflows/ci_reusable.yml
@@ -27,6 +27,13 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        env:
+          # Keep uv's cache on the same filesystem as the target venv (/opt/ros/cram-env) so uv can
+          # hardlink packages into site-packages instead of full-copying them. The default cache
+          # (~/.cache/uv under the mounted /github/home volume) is a different filesystem, which
+          # forces a full copy of every wheel and stores each package twice -- exhausting the runner
+          # disk ("No space left on device") during install.
+          UV_CACHE_DIR: /opt/ros/.uv_cache
         run: |
           cd cognitive_robot_abstract_machine
           source /opt/ros/cram-env/bin/activate

--- a/.github/workflows/example_demo_reusable.yml
+++ b/.github/workflows/example_demo_reusable.yml
@@ -27,12 +27,19 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        env:
+          # Keep uv's cache on the same filesystem as the target venv (/opt/ros/cram-env) so uv can
+          # hardlink packages into site-packages instead of full-copying them. The default cache
+          # (~/.cache/uv under the mounted /github/home volume) is a different filesystem, which
+          # forces a full copy of every wheel and stores each package twice -- exhausting the runner
+          # disk ("No space left on device") during install.
+          UV_CACHE_DIR: /opt/ros/.uv_cache
         run: |
           cd cognitive_robot_abstract_machine
           source /opt/ros/cram-env/bin/activate
           sudo apt-get update
           sudo apt-get install -y xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 libegl1
-          uv sync --extra dev,doc --active 
+          uv sync --extra dev,doc --active
 
       - name: Restore cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
uv's cache dir and the ROS venv live on different filesystems, so uv falls back to a full copy per package instead of hardlinking, doubling disk footprint and exhausting the CI runner mid-install. Points UV_CACHE_DIR at the venv's filesystem so uv hardlinks instead.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/52