### PR TITLE
Exclude hypothesis 6.156.6 (no linux-x86_64 wheel) so CI can install

### DIFF
--- a/semantic_digital_twin/requirements.txt
+++ b/semantic_digital_twin/requirements.txt
@@ -6,7 +6,7 @@ typing_extensions
 urdf-parser-py
 matplotlib
 casadi~=3.7.0
-hypothesis
+hypothesis!=6.156.6  # 6.156.6 ships no linux-x86_64 wheel; skip it so uv sync resolves
 scipy
 sqlacodegen
 pytest-order


### PR DESCRIPTION
hypothesis 6.156.6 has no manylinux x86_64 wheel, so uv sync fails on every Linux CI job across the whole workspace. This constrains the dependency to hypothesis!=6.156.6 so uv resolves to the last good release instead.

Full context: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/57