### PR TITLE
Fix SingletonMeta thread-safety race (spurious "circular dependency" error)

### DIFF
--- a/krrood/src/krrood/singleton.py
+++ b/krrood/src/krrood/singleton.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing_extensions import ClassVar, Dict, Type, Any, List
 
 
@@ -16,25 +17,33 @@ class SingletonMeta(type):
     """
     A list of classes that are currently being created.
     """
+    _construction_lock: ClassVar[threading.RLock] = threading.RLock()
+    """
+    Serialises singleton construction so a different thread racing to construct the same class waits
+    for it instead of seeing the in-progress construction as a circular dependency. Reentrant so the
+    same thread recursing into its own construction is still caught by ``_is_being_created``.
+    """
 
     def __call__(cls, *args, **kwargs):
         """
         Intercept the initialization of every class using this metaclass to check if there is an instance registered
         already.
         """
-        if cls in cls._is_being_created:
-            raise RuntimeError(
-                f"Circular dependency detected for class {cls.__name__},"
-                f"Some part of the code is trying to create an instance of {cls.__name__} while it is "
-                f"already being created."
-            )
-        if cls not in cls._instances:
+        with cls._construction_lock:
+            if cls in cls._instances:
+                return cls._instances[cls]
+            if cls in cls._is_being_created:
+                raise RuntimeError(
+                    f"Circular dependency detected for class {cls.__name__},"
+                    f"Some part of the code is trying to create an instance of {cls.__name__} while it is "
+                    f"already being created."
+                )
             cls._is_being_created.append(cls)
             try:
                 cls._instances[cls] = super().__call__(*args, **kwargs)
             finally:
                 cls._is_being_created.remove(cls)
-        return cls._instances[cls]
+            return cls._instances[cls]
 
     def clear_instance(cls):
         """

--- a/test/krrood_test/test_singleton.py
+++ b/test/krrood_test/test_singleton.py
@@ -1,0 +1,59 @@
+"""Thread-safety and reentrancy behaviour of :class:`~krrood.singleton.SingletonMeta`."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from krrood.singleton import SingletonMeta
+
+
+def test_concurrent_first_construction_does_not_raise_circular_dependency():
+    """Several threads racing to construct the same singleton for the first time must not see each
+    other's in-progress construction as a circular dependency: exactly one instance is built and every
+    thread observes it, with no exception."""
+
+    class ConcurrentlyConstructedSingleton(metaclass=SingletonMeta):
+        def __init__(self):
+            time.sleep(0.05)
+
+    errors = []
+    instances = []
+
+    def build():
+        try:
+            instances.append(ConcurrentlyConstructedSingleton())
+        except RuntimeError as error:
+            errors.append(error)
+
+    threads = [threading.Thread(target=build) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    ConcurrentlyConstructedSingleton.clear_instance()
+
+    assert errors == []
+    assert len(instances) == 8
+    assert len(set(map(id, instances))) == 1
+
+
+def test_recursive_construction_within_the_same_thread_still_raises():
+    """A singleton whose own construction recursively constructs itself again, on the same thread, is
+    a genuine circular dependency and must still raise."""
+
+    class SelfRecursingSingleton(metaclass=SingletonMeta):
+        def __init__(self, recurse: bool = True):
+            if recurse:
+                SelfRecursingSingleton(recurse=False)
+
+    try:
+        raised = False
+        try:
+            SelfRecursingSingleton()
+        except RuntimeError:
+            raised = True
+        assert raised
+    finally:
+        SelfRecursingSingleton.clear_instance()


### PR DESCRIPTION
SingletonMeta's check-then-create sequence isn't atomic across threads; coraplex's Parallel/TryAll combinators race real threads to construct the same singleton, misreporting a circular dependency. An RLock now serialises construction. New threaded test proves the bug then the fix; genuine same-thread recursion still raises.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/56