### PR TITLE
Add an opt-in SessionStart hook for personal Claude Code notes

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -44,21 +44,42 @@ Once, from any clone with push access to `origin`:
 ```
 
 This creates `claude/personal-notes` on `origin` with a single empty
-`.claude/personal/cram-notes.md`, without touching your current branch or working tree. Then edit
-that file (see below) to add your own notes. Every new Claude Code session — local or fresh-clone —
-now runs the hook automatically and writes `CLAUDE.local.md` from that branch, with no further
-configuration needed.
+`.claude/personal/cram-notes.md`, without touching your current branch or working tree. Every new
+Claude Code session — local or fresh-clone — now runs the hook automatically and writes
+`CLAUDE.local.md` from that branch, with no further configuration needed.
 
-To edit your notes after the branch exists:
+## Editing your notes
+
+Just ask Claude, in any session: *"add \<X\> to my personal notes"* or *"edit my personal notes."*
+No extra setup or explanation is needed — `session-start.sh` writes a short header at the top of
+`CLAUDE.local.md` every session (see below), and since Claude Code already loads `CLAUDE.local.md`
+as project memory, that header is always in context. It names the resolved branch/path and points
+at [`save-personal-notes.sh`](./save-personal-notes.sh), so Claude edits the notes below the header
+and runs that script to push the change back — deterministically, with no guessing at where notes
+live or how to persist them.
+
+The header looks like this (regenerated every session — editing it has no effect):
+
+```
+<!--
+Personal notes, synced from 'claude/personal-notes' (.claude/personal/cram-notes.md) by session-start.sh.
+To edit: change the notes below this line, then run
+  "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
+to push the change back to 'claude/personal-notes'. This header is regenerated
+every session from git config/environment/default - editing it has no effect.
+-->
+<!-- END-PERSONAL-NOTES-HEADER -->
+```
+
+To do it by hand instead: edit `CLAUDE.local.md` below that marker line, then run
 
 ```bash
-git fetch origin claude/personal-notes
-git worktree add /tmp/personal-notes origin/claude/personal-notes
-$EDITOR /tmp/personal-notes/.claude/personal/cram-notes.md
-git -C /tmp/personal-notes commit -am "update personal notes"
-git -C /tmp/personal-notes push origin HEAD:claude/personal-notes
-git worktree remove /tmp/personal-notes
+"$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
 ```
+
+It resolves the branch/path exactly like `session-start.sh` does, strips the header back out, and
+pushes only your actual notes content — in a scratch worktree, so your current branch and working
+tree are untouched, and as a no-op if nothing actually changed.
 
 ## Setup: overriding the default branch/path
 
@@ -135,9 +156,13 @@ directly:
   target): `git fetch` finds nothing, so nothing gets written.
 - Never merges anything: the hook only ever *reads* the resolved branch via `git show`. It never
   checks it out or merges it into your working branch.
-- `create-personal-notes-branch.sh` never touches your current branch or working tree either — it
-  does its work in a scratch worktree and refuses to run if the target branch already exists
-  locally or on `origin`.
+- `create-personal-notes-branch.sh` and `save-personal-notes.sh` never touch your current branch or
+  working tree either — both do their work in a scratch worktree.
+  `create-personal-notes-branch.sh` refuses to run if the target branch already exists locally or
+  on `origin`; `save-personal-notes.sh` is a no-op if there's nothing new to push.
+- The sync header `session-start.sh` writes is never itself pushed back: `save-personal-notes.sh`
+  strips everything up to and including the `END-PERSONAL-NOTES-HEADER` marker before committing,
+  so only your actual notes content ever lands on the notes branch.
 - `CLAUDE.local.md` is gitignored, so populated notes can't accidentally end up in a commit on any
   branch, including this one.
 - Safe to re-run: `session-start.sh` only ever overwrites `CLAUDE.local.md`, and does nothing if

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -262,6 +262,13 @@ directly:
   code path by which it could end up in a commit that gets merged.
 - `CLAUDE.local.md` is gitignored, so populated notes can't accidentally end up in a commit on any
   branch, including this one.
+- All four scripts always operate on *this* repo's project root specifically, never wherever they
+  happen to be invoked from: a `SessionStart` hook's cwd isn't guaranteed to be the project root,
+  and these scripts are also meant to be run directly. Each resolves its own location on disk
+  (`resolve-personal-notes-config.sh`'s own path, not `$CLAUDE_PROJECT_DIR` or the caller's cwd,
+  since neither is guaranteed) to find the project root deterministically, then both `cd`s there for
+  every git operation and reads/writes `CLAUDE.local.md` at that exact path — so it's never created
+  in, or read from, some other directory, even one that's a subdirectory of a *different* repo.
 - Safe to re-run: `session-start.sh` only ever overwrites `CLAUDE.local.md`, and does nothing if
   the resolved branch or path isn't reachable (e.g. a fresh clone, or a fork that never created
   it).

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -25,8 +25,28 @@ config, then `CLAUDE_PERSONAL_NOTES_BRANCH` env var, then the default `claude/pe
 so does the path on that branch (`claude.personalNotesPath` git config, then
 `CLAUDE_PERSONAL_NOTES_PATH` env var, then the default `.claude/personal/cram-notes.md`).
 
-The hook is still a no-op in effect for anyone who never creates the branch it resolves to: `git
-fetch` finds nothing, so it exits without writing `CLAUDE.local.md`.
+The hook is still a no-op in effect for anyone who never creates the branch it resolves to on
+*neither* the resolved remote *nor* the fallback below: `git fetch` finds nothing, so it exits
+without writing `CLAUDE.local.md`.
+
+### Fallback: the current branch's own upstream remote
+
+If the resolved remote doesn't have the branch, `session-start.sh` and `save-personal-notes.sh` try
+one more thing before giving up: the remote your *currently checked-out branch* already tracks
+(i.e. what `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` reports), if it has one and
+it differs from the resolved remote. This covers a very common case with zero configuration at
+all — a clone whose checked-out branch already tracks your own fork under some remote name other
+than `origin` (e.g. a session environment where `origin` is the shared upstream repo and your fork
+is a differently-named remote) — the hook finds your notes there automatically.
+
+This fallback is read-only: it only ever changes where notes are *read* from, never where
+`create-personal-notes-branch.sh` *creates* them (that script still targets exactly the resolved
+remote, so creation stays a deliberate, unambiguous act — though it does refuse to create a second,
+divergent copy if the branch already exists on the fallback remote; see its own comments). When
+`save-personal-notes.sh` reads notes via the fallback, it also *writes* the edit back to that same
+fallback remote, not the resolved one, so a save always lands wherever the notes actually came from.
+The header `session-start.sh` writes always names whichever remote actually served the notes, so
+it's never ambiguous which one was used.
 
 ### When you need to override the remote
 
@@ -75,15 +95,18 @@ at [`save-personal-notes.sh`](./save-personal-notes.sh), so Claude edits the not
 and runs that script to push the change back — deterministically, with no guessing at where notes
 live or how to persist them.
 
-The header looks like this (regenerated every session — editing it has no effect):
+The header looks like this (regenerated every session — editing it has no effect), naming whichever
+remote actually served the notes (the resolved one, or the fallback):
 
 ```
 <!--
-Personal notes, synced from 'claude/personal-notes' (.claude/personal/cram-notes.md) by session-start.sh.
+Personal notes, synced from 'claude/personal-notes' (.claude/personal/cram-notes.md) on remote
+'origin' by session-start.sh.
 To edit: change the notes below this line, then run
   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
-to push the change back to 'claude/personal-notes'. This header is regenerated
-every session from git config/environment/default - editing it has no effect.
+to push the change back. This header is regenerated every session from git
+config/environment/default (plus a same-branch-upstream fallback) - editing
+it has no effect.
 -->
 <!-- END-PERSONAL-NOTES-HEADER -->
 ```
@@ -176,14 +199,16 @@ directly:
 ## Safety
 
 - No-op in effect for anyone who never creates the `claude/personal-notes` branch (or an override
-  target): `git fetch` finds nothing, so nothing gets written.
+  target) on either the resolved remote or its upstream-tracking fallback: `git fetch` finds
+  nothing on either, so nothing gets written.
 - Never merges anything: the hook only ever *reads* the resolved branch, off `FETCH_HEAD` via `git
   show` (not a `<remote>/<branch>` ref, since a URL-form remote creates no tracking ref for one). It
   never checks the branch out or merges it into your working branch.
 - `create-personal-notes-branch.sh` and `save-personal-notes.sh` never touch your current branch or
   working tree either — both do their work in a scratch worktree.
-  `create-personal-notes-branch.sh` refuses to run if the target branch already exists locally or
-  on the resolved remote; `save-personal-notes.sh` is a no-op if there's nothing new to push.
+  `create-personal-notes-branch.sh` refuses to run if the target branch already exists locally, on
+  the resolved remote, or on the upstream-tracking fallback remote (see above);
+  `save-personal-notes.sh` is a no-op if there's nothing new to push.
 - The sync header `session-start.sh` writes is never itself pushed back: `save-personal-notes.sh`
   strips everything up to and including the `END-PERSONAL-NOTES-HEADER` marker before committing,
   so only your actual notes content ever lands on the notes branch.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -2,29 +2,46 @@
 
 An opt-in `SessionStart` hook that populates `CLAUDE.local.md` — which Claude Code already loads
 automatically as project memory, and which is gitignored — from a personal branch you name for
-yourself on `origin`, so your own workflow preferences ("always open my PRs as drafts," "never
-touch branch X directly," etc.) persist across sessions without ever being committed to a shared
-branch.
+yourself on a remote (`origin` by default), so your own workflow preferences ("always open my PRs
+as drafts," "never touch branch X directly," etc.) persist across sessions without ever being
+committed to a shared branch.
 
 It works out of the box with no config at all: it reads from a branch named `claude/personal-notes`
 on `origin` unless you tell it otherwise. Run [`create-personal-notes-branch.sh`](./create-personal-notes-branch.sh)
 once to create that branch with an empty notes file, and every session from then on picks it up
-automatically. It is collision-free for multiple contributors sharing one `origin` remote if you
-each override the branch name via your own config instead of relying on the shared default.
+automatically. It is collision-free for multiple contributors sharing one remote if you each
+override the branch name via your own config instead of relying on the shared default.
 
 ## How it decides what to read
 
-`session-start.sh` looks for a branch name in this order, first one found wins:
+`session-start.sh` looks for a remote in this order, first one found wins:
 
-1. **`git config claude.personalNotesBranch`** — local to one clone's `.git/config`.
-2. **`CLAUDE_PERSONAL_NOTES_BRANCH` environment variable** — used only if the git config isn't set.
-3. **`claude/personal-notes`** — the zero-config default, used if neither of the above is set.
+1. **`git config claude.personalNotesRemote`** — local to one clone's `.git/config`.
+2. **`CLAUDE_PERSONAL_NOTES_REMOTE` environment variable** — used only if the git config isn't set.
+3. **`origin`** — the zero-config default, used if neither of the above is set.
 
-The path on that branch follows the same precedence (`claude.personalNotesPath` git config, then
+The branch name on that remote follows the same precedence (`claude.personalNotesBranch` git
+config, then `CLAUDE_PERSONAL_NOTES_BRANCH` env var, then the default `claude/personal-notes`), and
+so does the path on that branch (`claude.personalNotesPath` git config, then
 `CLAUDE_PERSONAL_NOTES_PATH` env var, then the default `.claude/personal/cram-notes.md`).
 
 The hook is still a no-op in effect for anyone who never creates the branch it resolves to: `git
 fetch` finds nothing, so it exits without writing `CLAUDE.local.md`.
+
+### When you need to override the remote
+
+The remote only needs overriding when your own notes don't live on this clone's `origin` — for
+example, some session environments name the upstream repo `origin` and give your own fork a
+different remote name, or don't add your fork as a remote at all. The value can be either form,
+and `git fetch`/`git push` accept both identically:
+
+- **A remote name already configured in the clone** (e.g. `myfork`) — the natural choice for a
+  persistent local clone where you've already added your fork as a remote.
+- **A raw git URL** (e.g. `https://github.com/<you>/<repo>`) — needs no `git remote add` first, so
+  it works even in a clone that's never heard of your fork (a session environment that only added
+  the upstream repo, or a fresh clone every session). This is usually the right choice for
+  overriding the remote specifically, since it has no dependency on a particular remote alias
+  existing.
 
 Whether you need to override the default branch name depends on how your sessions start:
 
@@ -81,33 +98,37 @@ It resolves the branch/path exactly like `session-start.sh` does, strips the hea
 pushes only your actual notes content — in a scratch worktree, so your current branch and working
 tree are untouched, and as a no-op if nothing actually changed.
 
-## Setup: overriding the default branch/path
+## Setup: overriding the default remote/branch/path
 
-Skip this section if the zero-config default above is all you need.
+Skip this section if the zero-config default above is all you need. The three settings are
+independent — override only the one(s) you actually need (e.g. just the remote, if your fork isn't
+this clone's `origin` but the default branch/path are fine).
 
 ### Persistent local clone
 
 Once per clone, never committed:
 
 ```bash
+git config claude.personalNotesRemote <remote-name-or-url>   # optional, defaults to origin
 git config claude.personalNotesBranch <your-branch-name>
 git config claude.personalNotesPath   <path-on-that-branch>   # optional, defaults to
                                                                  # .claude/personal/cram-notes.md
 ```
 
-Push your notes file to that branch on `origin` (any branch name, any path — it never merges
+Push your notes file to that branch on that remote (any branch name, any path — it never merges
 anywhere), e.g. by running the branch-creation script with overrides:
 
 ```bash
-CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name> CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch> \
+CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url> \
+  CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name> CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch> \
   "$CLAUDE_PROJECT_DIR/.claude/hooks/create-personal-notes-branch.sh"
 ```
 
 ### Cloud/web sessions (fresh clone every time)
 
-Push your notes file to `origin` exactly as above first. Then wire the environment variable into
-your session environment's configuration — which of the two options below applies depends on what
-your specific environment offers:
+Push your notes file exactly as above first. Then wire the environment variables into your session
+environment's configuration — which of the two options below applies depends on what your specific
+environment offers:
 
 ### Option A: your environment has a persistent environment-variable list
 
@@ -115,6 +136,7 @@ Copy [`personal-notes.env.example`](./personal-notes.env.example) into that list
 values substituted:
 
 ```
+CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url>
 CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>
 ```
@@ -123,19 +145,20 @@ CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>
 
 ### Option B: your environment has a "setup script" (arbitrary commands run on every fresh clone)
 
-Set the same two variables however that setup script can see them (its own env-var mechanism, or
+Set the same variables however that setup script can see them (its own env-var mechanism, or
 literal `export` lines above the call), then run
 [`configure-personal-notes.sh`](./configure-personal-notes.sh), e.g.:
 
 ```bash
+export CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url>   # optional
 export CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 export CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>   # optional
 "$CLAUDE_PROJECT_DIR/.claude/hooks/configure-personal-notes.sh"
 ```
 
 This seeds the fresh clone's git config from those variables, so `session-start.sh` finds them
-exactly as it would for a persistent local clone. It's a no-op if
-`CLAUDE_PERSONAL_NOTES_BRANCH` isn't set, so it's safe to include even before you've opted in.
+exactly as it would for a persistent local clone. It's a no-op if none of the three are set, so
+it's safe to include even before you've opted in.
 
 See your environment provider's docs for exactly where to paste a setup script or persistent
 environment variables (for Claude Code on the web: <https://code.claude.com/docs/en/claude-code-on-the-web>).
@@ -154,12 +177,13 @@ directly:
 
 - No-op in effect for anyone who never creates the `claude/personal-notes` branch (or an override
   target): `git fetch` finds nothing, so nothing gets written.
-- Never merges anything: the hook only ever *reads* the resolved branch via `git show`. It never
-  checks it out or merges it into your working branch.
+- Never merges anything: the hook only ever *reads* the resolved branch, off `FETCH_HEAD` via `git
+  show` (not a `<remote>/<branch>` ref, since a URL-form remote creates no tracking ref for one). It
+  never checks the branch out or merges it into your working branch.
 - `create-personal-notes-branch.sh` and `save-personal-notes.sh` never touch your current branch or
   working tree either — both do their work in a scratch worktree.
   `create-personal-notes-branch.sh` refuses to run if the target branch already exists locally or
-  on `origin`; `save-personal-notes.sh` is a no-op if there's nothing new to push.
+  on the resolved remote; `save-personal-notes.sh` is a no-op if there's nothing new to push.
 - The sync header `session-start.sh` writes is never itself pushed back: `save-personal-notes.sh`
   strips everything up to and including the `END-PERSONAL-NOTES-HEADER` marker before committing,
   so only your actual notes content ever lands on the notes branch.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,120 @@
+# Personal Claude Code notes hook
+
+An opt-in `SessionStart` hook that populates `CLAUDE.local.md` — which Claude Code already loads
+automatically as project memory, and which is gitignored — from a personal branch you name for
+yourself on `origin`, so your own workflow preferences ("always open my PRs as drafts," "never
+touch branch X directly," etc.) persist across sessions without ever being committed to a shared
+branch.
+
+It is a complete no-op until you opt in, and collision-free for multiple contributors sharing one
+`origin` remote, because each contributor points at their own branch name via their own config
+rather than one hardcoded literal.
+
+## How it decides what to read
+
+`session-start.sh` looks for a branch name in this order, first one found wins:
+
+1. **`git config claude.personalNotesBranch`** — local to one clone's `.git/config`.
+2. **`CLAUDE_PERSONAL_NOTES_BRANCH` environment variable** — used only if the git config isn't set.
+
+The path on that branch follows the same precedence (`claude.personalNotesPath` git config, then
+`CLAUDE_PERSONAL_NOTES_PATH` env var, then the default `.claude/personal/cram-notes.md`).
+
+If neither the git config nor the environment variable is set, the hook exits immediately: no
+fetch, no write, no effect.
+
+Which one you need depends on how your sessions start:
+
+- **A persistent local clone** (you `git clone` once and keep working in it) → use git config. It's
+  set once and stays in that clone's `.git/config` forever.
+- **A fresh clone every session** (e.g. a cloud/web session environment that clones the repo from
+  scratch each time) → git config **will not work**: `.git/config` is part of the fresh clone, so
+  whatever you set there is gone by the next session. Use the environment variable instead,
+  configured once at the environment level (outside the repo), so it survives every fresh clone.
+
+## Setup: persistent local clone
+
+Once per clone, never committed:
+
+```bash
+git config claude.personalNotesBranch <your-branch-name>
+git config claude.personalNotesPath   <path-on-that-branch>   # optional, defaults to
+                                                                 # .claude/personal/cram-notes.md
+```
+
+Push your notes file to that branch on `origin` (any branch name, any path — it never merges
+anywhere):
+
+```bash
+git checkout --orphan <your-branch-name>
+git rm -rf --cached .
+mkdir -p .claude/personal
+echo "- your notes here" > .claude/personal/cram-notes.md
+git add .claude/personal/cram-notes.md
+git commit -m "personal notes"
+git push origin <your-branch-name>
+```
+
+Every new Claude Code session in this clone now runs the hook automatically and writes
+`CLAUDE.local.md` from that branch.
+
+## Setup: cloud/web sessions (fresh clone every time)
+
+Push your notes file to `origin` exactly as above first. Then wire the environment variable into
+your session environment's configuration — which of the two options below applies depends on what
+your specific environment offers:
+
+### Option A: your environment has a persistent environment-variable list
+
+Copy [`personal-notes.env.example`](./personal-notes.env.example) into that list, with your own
+values substituted:
+
+```
+CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
+CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>
+```
+
+`session-start.sh` reads these directly — nothing else to configure.
+
+### Option B: your environment has a "setup script" (arbitrary commands run on every fresh clone)
+
+Set the same two variables however that setup script can see them (its own env-var mechanism, or
+literal `export` lines above the call), then run
+[`configure-personal-notes.sh`](./configure-personal-notes.sh), e.g.:
+
+```bash
+export CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
+export CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>   # optional
+"$CLAUDE_PROJECT_DIR/.claude/hooks/configure-personal-notes.sh"
+```
+
+This seeds the fresh clone's git config from those variables, so `session-start.sh` finds them
+exactly as it would for a persistent local clone. It's a no-op if
+`CLAUDE_PERSONAL_NOTES_BRANCH` isn't set, so it's safe to include even before you've opted in.
+
+See your environment provider's docs for exactly where to paste a setup script or persistent
+environment variables (for Claude Code on the web: <https://code.claude.com/docs/en/claude-code-on-the-web>).
+
+## Verifying it worked
+
+Start a fresh session and check whether `CLAUDE.local.md` exists at the project root with your
+notes content. To check the mechanics without waiting for a real session boot, run the hook
+directly:
+
+```bash
+"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" && cat CLAUDE.local.md
+```
+
+## Safety
+
+- No-op by default: nothing happens for anyone who hasn't configured either the git config or the
+  environment variable.
+- Never merges anything: the hook only ever *reads* the configured branch via `git show`. It never
+  checks it out or merges it into your working branch.
+- `CLAUDE.local.md` is gitignored, so populated notes can't accidentally end up in a commit on any
+  branch, including this one.
+- Safe to re-run: it only ever overwrites `CLAUDE.local.md`, and does nothing if the configured
+  branch or path isn't reachable (e.g. a fresh clone, or a fork that never created it).
+- Coexists with your own hooks: Claude Code merges `SessionStart` hook arrays across all settings
+  layers by concatenation, not override, so this hook runs alongside — never instead of — any
+  `SessionStart` hook you already have configured for yourself.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,9 +6,11 @@ yourself on `origin`, so your own workflow preferences ("always open my PRs as d
 touch branch X directly," etc.) persist across sessions without ever being committed to a shared
 branch.
 
-It is a complete no-op until you opt in, and collision-free for multiple contributors sharing one
-`origin` remote, because each contributor points at their own branch name via their own config
-rather than one hardcoded literal.
+It works out of the box with no config at all: it reads from a branch named `claude/personal-notes`
+on `origin` unless you tell it otherwise. Run [`create-personal-notes-branch.sh`](./create-personal-notes-branch.sh)
+once to create that branch with an empty notes file, and every session from then on picks it up
+automatically. It is collision-free for multiple contributors sharing one `origin` remote if you
+each override the branch name via your own config instead of relying on the shared default.
 
 ## How it decides what to read
 
@@ -16,23 +18,53 @@ rather than one hardcoded literal.
 
 1. **`git config claude.personalNotesBranch`** — local to one clone's `.git/config`.
 2. **`CLAUDE_PERSONAL_NOTES_BRANCH` environment variable** — used only if the git config isn't set.
+3. **`claude/personal-notes`** — the zero-config default, used if neither of the above is set.
 
 The path on that branch follows the same precedence (`claude.personalNotesPath` git config, then
 `CLAUDE_PERSONAL_NOTES_PATH` env var, then the default `.claude/personal/cram-notes.md`).
 
-If neither the git config nor the environment variable is set, the hook exits immediately: no
-fetch, no write, no effect.
+The hook is still a no-op in effect for anyone who never creates the branch it resolves to: `git
+fetch` finds nothing, so it exits without writing `CLAUDE.local.md`.
 
-Which one you need depends on how your sessions start:
+Whether you need to override the default branch name depends on how your sessions start:
 
-- **A persistent local clone** (you `git clone` once and keep working in it) → use git config. It's
-  set once and stays in that clone's `.git/config` forever.
+- **A persistent local clone** (you `git clone` once and keep working in it) → the default just
+  works once you've run the setup script below. Only set git config if you want a different
+  branch/path than the shared default (e.g. to keep your notes separate from other contributors').
 - **A fresh clone every session** (e.g. a cloud/web session environment that clones the repo from
-  scratch each time) → git config **will not work**: `.git/config` is part of the fresh clone, so
-  whatever you set there is gone by the next session. Use the environment variable instead,
-  configured once at the environment level (outside the repo), so it survives every fresh clone.
+  scratch each time) → the default still just works, since it needs no `.git/config` entry to
+  survive. Only set the environment variable if you want to override it — see Option A below.
 
-## Setup: persistent local clone
+## Setup: quick start (works for both persistent and fresh-clone sessions)
+
+Once, from any clone with push access to `origin`:
+
+```bash
+"$CLAUDE_PROJECT_DIR/.claude/hooks/create-personal-notes-branch.sh"
+```
+
+This creates `claude/personal-notes` on `origin` with a single empty
+`.claude/personal/cram-notes.md`, without touching your current branch or working tree. Then edit
+that file (see below) to add your own notes. Every new Claude Code session — local or fresh-clone —
+now runs the hook automatically and writes `CLAUDE.local.md` from that branch, with no further
+configuration needed.
+
+To edit your notes after the branch exists:
+
+```bash
+git fetch origin claude/personal-notes
+git worktree add /tmp/personal-notes origin/claude/personal-notes
+$EDITOR /tmp/personal-notes/.claude/personal/cram-notes.md
+git -C /tmp/personal-notes commit -am "update personal notes"
+git -C /tmp/personal-notes push origin HEAD:claude/personal-notes
+git worktree remove /tmp/personal-notes
+```
+
+## Setup: overriding the default branch/path
+
+Skip this section if the zero-config default above is all you need.
+
+### Persistent local clone
 
 Once per clone, never committed:
 
@@ -43,22 +75,14 @@ git config claude.personalNotesPath   <path-on-that-branch>   # optional, defaul
 ```
 
 Push your notes file to that branch on `origin` (any branch name, any path — it never merges
-anywhere):
+anywhere), e.g. by running the branch-creation script with overrides:
 
 ```bash
-git checkout --orphan <your-branch-name>
-git rm -rf --cached .
-mkdir -p .claude/personal
-echo "- your notes here" > .claude/personal/cram-notes.md
-git add .claude/personal/cram-notes.md
-git commit -m "personal notes"
-git push origin <your-branch-name>
+CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name> CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch> \
+  "$CLAUDE_PROJECT_DIR/.claude/hooks/create-personal-notes-branch.sh"
 ```
 
-Every new Claude Code session in this clone now runs the hook automatically and writes
-`CLAUDE.local.md` from that branch.
-
-## Setup: cloud/web sessions (fresh clone every time)
+### Cloud/web sessions (fresh clone every time)
 
 Push your notes file to `origin` exactly as above first. Then wire the environment variable into
 your session environment's configuration — which of the two options below applies depends on what
@@ -107,14 +131,18 @@ directly:
 
 ## Safety
 
-- No-op by default: nothing happens for anyone who hasn't configured either the git config or the
-  environment variable.
-- Never merges anything: the hook only ever *reads* the configured branch via `git show`. It never
+- No-op in effect for anyone who never creates the `claude/personal-notes` branch (or an override
+  target): `git fetch` finds nothing, so nothing gets written.
+- Never merges anything: the hook only ever *reads* the resolved branch via `git show`. It never
   checks it out or merges it into your working branch.
+- `create-personal-notes-branch.sh` never touches your current branch or working tree either — it
+  does its work in a scratch worktree and refuses to run if the target branch already exists
+  locally or on `origin`.
 - `CLAUDE.local.md` is gitignored, so populated notes can't accidentally end up in a commit on any
   branch, including this one.
-- Safe to re-run: it only ever overwrites `CLAUDE.local.md`, and does nothing if the configured
-  branch or path isn't reachable (e.g. a fresh clone, or a fork that never created it).
+- Safe to re-run: `session-start.sh` only ever overwrites `CLAUDE.local.md`, and does nothing if
+  the resolved branch or path isn't reachable (e.g. a fresh clone, or a fork that never created
+  it).
 - Coexists with your own hooks: Claude Code merges `SessionStart` hook arrays across all settings
   layers by concatenation, not override, so this hook runs alongside — never instead of — any
   `SessionStart` hook you already have configured for yourself.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -102,24 +102,67 @@ remote actually served the notes (the resolved one, or the fallback):
 <!--
 Personal notes, synced from 'claude/personal-notes' (.claude/personal/cram-notes.md) on remote
 'origin' by session-start.sh.
-To edit: change the notes below this line, then run
+To edit: change the notes between the markers below, then run
   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
-to push the change back. This header is regenerated every session from git
-config/environment/default (plus a same-branch-upstream fallback) - editing
-it has no effect.
+to push the change back. This header and the markers are regenerated every
+session from git config/environment/default (plus a same-branch-upstream
+fallback) - editing them has no effect; only content between the markers is
+ever saved.
 -->
-<!-- END-PERSONAL-NOTES-HEADER -->
+<!-- BEGIN-PERSONAL-NOTES -->
+<!-- END-PERSONAL-NOTES -->
 ```
 
-To do it by hand instead: edit `CLAUDE.local.md` below that marker line, then run
+To do it by hand instead: edit `CLAUDE.local.md` between those two marker lines, then run
 
 ```bash
 "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
 ```
 
-It resolves the branch/path exactly like `session-start.sh` does, strips the header back out, and
-pushes only your actual notes content — in a scratch worktree, so your current branch and working
-tree are untouched, and as a no-op if nothing actually changed.
+It resolves the branch/path exactly like `session-start.sh` does, extracts only what's between the
+markers, and pushes just that — in a scratch worktree, so your current branch and working tree are
+untouched, and as a no-op if nothing actually changed.
+
+## Tracking a PR's plan and progress
+
+On any branch with a sensible "current PR" — not the default branch, a detached `HEAD`, or the
+personal-notes branch itself — `CLAUDE.local.md` also gets a second section, keyed to that branch,
+for the plan/progress/next-steps of whatever you're working on. Like the notes above, it's stored
+only on the personal-notes branch (at `.claude/personal/pr-progress/<branch-name>.md`), so it can
+never end up committed to the PR branch, or merged when the PR merges — that's a property of where
+it's stored, not a rule anyone has to remember.
+
+It's always present on a qualifying branch, even before anything's been saved — as a scaffold
+prompting you (or Claude) to initialize it — so the section is there to nudge maintaining it from
+the first session on a new PR, not only once something already exists:
+
+```
+<!--
+PR progress for branch 'my-feature-branch', synced from 'claude/personal-notes'
+(.claude/personal/pr-progress/my-feature-branch.md) on remote 'origin' by
+session-start.sh. Maintain the current plan, what's done, and what's next
+here throughout work on this PR. It is never merged: it lives only on
+'claude/personal-notes', never on this branch. A stale file left behind after the
+PR merges is harmless (just unread from then on) - delete it directly on
+'claude/personal-notes' if you want to tidy it up.
+To edit: change the notes between the markers below, then run
+  "$CLAUDE_PROJECT_DIR/.claude/hooks/save-pr-progress.sh"
+to push the change back. This header and the markers are regenerated every
+session - editing them has no effect; only content between the markers is
+ever saved.
+-->
+<!-- BEGIN-PR-PROGRESS -->
+No progress recorded yet for this branch. Initialize it now: a short plan,
+what's done so far, and what's next. Keep it current as you work.
+<!-- END-PR-PROGRESS -->
+```
+
+Ask Claude to keep it updated the same way as your notes: it edits between the `BEGIN-PR-PROGRESS`/
+`END-PR-PROGRESS` markers, then runs [`save-pr-progress.sh`](./save-pr-progress.sh) — which resolves
+the same remote/branch as everything else, derives the path from whichever branch is currently
+checked out (never configured directly, so one PR's progress can't accidentally get saved under
+another PR's key), extracts only what's between its own markers, and pushes just that. A good anchor
+for *when* to save: whenever the plan changes, and before ending any turn that changed it.
 
 ## Setup: overriding the default remote/branch/path
 
@@ -204,14 +247,19 @@ directly:
 - Never merges anything: the hook only ever *reads* the resolved branch, off `FETCH_HEAD` via `git
   show` (not a `<remote>/<branch>` ref, since a URL-form remote creates no tracking ref for one). It
   never checks the branch out or merges it into your working branch.
-- `create-personal-notes-branch.sh` and `save-personal-notes.sh` never touch your current branch or
-  working tree either — both do their work in a scratch worktree.
+- `create-personal-notes-branch.sh`, `save-personal-notes.sh` and `save-pr-progress.sh` never touch
+  your current branch or working tree either — all three do their work in a scratch worktree.
   `create-personal-notes-branch.sh` refuses to run if the target branch already exists locally, on
-  the resolved remote, or on the upstream-tracking fallback remote (see above);
-  `save-personal-notes.sh` is a no-op if there's nothing new to push.
-- The sync header `session-start.sh` writes is never itself pushed back: `save-personal-notes.sh`
-  strips everything up to and including the `END-PERSONAL-NOTES-HEADER` marker before committing,
-  so only your actual notes content ever lands on the notes branch.
+  the resolved remote, or on the upstream-tracking fallback remote (see above); the two save scripts
+  are each a no-op if there's nothing new to push.
+- The sync headers `session-start.sh` writes are never themselves pushed back: `save-personal-notes.sh`
+  and `save-pr-progress.sh` each extract only the content between their own markers
+  (`BEGIN-PERSONAL-NOTES`/`END-PERSONAL-NOTES` and `BEGIN-PR-PROGRESS`/`END-PR-PROGRESS`
+  respectively) before committing, so neither header, and neither script's section, can ever leak
+  into the other's saved content.
+- PR-progress content is never merged, by construction: it is written only to the branch-keyed path
+  on the personal-notes branch, never to any file tracked on the PR branch itself, so there is no
+  code path by which it could end up in a commit that gets merged.
 - `CLAUDE.local.md` is gitignored, so populated notes can't accidentally end up in a commit on any
   branch, including this one.
 - Safe to re-run: `session-start.sh` only ever overwrites `CLAUDE.local.md`, and does nothing if

--- a/.claude/hooks/configure-personal-notes.sh
+++ b/.claude/hooks/configure-personal-notes.sh
@@ -7,28 +7,33 @@ set -euo pipefail
 # as opposed to a persistent environment-variable list) if that's what your
 # environment offers instead of persistent environment variables.
 #
-# It reads the same two variable names as ./personal-notes.env.example
-# (CLAUDE_PERSONAL_NOTES_BRANCH, CLAUDE_PERSONAL_NOTES_PATH) and seeds them
-# into this fresh clone's git config, so session-start.sh finds them there
-# exactly as it would for a persistent local clone where you ran `git config`
-# yourself once. Set the two variables however your environment lets you
-# (its own persistent-environment-variable feature, or literal `export` lines
-# pasted above the call to this script) - this script only turns them into
-# git config, it does not define them itself, so it stays generic: nothing
-# here is specific to any one contributor's branch name.
+# It reads the same three variable names as ./personal-notes.env.example
+# (CLAUDE_PERSONAL_NOTES_REMOTE, CLAUDE_PERSONAL_NOTES_BRANCH,
+# CLAUDE_PERSONAL_NOTES_PATH) and seeds them into this fresh clone's git
+# config, so session-start.sh finds them there exactly as it would for a
+# persistent local clone where you ran `git config` yourself once. Set the
+# variables however your environment lets you (its own
+# persistent-environment-variable feature, or literal `export` lines pasted
+# above the call to this script) - this script only turns them into git
+# config, it does not define them itself, so it stays generic: nothing here
+# is specific to any one contributor's branch name or fork.
 #
-# No-op (exit 0, no git config written) if CLAUDE_PERSONAL_NOTES_BRANCH isn't
-# set, so it's always safe to include in a setup script even before you've
-# opted in.
+# No-op (exit 0, no git config written) if none of the three are set, so it's
+# always safe to include in a setup script even before you've opted in. Each
+# of the three is otherwise independent: set only CLAUDE_PERSONAL_NOTES_REMOTE
+# if you just need to point at a fork that isn't this clone's `origin`, while
+# keeping the default branch/path.
 #
 # Safe to re-run: `git config` simply overwrites the previous value.
 
+NOTES_REMOTE="${CLAUDE_PERSONAL_NOTES_REMOTE:-}"
 NOTES_BRANCH="${CLAUDE_PERSONAL_NOTES_BRANCH:-}"
-[ -n "${NOTES_BRANCH}" ] || exit 0
-
-git config claude.personalNotesBranch "${NOTES_BRANCH}"
-
 NOTES_PATH="${CLAUDE_PERSONAL_NOTES_PATH:-}"
-if [ -n "${NOTES_PATH}" ]; then
-  git config claude.personalNotesPath "${NOTES_PATH}"
+
+if [ -z "${NOTES_REMOTE}" ] && [ -z "${NOTES_BRANCH}" ] && [ -z "${NOTES_PATH}" ]; then
+  exit 0
 fi
+
+[ -z "${NOTES_REMOTE}" ] || git config claude.personalNotesRemote "${NOTES_REMOTE}"
+[ -z "${NOTES_BRANCH}" ] || git config claude.personalNotesBranch "${NOTES_BRANCH}"
+[ -z "${NOTES_PATH}" ] || git config claude.personalNotesPath "${NOTES_PATH}"

--- a/.claude/hooks/configure-personal-notes.sh
+++ b/.claude/hooks/configure-personal-notes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generic environment-setup script for the personal-notes SessionStart hook
+# (./session-start.sh). Paste this into your cloud/web session environment's
+# "setup script" (a field that runs arbitrary commands on every fresh clone,
+# as opposed to a persistent environment-variable list) if that's what your
+# environment offers instead of persistent environment variables.
+#
+# It reads the same two variable names as ./personal-notes.env.example
+# (CLAUDE_PERSONAL_NOTES_BRANCH, CLAUDE_PERSONAL_NOTES_PATH) and seeds them
+# into this fresh clone's git config, so session-start.sh finds them there
+# exactly as it would for a persistent local clone where you ran `git config`
+# yourself once. Set the two variables however your environment lets you
+# (its own persistent-environment-variable feature, or literal `export` lines
+# pasted above the call to this script) - this script only turns them into
+# git config, it does not define them itself, so it stays generic: nothing
+# here is specific to any one contributor's branch name.
+#
+# No-op (exit 0, no git config written) if CLAUDE_PERSONAL_NOTES_BRANCH isn't
+# set, so it's always safe to include in a setup script even before you've
+# opted in.
+#
+# Safe to re-run: `git config` simply overwrites the previous value.
+
+NOTES_BRANCH="${CLAUDE_PERSONAL_NOTES_BRANCH:-}"
+[ -n "${NOTES_BRANCH}" ] || exit 0
+
+git config claude.personalNotesBranch "${NOTES_BRANCH}"
+
+NOTES_PATH="${CLAUDE_PERSONAL_NOTES_PATH:-}"
+if [ -n "${NOTES_PATH}" ]; then
+  git config claude.personalNotesPath "${NOTES_PATH}"
+fi

--- a/.claude/hooks/create-personal-notes-branch.sh
+++ b/.claude/hooks/create-personal-notes-branch.sh
@@ -10,8 +10,10 @@ set -euo pipefail
 # Usage (from anywhere inside the repo):
 #   ./.claude/hooks/create-personal-notes-branch.sh
 #
-# Override the branch/path if you don't want the defaults (matches the same
-# two variable names session-start.sh and configure-personal-notes.sh read):
+# Resolves the branch/path the same way session-start.sh does (git config >
+# environment variable > default), so it always targets whatever a fresh
+# session would actually read from. Override via the same two variable names
+# it and configure-personal-notes.sh read:
 #   CLAUDE_PERSONAL_NOTES_BRANCH=<branch> CLAUDE_PERSONAL_NOTES_PATH=<path> \
 #     ./.claude/hooks/create-personal-notes-branch.sh
 #
@@ -19,8 +21,8 @@ set -euo pipefail
 # origin, so it never overwrites existing notes. Does its work in a scratch
 # worktree, so it never touches your current branch or working tree.
 
-NOTES_BRANCH="${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}"
-NOTES_PATH="${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
 
 if git show-ref --verify --quiet "refs/heads/${NOTES_BRANCH}"; then
   echo "Branch '${NOTES_BRANCH}' already exists locally - not touching it." >&2

--- a/.claude/hooks/create-personal-notes-branch.sh
+++ b/.claude/hooks/create-personal-notes-branch.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # and pushes it - so session-start.sh has something to read out of the box,
 # with no config needed on your end.
 #
-# Usage (from anywhere inside the repo):
+# Usage (from anywhere - always operates on this repo specifically, see
+# resolve-personal-notes-config.sh):
 #   ./.claude/hooks/create-personal-notes-branch.sh
 #
 # Resolves the remote/branch/path the same way session-start.sh does (git

--- a/.claude/hooks/create-personal-notes-branch.sh
+++ b/.claude/hooks/create-personal-notes-branch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# One-time helper: creates the personal-notes branch (default:
+# `claude/personal-notes`) on `origin` with a single empty notes file at the
+# default path (`.claude/personal/cram-notes.md`), and pushes it - so
+# session-start.sh has something to read out of the box, with no config
+# needed on your end.
+#
+# Usage (from anywhere inside the repo):
+#   ./.claude/hooks/create-personal-notes-branch.sh
+#
+# Override the branch/path if you don't want the defaults (matches the same
+# two variable names session-start.sh and configure-personal-notes.sh read):
+#   CLAUDE_PERSONAL_NOTES_BRANCH=<branch> CLAUDE_PERSONAL_NOTES_PATH=<path> \
+#     ./.claude/hooks/create-personal-notes-branch.sh
+#
+# Safe to re-run: refuses to touch a branch that already exists locally or on
+# origin, so it never overwrites existing notes. Does its work in a scratch
+# worktree, so it never touches your current branch or working tree.
+
+NOTES_BRANCH="${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}"
+NOTES_PATH="${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}"
+
+if git show-ref --verify --quiet "refs/heads/${NOTES_BRANCH}"; then
+  echo "Branch '${NOTES_BRANCH}' already exists locally - not touching it." >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code --heads origin "${NOTES_BRANCH}" > /dev/null 2>&1; then
+  echo "Branch '${NOTES_BRANCH}' already exists on origin - not touching it." >&2
+  exit 1
+fi
+
+SCRATCH_DIR="$(mktemp -d)"
+trap 'git worktree remove --force "${SCRATCH_DIR}" 2>/dev/null || rm -rf "${SCRATCH_DIR}"' EXIT
+
+git worktree add --orphan -b "${NOTES_BRANCH}" "${SCRATCH_DIR}" --quiet
+git -C "${SCRATCH_DIR}" rm -rf --quiet . > /dev/null 2>&1 || true
+
+mkdir -p "${SCRATCH_DIR}/$(dirname "${NOTES_PATH}")"
+: > "${SCRATCH_DIR}/${NOTES_PATH}"
+
+git -C "${SCRATCH_DIR}" add "${NOTES_PATH}"
+git -C "${SCRATCH_DIR}" commit --quiet -m "Initialize personal notes branch"
+git -C "${SCRATCH_DIR}" push origin "${NOTES_BRANCH}"
+
+git worktree remove --force "${SCRATCH_DIR}"
+git branch -D "${NOTES_BRANCH}" > /dev/null
+trap - EXIT
+
+echo "Created and pushed '${NOTES_BRANCH}' with an empty '${NOTES_PATH}'."
+echo "Your current branch and working tree are untouched."

--- a/.claude/hooks/create-personal-notes-branch.sh
+++ b/.claude/hooks/create-personal-notes-branch.sh
@@ -19,9 +19,16 @@ set -euo pipefail
 #     ./.claude/hooks/create-personal-notes-branch.sh
 # See ./README.md for when a remote name vs. a raw URL is the right choice.
 #
-# Safe to re-run: refuses to touch a branch that already exists locally or on
-# the remote, so it never overwrites existing notes. Does its work in a
-# scratch worktree, so it never touches your current branch or working tree.
+# Safe to re-run: refuses to touch a branch that already exists locally, on
+# the resolved remote, or on the current branch's own upstream remote (see
+# current_branch_upstream_remote in ./resolve-personal-notes-config.sh) - so
+# it never overwrites existing notes, and never creates a second, divergent
+# copy of a branch that fetch_personal_notes_branch's fallback would already
+# have found on read. It always creates on the resolved remote specifically,
+# though, never on the fallback one - creation is a deliberate act, so it
+# targets exactly what you configured (or the zero-config default), with no
+# surprises. Does its work in a scratch worktree, so it never touches your
+# current branch or working tree.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
@@ -33,6 +40,15 @@ fi
 
 if git ls-remote --exit-code --heads "${NOTES_REMOTE}" "${NOTES_BRANCH}" > /dev/null 2>&1; then
   echo "Branch '${NOTES_BRANCH}' already exists on '${NOTES_REMOTE}' - not touching it." >&2
+  exit 1
+fi
+
+UPSTREAM_REMOTE="$(current_branch_upstream_remote)"
+if [ -n "${UPSTREAM_REMOTE}" ] && [ "${UPSTREAM_REMOTE}" != "${NOTES_REMOTE}" ] \
+    && git ls-remote --exit-code --heads "${UPSTREAM_REMOTE}" "${NOTES_BRANCH}" > /dev/null 2>&1; then
+  echo "Branch '${NOTES_BRANCH}' already exists on '${UPSTREAM_REMOTE}' (this branch's upstream" >&2
+  echo "remote) - not creating a second copy on '${NOTES_REMOTE}'. session-start.sh and" >&2
+  echo "save-personal-notes.sh already fall back to '${UPSTREAM_REMOTE}' automatically." >&2
   exit 1
 fi
 

--- a/.claude/hooks/create-personal-notes-branch.sh
+++ b/.claude/hooks/create-personal-notes-branch.sh
@@ -2,24 +2,26 @@
 set -euo pipefail
 
 # One-time helper: creates the personal-notes branch (default:
-# `claude/personal-notes`) on `origin` with a single empty notes file at the
-# default path (`.claude/personal/cram-notes.md`), and pushes it - so
-# session-start.sh has something to read out of the box, with no config
-# needed on your end.
+# `claude/personal-notes`) on a remote (default: `origin`) with a single
+# empty notes file at the default path (`.claude/personal/cram-notes.md`),
+# and pushes it - so session-start.sh has something to read out of the box,
+# with no config needed on your end.
 #
 # Usage (from anywhere inside the repo):
 #   ./.claude/hooks/create-personal-notes-branch.sh
 #
-# Resolves the branch/path the same way session-start.sh does (git config >
-# environment variable > default), so it always targets whatever a fresh
-# session would actually read from. Override via the same two variable names
-# it and configure-personal-notes.sh read:
-#   CLAUDE_PERSONAL_NOTES_BRANCH=<branch> CLAUDE_PERSONAL_NOTES_PATH=<path> \
+# Resolves the remote/branch/path the same way session-start.sh does (git
+# config > environment variable > default), so it always targets whatever a
+# fresh session would actually read from. Override via the same variable
+# names it and configure-personal-notes.sh read:
+#   CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url> \
+#     CLAUDE_PERSONAL_NOTES_BRANCH=<branch> CLAUDE_PERSONAL_NOTES_PATH=<path> \
 #     ./.claude/hooks/create-personal-notes-branch.sh
+# See ./README.md for when a remote name vs. a raw URL is the right choice.
 #
 # Safe to re-run: refuses to touch a branch that already exists locally or on
-# origin, so it never overwrites existing notes. Does its work in a scratch
-# worktree, so it never touches your current branch or working tree.
+# the remote, so it never overwrites existing notes. Does its work in a
+# scratch worktree, so it never touches your current branch or working tree.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
@@ -29,8 +31,8 @@ if git show-ref --verify --quiet "refs/heads/${NOTES_BRANCH}"; then
   exit 1
 fi
 
-if git ls-remote --exit-code --heads origin "${NOTES_BRANCH}" > /dev/null 2>&1; then
-  echo "Branch '${NOTES_BRANCH}' already exists on origin - not touching it." >&2
+if git ls-remote --exit-code --heads "${NOTES_REMOTE}" "${NOTES_BRANCH}" > /dev/null 2>&1; then
+  echo "Branch '${NOTES_BRANCH}' already exists on '${NOTES_REMOTE}' - not touching it." >&2
   exit 1
 fi
 
@@ -45,7 +47,7 @@ mkdir -p "${SCRATCH_DIR}/$(dirname "${NOTES_PATH}")"
 
 git -C "${SCRATCH_DIR}" add "${NOTES_PATH}"
 git -C "${SCRATCH_DIR}" commit --quiet -m "Initialize personal notes branch"
-git -C "${SCRATCH_DIR}" push origin "${NOTES_BRANCH}"
+git -C "${SCRATCH_DIR}" push "${NOTES_REMOTE}" "${NOTES_BRANCH}"
 
 git worktree remove --force "${SCRATCH_DIR}"
 git branch -D "${NOTES_BRANCH}" > /dev/null

--- a/.claude/hooks/personal-notes.env.example
+++ b/.claude/hooks/personal-notes.env.example
@@ -1,0 +1,19 @@
+# Environment variables for the personal-notes SessionStart hook
+# (.claude/hooks/session-start.sh), for anywhere sessions start from a fresh
+# clone every time (e.g. a cloud/web session environment) and so can't rely
+# on the git-config opt-in, which lives in the per-clone .git/config and
+# would be empty again on the next fresh clone.
+#
+# This file is a template: copy the two lines below into your environment's
+# persistent environment-variable configuration (outside this repo, so it
+# survives every fresh clone), with your own values substituted. Do not
+# commit a copy of this file with real values filled in.
+#
+# git config still wins if you also set it locally, so this is purely a
+# fallback default for sessions that never get a chance to run `git config`
+# themselves. Both variables are optional independently of each other:
+# CLAUDE_PERSONAL_NOTES_PATH only matters once CLAUDE_PERSONAL_NOTES_BRANCH
+# is set, and defaults to .claude/personal/cram-notes.md if omitted.
+
+CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
+CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>

--- a/.claude/hooks/personal-notes.env.example
+++ b/.claude/hooks/personal-notes.env.example
@@ -14,6 +14,10 @@
 # themselves. Both variables are optional independently of each other:
 # CLAUDE_PERSONAL_NOTES_PATH only matters once CLAUDE_PERSONAL_NOTES_BRANCH
 # is set, and defaults to .claude/personal/cram-notes.md if omitted.
+#
+# You only need this file at all if you want a branch/path other than the
+# hook's own zero-config default (`claude/personal-notes` /
+# .claude/personal/cram-notes.md, see ./create-personal-notes-branch.sh).
 
 CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>

--- a/.claude/hooks/personal-notes.env.example
+++ b/.claude/hooks/personal-notes.env.example
@@ -4,20 +4,27 @@
 # on the git-config opt-in, which lives in the per-clone .git/config and
 # would be empty again on the next fresh clone.
 #
-# This file is a template: copy the two lines below into your environment's
+# This file is a template: copy the lines below into your environment's
 # persistent environment-variable configuration (outside this repo, so it
 # survives every fresh clone), with your own values substituted. Do not
 # commit a copy of this file with real values filled in.
 #
 # git config still wins if you also set it locally, so this is purely a
 # fallback default for sessions that never get a chance to run `git config`
-# themselves. Both variables are optional independently of each other:
-# CLAUDE_PERSONAL_NOTES_PATH only matters once CLAUDE_PERSONAL_NOTES_BRANCH
-# is set, and defaults to .claude/personal/cram-notes.md if omitted.
+# themselves. All three variables are optional independently of each other -
+# set only the ones you need:
+# - CLAUDE_PERSONAL_NOTES_REMOTE defaults to `origin`. Only set it if your
+#   notes live on a remote other than this clone's `origin` (e.g. some
+#   session environments name the upstream repo `origin` and your own fork
+#   something else). Accepts either a remote already configured in the clone
+#   (by name) or a raw git URL (`https://github.com/<you>/<repo>`) - a URL
+#   needs no `git remote add` first. See ./README.md.
+# - CLAUDE_PERSONAL_NOTES_BRANCH defaults to `claude/personal-notes`.
+# - CLAUDE_PERSONAL_NOTES_PATH defaults to .claude/personal/cram-notes.md.
 #
-# You only need this file at all if you want a branch/path other than the
-# hook's own zero-config default (`claude/personal-notes` /
-# .claude/personal/cram-notes.md, see ./create-personal-notes-branch.sh).
+# You only need this file at all if you want a remote/branch/path other than
+# the hook's own zero-config default (see ./create-personal-notes-branch.sh).
 
+CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url>
 CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -1,0 +1,10 @@
+# Sourced (not executed) by session-start.sh, create-personal-notes-branch.sh
+# and save-personal-notes.sh, so all three resolve the personal-notes branch
+# and path with the exact same precedence: git config > environment variable
+# > the `claude/personal-notes` zero-config default. See ./README.md.
+
+NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
+NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}}"
+
+NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
+NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}}"

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -1,7 +1,28 @@
-# Sourced (not executed) by session-start.sh, create-personal-notes-branch.sh
-# and save-personal-notes.sh, so all three resolve the personal-notes remote,
-# branch and path with the exact same precedence: git config > environment
-# variable > the zero-config default. See ./README.md.
+# Sourced (not executed) by session-start.sh, create-personal-notes-branch.sh,
+# save-personal-notes.sh and save-pr-progress.sh, so all four resolve the
+# personal-notes remote, branch and path with the exact same precedence: git
+# config > environment variable > the zero-config default. See ./README.md.
+
+# CLAUDE_LOCAL_MD: the one, deterministic path to CLAUDE.local.md, always the
+# project root regardless of the caller's current working directory. Derived
+# from this file's own location on disk (${BASH_SOURCE[0]}, which - inside a
+# sourced file - is that file's own path, not the sourcing script's) rather
+# than $CLAUDE_PROJECT_DIR or the caller's cwd: a SessionStart hook's cwd
+# isn't guaranteed to be the project root (see session-start.sh), and these
+# scripts are also run directly, outside any hook, where nothing guarantees
+# $CLAUDE_PROJECT_DIR is set at all. This file always lives at
+# <project-root>/.claude/hooks/resolve-personal-notes-config.sh, so two
+# levels up from its own directory is always the project root, unconditionally.
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${HOOKS_DIR}/../.." && pwd)"
+CLAUDE_LOCAL_MD="${PROJECT_ROOT}/CLAUDE.local.md"
+
+# Every caller also does `git` operations (config, fetch, worktree, branch)
+# that assume they're running inside this repo. Move there explicitly instead
+# of trusting the invoking cwd to already be inside it (or inside it at all) -
+# git itself would otherwise auto-discover a *different* repo if run from
+# inside some other one, or fail outright if run from outside any repo.
+cd "${PROJECT_ROOT}"
 
 NOTES_REMOTE="$(git config --get claude.personalNotesRemote || true)"
 NOTES_REMOTE="${NOTES_REMOTE:-${CLAUDE_PERSONAL_NOTES_REMOTE:-origin}}"

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -1,10 +1,21 @@
 # Sourced (not executed) by session-start.sh, create-personal-notes-branch.sh
-# and save-personal-notes.sh, so all three resolve the personal-notes branch
-# and path with the exact same precedence: git config > environment variable
-# > the `claude/personal-notes` zero-config default. See ./README.md.
+# and save-personal-notes.sh, so all three resolve the personal-notes remote,
+# branch and path with the exact same precedence: git config > environment
+# variable > the zero-config default. See ./README.md.
+
+NOTES_REMOTE="$(git config --get claude.personalNotesRemote || true)"
+NOTES_REMOTE="${NOTES_REMOTE:-${CLAUDE_PERSONAL_NOTES_REMOTE:-origin}}"
 
 NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
 NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}}"
 
 NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
 NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}}"
+
+# NOTES_REMOTE may be either a configured remote's name (e.g. "origin") or a
+# raw git URL (e.g. "https://github.com/<you>/<repo>") - `git fetch`/`git
+# push` accept both interchangeably, and a URL needs no `git remote add`
+# first. Use a URL whenever your own fork isn't the clone's "origin" (for
+# example, some session environments name the upstream repo "origin" and your
+# fork something else) - the URL form works without depending on that
+# session-specific remote name/alias existing at all.

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -70,3 +70,24 @@ fetch_personal_notes_branch() {
 
   return 1
 }
+
+# pr_progress_path: prints the deterministic per-branch PR-progress file path
+# (.claude/personal/pr-progress/<branch>.md) for whichever branch is currently
+# checked out, and returns 0. Returns 1 (prints nothing) if there's no
+# sensible "current PR" to track progress for: detached HEAD, the repo's
+# default branch (main/master), or the personal-notes branch itself. The
+# directory is a fixed convention, independent of NOTES_PATH - PR progress is
+# inherently plural/keyed, unlike the single personal-notes file, so it isn't
+# tied to wherever NOTES_PATH happens to be overridden to.
+#
+# Shared by session-start.sh and save-pr-progress.sh so both agree on exactly
+# the same key for exactly the same branch - there is no other place this
+# path is computed, so it can never drift between reading and writing it.
+pr_progress_path() {
+  local branch
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  case "${branch}" in
+    HEAD|main|master|"${NOTES_BRANCH}"|"") return 1 ;;
+  esac
+  printf '.claude/personal/pr-progress/%s.md\n' "${branch}"
+}

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -19,3 +19,54 @@ NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-no
 # example, some session environments name the upstream repo "origin" and your
 # fork something else) - the URL form works without depending on that
 # session-specific remote name/alias existing at all.
+
+# current_branch_upstream_remote: prints the remote name the current branch
+# tracks (e.g. "abdel-direct" for a branch whose upstream is
+# "abdel-direct/some-branch"), or nothing if it has no upstream (detached
+# HEAD, or a branch that was never pushed with -u/--set-upstream). Shared by
+# fetch_personal_notes_branch below and by create-personal-notes-branch.sh's
+# existence check, so both apply the exact same fallback remote.
+current_branch_upstream_remote() {
+  git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null | cut -d/ -f1
+}
+
+# fetch_personal_notes_branch: fetches NOTES_BRANCH from NOTES_REMOTE. If that
+# fails (remote unreachable, or the branch just isn't there), falls back once
+# to the current branch's own upstream remote (current_branch_upstream_remote
+# above) - if it has one, and it differs from NOTES_REMOTE - before giving up.
+# This covers the common case of a clone whose checked-out branch already
+# tracks a contributor's own fork under some other remote name/URL, without
+# requiring NOTES_REMOTE to be configured explicitly for it.
+#
+# On success: sets ACTIVE_NOTES_REMOTE to whichever remote actually served
+# the branch (NOTES_REMOTE or the upstream fallback), leaves the fetched
+# commit in FETCH_HEAD (see the note on FETCH_HEAD vs. "<remote>/<branch>"
+# refs in session-start.sh), and returns 0.
+# On failure: sets ATTEMPTED_NOTES_REMOTES to a human-readable, comma
+# separated list of every remote that was tried (for callers that want to
+# report it), and returns 1.
+#
+# Read-only fallback: this never affects where create-personal-notes-branch.sh
+# creates the branch, or (by itself) where save-personal-notes.sh pushes an
+# edit back to - callers that push should push back to ACTIVE_NOTES_REMOTE,
+# i.e. wherever the branch was actually read from, not unconditionally to
+# NOTES_REMOTE, so a save always lands on the same remote the notes came from.
+fetch_personal_notes_branch() {
+  ATTEMPTED_NOTES_REMOTES="${NOTES_REMOTE}"
+  if git fetch "${NOTES_REMOTE}" "${NOTES_BRANCH}" --quiet 2>/dev/null; then
+    ACTIVE_NOTES_REMOTE="${NOTES_REMOTE}"
+    return 0
+  fi
+
+  local upstream_remote
+  upstream_remote="$(current_branch_upstream_remote)"
+  if [ -n "${upstream_remote}" ] && [ "${upstream_remote}" != "${NOTES_REMOTE}" ]; then
+    ATTEMPTED_NOTES_REMOTES="${ATTEMPTED_NOTES_REMOTES}, ${upstream_remote}"
+    if git fetch "${upstream_remote}" "${NOTES_BRANCH}" --quiet 2>/dev/null; then
+      ACTIVE_NOTES_REMOTE="${upstream_remote}"
+      return 0
+    fi
+  fi
+
+  return 1
+}

--- a/.claude/hooks/save-personal-notes.sh
+++ b/.claude/hooks/save-personal-notes.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# Persists edits made to CLAUDE.local.md back onto the personal-notes branch
+# on origin, so the next session's session-start.sh reads the updated notes.
+# This is the write half of the loop session-start.sh's own header
+# (see ./session-start.sh) points Claude at when asked to edit your notes:
+# edit CLAUDE.local.md below its header, then run this script.
+#
+# Usage (from the project root, after editing CLAUDE.local.md):
+#   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
+#
+# Resolves the branch/path exactly like session-start.sh (git config >
+# environment variable > the `claude/personal-notes` default), so it always
+# writes back to wherever the notes were read from.
+#
+# Strips the auto-generated sync header (everything up to and including the
+# "END-PERSONAL-NOTES-HEADER" marker line) before pushing, so the header
+# itself never ends up committed to the notes branch - only your actual notes
+# content does.
+#
+# Safe to re-run: a no-op if CLAUDE.local.md's content (after stripping the
+# header) already matches what's on the branch. Does its work in a scratch
+# worktree, so it never touches your current branch or working tree. Fails
+# with a clear message if the target branch doesn't exist yet on origin - run
+# ./create-personal-notes-branch.sh first in that case.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
+
+if [ ! -f CLAUDE.local.md ]; then
+  echo "No CLAUDE.local.md in the current directory - nothing to save." >&2
+  exit 1
+fi
+
+if ! git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null; then
+  echo "Branch '${NOTES_BRANCH}' doesn't exist on origin yet." >&2
+  echo "Run ./create-personal-notes-branch.sh first, then re-run this script." >&2
+  exit 1
+fi
+
+CONTENT_FILE="$(mktemp)"
+SCRATCH_DIR="$(mktemp -d)"
+cleanup() {
+  git worktree remove --force "${SCRATCH_DIR}" 2>/dev/null || rm -rf "${SCRATCH_DIR}"
+  git branch -D __save-personal-notes-tmp > /dev/null 2>&1 || true
+  rm -f "${CONTENT_FILE}"
+}
+trap cleanup EXIT
+
+CONTENT_START="$(grep -n '^<!-- END-PERSONAL-NOTES-HEADER -->$' CLAUDE.local.md | head -1 | cut -d: -f1)"
+if [ -n "${CONTENT_START}" ]; then
+  tail -n "+$((CONTENT_START + 1))" CLAUDE.local.md > "${CONTENT_FILE}"
+else
+  cp CLAUDE.local.md "${CONTENT_FILE}"
+fi
+
+git branch -D __save-personal-notes-tmp > /dev/null 2>&1 || true
+git worktree add -b __save-personal-notes-tmp "${SCRATCH_DIR}" "origin/${NOTES_BRANCH}" --quiet
+
+mkdir -p "${SCRATCH_DIR}/$(dirname "${NOTES_PATH}")"
+cp "${CONTENT_FILE}" "${SCRATCH_DIR}/${NOTES_PATH}"
+git -C "${SCRATCH_DIR}" add "${NOTES_PATH}"
+
+if git -C "${SCRATCH_DIR}" diff --cached --quiet -- "${NOTES_PATH}"; then
+  echo "No changes to save - '${NOTES_PATH}' on '${NOTES_BRANCH}' is already up to date."
+  exit 0
+fi
+
+git -C "${SCRATCH_DIR}" commit --quiet -m "Update personal notes"
+git -C "${SCRATCH_DIR}" push origin "HEAD:${NOTES_BRANCH}"
+
+echo "Saved '${NOTES_PATH}' back to '${NOTES_BRANCH}'."

--- a/.claude/hooks/save-personal-notes.sh
+++ b/.claude/hooks/save-personal-notes.sh
@@ -8,8 +8,13 @@ set -euo pipefail
 # asked to edit your notes: edit CLAUDE.local.md below its header, then run
 # this script.
 #
-# Usage (from the project root, after editing CLAUDE.local.md):
+# Usage (from anywhere, after editing CLAUDE.local.md):
 #   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
+#
+# Always reads/writes the project root's CLAUDE.local.md specifically (see
+# CLAUDE_LOCAL_MD in ./resolve-personal-notes-config.sh), regardless of the
+# invoking cwd - not whatever CLAUDE.local.md a bare relative path might
+# happen to resolve to from wherever this is run.
 #
 # Resolves the remote/branch/path exactly like session-start.sh (git config >
 # environment variable > the zero-config default, plus the same
@@ -34,8 +39,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
 
-if [ ! -f CLAUDE.local.md ]; then
-  echo "No CLAUDE.local.md in the current directory - nothing to save." >&2
+if [ ! -f "${CLAUDE_LOCAL_MD}" ]; then
+  echo "No CLAUDE.local.md at the project root (${CLAUDE_LOCAL_MD}) - nothing to save." >&2
   exit 1
 fi
 
@@ -54,11 +59,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if grep -q '^<!-- BEGIN-PERSONAL-NOTES -->$' CLAUDE.local.md; then
+if grep -q '^<!-- BEGIN-PERSONAL-NOTES -->$' "${CLAUDE_LOCAL_MD}"; then
   awk '/^<!-- BEGIN-PERSONAL-NOTES -->$/{flag=1; next} /^<!-- END-PERSONAL-NOTES -->$/{flag=0} flag' \
-    CLAUDE.local.md > "${CONTENT_FILE}"
+    "${CLAUDE_LOCAL_MD}" > "${CONTENT_FILE}"
 else
-  cp CLAUDE.local.md "${CONTENT_FILE}"
+  cp "${CLAUDE_LOCAL_MD}" "${CONTENT_FILE}"
 fi
 
 git branch -D __save-personal-notes-tmp > /dev/null 2>&1 || true

--- a/.claude/hooks/save-personal-notes.sh
+++ b/.claude/hooks/save-personal-notes.sh
@@ -19,10 +19,11 @@ set -euo pipefail
 # rather than the resolved one. The remote may be a configured remote's name
 # or a raw git URL - see ./README.md.
 #
-# Strips the auto-generated sync header (everything up to and including the
-# "END-PERSONAL-NOTES-HEADER" marker line) before pushing, so the header
-# itself never ends up committed to the notes branch - only your actual notes
-# content does.
+# Extracts only the content between the BEGIN-PERSONAL-NOTES/END-PERSONAL-NOTES
+# markers before pushing - never the header above them, and never the separate
+# PR-progress section session-start.sh may have appended below them (see
+# ./save-pr-progress.sh for that one) - so only your actual notes content ever
+# ends up committed to the notes branch.
 #
 # Safe to re-run: a no-op if CLAUDE.local.md's content (after stripping the
 # header) already matches what's on the branch. Does its work in a scratch
@@ -53,9 +54,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-CONTENT_START="$(grep -n '^<!-- END-PERSONAL-NOTES-HEADER -->$' CLAUDE.local.md | head -1 | cut -d: -f1)"
-if [ -n "${CONTENT_START}" ]; then
-  tail -n "+$((CONTENT_START + 1))" CLAUDE.local.md > "${CONTENT_FILE}"
+if grep -q '^<!-- BEGIN-PERSONAL-NOTES -->$' CLAUDE.local.md; then
+  awk '/^<!-- BEGIN-PERSONAL-NOTES -->$/{flag=1; next} /^<!-- END-PERSONAL-NOTES -->$/{flag=0} flag' \
+    CLAUDE.local.md > "${CONTENT_FILE}"
 else
   cp CLAUDE.local.md "${CONTENT_FILE}"
 fi

--- a/.claude/hooks/save-personal-notes.sh
+++ b/.claude/hooks/save-personal-notes.sh
@@ -2,17 +2,19 @@
 set -euo pipefail
 
 # Persists edits made to CLAUDE.local.md back onto the personal-notes branch
-# on origin, so the next session's session-start.sh reads the updated notes.
-# This is the write half of the loop session-start.sh's own header
-# (see ./session-start.sh) points Claude at when asked to edit your notes:
-# edit CLAUDE.local.md below its header, then run this script.
+# on its remote (default: `origin`), so the next session's session-start.sh
+# reads the updated notes. This is the write half of the loop
+# session-start.sh's own header (see ./session-start.sh) points Claude at when
+# asked to edit your notes: edit CLAUDE.local.md below its header, then run
+# this script.
 #
 # Usage (from the project root, after editing CLAUDE.local.md):
 #   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
 #
-# Resolves the branch/path exactly like session-start.sh (git config >
-# environment variable > the `claude/personal-notes` default), so it always
-# writes back to wherever the notes were read from.
+# Resolves the remote/branch/path exactly like session-start.sh (git config >
+# environment variable > the zero-config default), so it always writes back
+# to wherever the notes were read from. The remote may be a configured
+# remote's name or a raw git URL - see ./README.md.
 #
 # Strips the auto-generated sync header (everything up to and including the
 # "END-PERSONAL-NOTES-HEADER" marker line) before pushing, so the header
@@ -22,8 +24,8 @@ set -euo pipefail
 # Safe to re-run: a no-op if CLAUDE.local.md's content (after stripping the
 # header) already matches what's on the branch. Does its work in a scratch
 # worktree, so it never touches your current branch or working tree. Fails
-# with a clear message if the target branch doesn't exist yet on origin - run
-# ./create-personal-notes-branch.sh first in that case.
+# with a clear message if the target branch doesn't exist yet on the remote -
+# run ./create-personal-notes-branch.sh first in that case.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
@@ -33,8 +35,8 @@ if [ ! -f CLAUDE.local.md ]; then
   exit 1
 fi
 
-if ! git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null; then
-  echo "Branch '${NOTES_BRANCH}' doesn't exist on origin yet." >&2
+if ! git fetch "${NOTES_REMOTE}" "${NOTES_BRANCH}" --quiet 2>/dev/null; then
+  echo "Branch '${NOTES_BRANCH}' doesn't exist on '${NOTES_REMOTE}' yet." >&2
   echo "Run ./create-personal-notes-branch.sh first, then re-run this script." >&2
   exit 1
 fi
@@ -56,7 +58,12 @@ else
 fi
 
 git branch -D __save-personal-notes-tmp > /dev/null 2>&1 || true
-git worktree add -b __save-personal-notes-tmp "${SCRATCH_DIR}" "origin/${NOTES_BRANCH}" --quiet
+# FETCH_HEAD, not "${NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form NOTES_REMOTE
+# creates no remote-tracking ref, but FETCH_HEAD always points at what was
+# just fetched, whether NOTES_REMOTE was a remote name or a raw URL. It's
+# shared across worktrees (unlike HEAD/index), so this scratch worktree sees
+# the fetch above correctly.
+git worktree add -b __save-personal-notes-tmp "${SCRATCH_DIR}" FETCH_HEAD --quiet
 
 mkdir -p "${SCRATCH_DIR}/$(dirname "${NOTES_PATH}")"
 cp "${CONTENT_FILE}" "${SCRATCH_DIR}/${NOTES_PATH}"
@@ -68,6 +75,6 @@ if git -C "${SCRATCH_DIR}" diff --cached --quiet -- "${NOTES_PATH}"; then
 fi
 
 git -C "${SCRATCH_DIR}" commit --quiet -m "Update personal notes"
-git -C "${SCRATCH_DIR}" push origin "HEAD:${NOTES_BRANCH}"
+git -C "${SCRATCH_DIR}" push "${NOTES_REMOTE}" "HEAD:${NOTES_BRANCH}"
 
 echo "Saved '${NOTES_PATH}' back to '${NOTES_BRANCH}'."

--- a/.claude/hooks/save-personal-notes.sh
+++ b/.claude/hooks/save-personal-notes.sh
@@ -12,9 +12,12 @@ set -euo pipefail
 #   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
 #
 # Resolves the remote/branch/path exactly like session-start.sh (git config >
-# environment variable > the zero-config default), so it always writes back
-# to wherever the notes were read from. The remote may be a configured
-# remote's name or a raw git URL - see ./README.md.
+# environment variable > the zero-config default, plus the same
+# same-branch-upstream fallback - see fetch_personal_notes_branch in
+# ./resolve-personal-notes-config.sh), so it always writes back to wherever
+# the notes were actually read from, even when that was the fallback remote
+# rather than the resolved one. The remote may be a configured remote's name
+# or a raw git URL - see ./README.md.
 #
 # Strips the auto-generated sync header (everything up to and including the
 # "END-PERSONAL-NOTES-HEADER" marker line) before pushing, so the header
@@ -24,8 +27,8 @@ set -euo pipefail
 # Safe to re-run: a no-op if CLAUDE.local.md's content (after stripping the
 # header) already matches what's on the branch. Does its work in a scratch
 # worktree, so it never touches your current branch or working tree. Fails
-# with a clear message if the target branch doesn't exist yet on the remote -
-# run ./create-personal-notes-branch.sh first in that case.
+# with a clear message if the target branch doesn't exist yet on any resolved
+# remote - run ./create-personal-notes-branch.sh first in that case.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
@@ -35,8 +38,8 @@ if [ ! -f CLAUDE.local.md ]; then
   exit 1
 fi
 
-if ! git fetch "${NOTES_REMOTE}" "${NOTES_BRANCH}" --quiet 2>/dev/null; then
-  echo "Branch '${NOTES_BRANCH}' doesn't exist on '${NOTES_REMOTE}' yet." >&2
+if ! fetch_personal_notes_branch; then
+  echo "Branch '${NOTES_BRANCH}' doesn't exist yet (tried: ${ATTEMPTED_NOTES_REMOTES})." >&2
   echo "Run ./create-personal-notes-branch.sh first, then re-run this script." >&2
   exit 1
 fi
@@ -58,9 +61,9 @@ else
 fi
 
 git branch -D __save-personal-notes-tmp > /dev/null 2>&1 || true
-# FETCH_HEAD, not "${NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form NOTES_REMOTE
+# FETCH_HEAD, not "${ACTIVE_NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form remote
 # creates no remote-tracking ref, but FETCH_HEAD always points at what was
-# just fetched, whether NOTES_REMOTE was a remote name or a raw URL. It's
+# just fetched, whether the serving remote was a name or a raw URL. It's
 # shared across worktrees (unlike HEAD/index), so this scratch worktree sees
 # the fetch above correctly.
 git worktree add -b __save-personal-notes-tmp "${SCRATCH_DIR}" FETCH_HEAD --quiet
@@ -70,11 +73,14 @@ cp "${CONTENT_FILE}" "${SCRATCH_DIR}/${NOTES_PATH}"
 git -C "${SCRATCH_DIR}" add "${NOTES_PATH}"
 
 if git -C "${SCRATCH_DIR}" diff --cached --quiet -- "${NOTES_PATH}"; then
-  echo "No changes to save - '${NOTES_PATH}' on '${NOTES_BRANCH}' is already up to date."
+  echo "No changes to save - '${NOTES_PATH}' on '${NOTES_BRANCH}' (remote '${ACTIVE_NOTES_REMOTE}') is already up to date."
   exit 0
 fi
 
 git -C "${SCRATCH_DIR}" commit --quiet -m "Update personal notes"
-git -C "${SCRATCH_DIR}" push "${NOTES_REMOTE}" "HEAD:${NOTES_BRANCH}"
+# Push back to ACTIVE_NOTES_REMOTE (wherever the branch was actually read
+# from above), not unconditionally to NOTES_REMOTE, so a save always lands on
+# the same remote the notes came from - see fetch_personal_notes_branch.
+git -C "${SCRATCH_DIR}" push "${ACTIVE_NOTES_REMOTE}" "HEAD:${NOTES_BRANCH}"
 
-echo "Saved '${NOTES_PATH}' back to '${NOTES_BRANCH}'."
+echo "Saved '${NOTES_PATH}' back to '${NOTES_BRANCH}' on '${ACTIVE_NOTES_REMOTE}'."

--- a/.claude/hooks/save-pr-progress.sh
+++ b/.claude/hooks/save-pr-progress.sh
@@ -10,8 +10,13 @@ set -euo pipefail
 # to update the plan: edit CLAUDE.local.md between the BEGIN-PR-PROGRESS /
 # END-PR-PROGRESS markers, then run this script.
 #
-# Usage (from the project root, after editing CLAUDE.local.md):
+# Usage (from anywhere, after editing CLAUDE.local.md):
 #   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-pr-progress.sh"
+#
+# Always reads the project root's CLAUDE.local.md specifically (see
+# CLAUDE_LOCAL_MD in ./resolve-personal-notes-config.sh), regardless of the
+# invoking cwd - not whatever CLAUDE.local.md a bare relative path might
+# happen to resolve to from wherever this is run.
 #
 # Resolves the remote/branch exactly like session-start.sh and
 # save-personal-notes.sh (git config > environment variable > the zero-config
@@ -44,12 +49,12 @@ if [ -z "${PROGRESS_PATH}" ]; then
   exit 1
 fi
 
-if [ ! -f CLAUDE.local.md ]; then
-  echo "No CLAUDE.local.md in the current directory - nothing to save." >&2
+if [ ! -f "${CLAUDE_LOCAL_MD}" ]; then
+  echo "No CLAUDE.local.md at the project root (${CLAUDE_LOCAL_MD}) - nothing to save." >&2
   exit 1
 fi
 
-if ! grep -q '^<!-- BEGIN-PR-PROGRESS -->$' CLAUDE.local.md; then
+if ! grep -q '^<!-- BEGIN-PR-PROGRESS -->$' "${CLAUDE_LOCAL_MD}"; then
   echo "CLAUDE.local.md has no PR-progress section to extract." >&2
   echo "Run session-start.sh first, then edit the section it writes." >&2
   exit 1
@@ -72,7 +77,7 @@ cleanup() {
 trap cleanup EXIT
 
 awk '/^<!-- BEGIN-PR-PROGRESS -->$/{flag=1; next} /^<!-- END-PR-PROGRESS -->$/{flag=0} flag' \
-  CLAUDE.local.md > "${CONTENT_FILE}"
+  "${CLAUDE_LOCAL_MD}" > "${CONTENT_FILE}"
 
 git branch -D __save-pr-progress-tmp > /dev/null 2>&1 || true
 # FETCH_HEAD: see the note on FETCH_HEAD vs. "<remote>/<branch>" refs in

--- a/.claude/hooks/save-pr-progress.sh
+++ b/.claude/hooks/save-pr-progress.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+# Persists edits made to CLAUDE.local.md's PR-progress section back onto the
+# personal-notes branch, at a path keyed to the branch currently checked out
+# (see pr_progress_path in ./resolve-personal-notes-config.sh) - so the
+# plan/progress/next-steps for *this* PR survives session restarts, without
+# ever being committed to the PR branch itself. This is the write half of the
+# loop session-start.sh's own PR-progress header points Claude at when asked
+# to update the plan: edit CLAUDE.local.md between the BEGIN-PR-PROGRESS /
+# END-PR-PROGRESS markers, then run this script.
+#
+# Usage (from the project root, after editing CLAUDE.local.md):
+#   "$CLAUDE_PROJECT_DIR/.claude/hooks/save-pr-progress.sh"
+#
+# Resolves the remote/branch exactly like session-start.sh and
+# save-personal-notes.sh (git config > environment variable > the zero-config
+# default, plus the same-branch-upstream fallback - see
+# fetch_personal_notes_branch in ./resolve-personal-notes-config.sh). The path
+# is never configured directly - it's always derived from the branch you
+# currently have checked out, so it's impossible to accidentally save one
+# PR's progress under another PR's key.
+#
+# Refuses to run on a branch with no sensible "current PR" (the default
+# branch, a detached HEAD, or the personal-notes branch itself), or if
+# CLAUDE.local.md has no PR-progress section to extract - run
+# session-start.sh first in that case.
+#
+# Safe to re-run: a no-op if the extracted content already matches what's on
+# the branch. Does its work in a scratch worktree, so it never touches your
+# current branch or working tree - and never touches the PR branch itself, or
+# anything that could be merged: the progress file lives only on the
+# personal-notes branch. Fails with a clear message if that branch doesn't
+# exist yet on any resolved remote - run ./create-personal-notes-branch.sh
+# first in that case.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
+
+PROGRESS_PATH="$(pr_progress_path || true)"
+if [ -z "${PROGRESS_PATH}" ]; then
+  echo "Not on a PR branch (or on the personal-notes branch itself) - nothing to save." >&2
+  echo "Switch to the branch whose progress you want to save, then re-run this script." >&2
+  exit 1
+fi
+
+if [ ! -f CLAUDE.local.md ]; then
+  echo "No CLAUDE.local.md in the current directory - nothing to save." >&2
+  exit 1
+fi
+
+if ! grep -q '^<!-- BEGIN-PR-PROGRESS -->$' CLAUDE.local.md; then
+  echo "CLAUDE.local.md has no PR-progress section to extract." >&2
+  echo "Run session-start.sh first, then edit the section it writes." >&2
+  exit 1
+fi
+
+if ! fetch_personal_notes_branch; then
+  echo "Branch '${NOTES_BRANCH}' doesn't exist yet (tried: ${ATTEMPTED_NOTES_REMOTES})." >&2
+  echo "Run ./create-personal-notes-branch.sh first, then re-run this script." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+CONTENT_FILE="$(mktemp)"
+SCRATCH_DIR="$(mktemp -d)"
+cleanup() {
+  git worktree remove --force "${SCRATCH_DIR}" 2>/dev/null || rm -rf "${SCRATCH_DIR}"
+  git branch -D __save-pr-progress-tmp > /dev/null 2>&1 || true
+  rm -f "${CONTENT_FILE}"
+}
+trap cleanup EXIT
+
+awk '/^<!-- BEGIN-PR-PROGRESS -->$/{flag=1; next} /^<!-- END-PR-PROGRESS -->$/{flag=0} flag' \
+  CLAUDE.local.md > "${CONTENT_FILE}"
+
+git branch -D __save-pr-progress-tmp > /dev/null 2>&1 || true
+# FETCH_HEAD: see the note on FETCH_HEAD vs. "<remote>/<branch>" refs in
+# save-personal-notes.sh - a URL-form remote has no tracking ref, and
+# FETCH_HEAD is shared across worktrees so this scratch worktree sees the
+# fetch above correctly regardless.
+git worktree add -b __save-pr-progress-tmp "${SCRATCH_DIR}" FETCH_HEAD --quiet
+
+mkdir -p "${SCRATCH_DIR}/$(dirname "${PROGRESS_PATH}")"
+cp "${CONTENT_FILE}" "${SCRATCH_DIR}/${PROGRESS_PATH}"
+git -C "${SCRATCH_DIR}" add "${PROGRESS_PATH}"
+
+if git -C "${SCRATCH_DIR}" diff --cached --quiet -- "${PROGRESS_PATH}"; then
+  echo "No changes to save - '${PROGRESS_PATH}' on '${NOTES_BRANCH}' (remote '${ACTIVE_NOTES_REMOTE}') is already up to date."
+  exit 0
+fi
+
+git -C "${SCRATCH_DIR}" commit --quiet -m "Update PR progress for ${CURRENT_BRANCH}"
+git -C "${SCRATCH_DIR}" push "${ACTIVE_NOTES_REMOTE}" "HEAD:${NOTES_BRANCH}"
+
+echo "Saved '${PROGRESS_PATH}' back to '${NOTES_BRANCH}' on '${ACTIVE_NOTES_REMOTE}'."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 # for multiple contributors sharing one remote if each overrides the branch
 # name via local config instead of relying on the shared default.
 #
+# Always writes to the project root, never wherever this happens to be
+# invoked from: a SessionStart hook's cwd isn't guaranteed to be the project
+# root, so a bare `CLAUDE.local.md` could silently land in the wrong place
+# (and Claude Code only auto-loads it from the root) - see CLAUDE_LOCAL_MD in
+# ./resolve-personal-notes-config.sh for how that's resolved deterministically.
+#
 # Works out of the box, zero config: it looks for a branch named
 # `claude/personal-notes` on `origin` and, if found, reads
 # `.claude/personal/cram-notes.md` off it into CLAUDE.local.md.
@@ -148,7 +154,7 @@ SCAFFOLD
 fi
 
 if [ "${WROTE_ANYTHING}" = "1" ]; then
-  mv "${OUTPUT_FILE}" CLAUDE.local.md
+  mv "${OUTPUT_FILE}" "${CLAUDE_LOCAL_MD}"
 else
   rm -f "${OUTPUT_FILE}"
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -34,6 +34,13 @@ set -euo pipefail
 # the configured (or default) branch or path isn't reachable (e.g. a fresh
 # clone, or a fork that never created it).
 #
+# Editing your notes: the written CLAUDE.local.md starts with a short header
+# (see below) naming the resolved branch/path and pointing at
+# ./save-personal-notes.sh. Since Claude Code loads CLAUDE.local.md as project
+# memory every session, that header is always in context - so asking Claude to
+# "edit my personal notes" needs no other setup: it edits the file below the
+# header, then runs the save script to push the change back.
+#
 # How this script gets invoked (see ../settings.json): Claude Code registers it
 # as a SessionStart hook via `$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh`.
 # CLAUDE_PROJECT_DIR is an env var Claude Code itself injects into every hook
@@ -48,14 +55,23 @@ set -euo pipefail
 # yourself. settings.json is strict JSON with no comment support, which is why
 # this explanation lives here instead of there.
 
-NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
-NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}}"
-
-NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
-NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
 
 git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
 
 if git cat-file -e "origin/${NOTES_BRANCH}:${NOTES_PATH}" 2>/dev/null; then
-  git show "origin/${NOTES_BRANCH}:${NOTES_PATH}" > CLAUDE.local.md
+  {
+    cat <<HEADER
+<!--
+Personal notes, synced from '${NOTES_BRANCH}' (${NOTES_PATH}) by session-start.sh.
+To edit: change the notes below this line, then run
+  "\$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
+to push the change back to '${NOTES_BRANCH}'. This header is regenerated
+every session from git config/environment/default - editing it has no effect.
+-->
+<!-- END-PERSONAL-NOTES-HEADER -->
+HEADER
+    git show "origin/${NOTES_BRANCH}:${NOTES_PATH}"
+  } > CLAUDE.local.md
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-# Generic, opt-in personal Claude Code notes hook.
+# Generic personal Claude Code notes hook.
 #
 # Populates CLAUDE.local.md (gitignored, never committed on any branch) from a
-# personal branch on `origin` that each contributor names for themselves via
-# local git config, so this stays a complete no-op for anyone who hasn't opted
-# in, and collision-free for multiple contributors sharing one origin remote
-# (each points at their own branch name instead of one hardcoded literal).
+# personal branch on `origin`. No-op in effect for anyone who never creates
+# that branch (default or overridden), and collision-free for multiple
+# contributors sharing one origin remote if each overrides the branch name via
+# local config instead of relying on the shared default.
 #
 # Works out of the box, zero config: it looks for a branch named
 # `claude/personal-notes` on `origin` and, if found, reads

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Personal-only Claude Code notes for abdelrhmanbassiouny's fork.
+#
+# These notes (draft-PR-by-default, bug-fix labeling, etc.) live on the
+# `claude/personal-notes` branch only and must never reach `main`. This hook
+# fetches that branch's file straight from the remote (without checking it out
+# or merging it into the working branch) and writes it to CLAUDE.local.md,
+# which Claude Code loads automatically as project memory but which stays out
+# of git history for every other branch (see .gitignore).
+#
+# Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
+# the personal-notes branch or file isn't reachable (e.g. a fresh clone that
+# doesn't have it, or a fork that never created it).
+
+NOTES_BRANCH="origin/claude/personal-notes"
+NOTES_PATH=".claude/personal/cram-notes.md"
+
+git fetch origin claude/personal-notes --quiet 2>/dev/null || exit 0
+
+if git cat-file -e "${NOTES_BRANCH}:${NOTES_PATH}" 2>/dev/null; then
+  git show "${NOTES_BRANCH}:${NOTES_PATH}" > CLAUDE.local.md
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 # Generic personal Claude Code notes hook.
 #
 # Populates CLAUDE.local.md (gitignored, never committed on any branch) from a
-# personal branch on `origin`. No-op in effect for anyone who never creates
-# that branch (default or overridden), and collision-free for multiple
-# contributors sharing one origin remote if each overrides the branch name via
-# local config instead of relying on the shared default.
+# personal branch on a remote (default: `origin`). No-op in effect for anyone
+# who never creates that branch (default or overridden), and collision-free
+# for multiple contributors sharing one remote if each overrides the branch
+# name via local config instead of relying on the shared default.
 #
 # Works out of the box, zero config: it looks for a branch named
 # `claude/personal-notes` on `origin` and, if found, reads
@@ -15,20 +15,30 @@ set -euo pipefail
 # ./create-personal-notes-branch.sh creates that branch (with an empty notes
 # file) for anyone who doesn't have it yet.
 #
-# Override the branch/path per clone, locally (never committed):
+# Override the remote/branch/path per clone, locally (never committed):
+#   git config claude.personalNotesRemote <remote-name-or-url>   # optional
 #   git config claude.personalNotesBranch <your-branch-name>
 #   git config claude.personalNotesPath   <path-on-that-branch>   # optional
+#
+# The remote defaults to `origin`, but only matters when your own notes live
+# somewhere other than the clone's `origin` - e.g. some session environments
+# name the upstream repo `origin` and your own fork something else. Set it to
+# either a remote already configured in this clone (by name) or a raw git URL
+# (`https://github.com/<you>/<repo>`) - `git fetch`/`git push` accept both, and
+# a URL needs no `git remote add` first, so it works even in a clone that's
+# never heard of your fork. See ./README.md for when to use which form.
 #
 # git config is per-clone, so it's the wrong mechanism anywhere sessions start
 # from a fresh clone every time (e.g. cloud/web sessions) - there's no
 # persistent .git/config for it to live in. For that case, override via
 # persistent environment variables instead (configured once at the environment
 # level, outside the repo, so they survive every fresh clone):
+#   CLAUDE_PERSONAL_NOTES_REMOTE=<remote-name-or-url>   # optional
 #   CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 #   CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>   # optional
 # See ./README.md for exactly how to wire these into a cloud environment.
-# Precedence: git config > environment variable > the `claude/personal-notes`
-# default, so a local or environment-level override always wins over it.
+# Precedence: git config > environment variable > the zero-config default, so
+# a local or environment-level override always wins over it.
 #
 # Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
 # the configured (or default) branch or path isn't reachable (e.g. a fresh
@@ -58,9 +68,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
 
-git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
+git fetch "${NOTES_REMOTE}" "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
 
-if git cat-file -e "origin/${NOTES_BRANCH}:${NOTES_PATH}" 2>/dev/null; then
+# FETCH_HEAD, not "${NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form NOTES_REMOTE
+# creates no remote-tracking ref, but FETCH_HEAD always points at what was
+# just fetched, whether NOTES_REMOTE was a remote name or a raw URL.
+if git cat-file -e "FETCH_HEAD:${NOTES_PATH}" 2>/dev/null; then
   {
     cat <<HEADER
 <!--
@@ -72,6 +85,6 @@ every session from git config/environment/default - editing it has no effect.
 -->
 <!-- END-PERSONAL-NOTES-HEADER -->
 HEADER
-    git show "origin/${NOTES_BRANCH}:${NOTES_PATH}"
+    git show "FETCH_HEAD:${NOTES_PATH}"
   } > CLAUDE.local.md
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,8 +13,19 @@ set -euo pipefail
 #   git config claude.personalNotesBranch <your-branch-name>
 #   git config claude.personalNotesPath   <path-on-that-branch>   # optional
 #
-# With claude.personalNotesBranch unset, this exits immediately: no fetch, no
-# write, no effect for anyone who hasn't configured it.
+# git config is per-clone, so it's the wrong mechanism anywhere sessions start
+# from a fresh clone every time (e.g. cloud/web sessions) - there's no
+# persistent .git/config for it to live in. For that case, opt in via
+# persistent environment variables instead (configured once at the environment
+# level, outside the repo, so they survive every fresh clone):
+#   CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
+#   CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>   # optional
+# See ./README.md for exactly how to wire these into a cloud environment.
+# git config wins when both are set, so a local override always takes
+# precedence over an environment-level default.
+#
+# With neither set, this exits immediately: no fetch, no write, no effect for
+# anyone who hasn't configured it.
 #
 # Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
 # the configured branch or path isn't reachable (e.g. a fresh clone, or a fork
@@ -35,10 +46,11 @@ set -euo pipefail
 # this explanation lives here instead of there.
 
 NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
+NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-}}"
 [ -n "${NOTES_BRANCH}" ] || exit 0
 
 NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
-NOTES_PATH="${NOTES_PATH:-.claude/personal/cram-notes.md}"
+NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}}"
 
 git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,27 +9,30 @@ set -euo pipefail
 # in, and collision-free for multiple contributors sharing one origin remote
 # (each points at their own branch name instead of one hardcoded literal).
 #
-# Opt in once, locally, per clone (never committed):
+# Works out of the box, zero config: it looks for a branch named
+# `claude/personal-notes` on `origin` and, if found, reads
+# `.claude/personal/cram-notes.md` off it into CLAUDE.local.md.
+# ./create-personal-notes-branch.sh creates that branch (with an empty notes
+# file) for anyone who doesn't have it yet.
+#
+# Override the branch/path per clone, locally (never committed):
 #   git config claude.personalNotesBranch <your-branch-name>
 #   git config claude.personalNotesPath   <path-on-that-branch>   # optional
 #
 # git config is per-clone, so it's the wrong mechanism anywhere sessions start
 # from a fresh clone every time (e.g. cloud/web sessions) - there's no
-# persistent .git/config for it to live in. For that case, opt in via
+# persistent .git/config for it to live in. For that case, override via
 # persistent environment variables instead (configured once at the environment
 # level, outside the repo, so they survive every fresh clone):
 #   CLAUDE_PERSONAL_NOTES_BRANCH=<your-branch-name>
 #   CLAUDE_PERSONAL_NOTES_PATH=<path-on-that-branch>   # optional
 # See ./README.md for exactly how to wire these into a cloud environment.
-# git config wins when both are set, so a local override always takes
-# precedence over an environment-level default.
-#
-# With neither set, this exits immediately: no fetch, no write, no effect for
-# anyone who hasn't configured it.
+# Precedence: git config > environment variable > the `claude/personal-notes`
+# default, so a local or environment-level override always wins over it.
 #
 # Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
-# the configured branch or path isn't reachable (e.g. a fresh clone, or a fork
-# that never created it).
+# the configured (or default) branch or path isn't reachable (e.g. a fresh
+# clone, or a fork that never created it).
 #
 # How this script gets invoked (see ../settings.json): Claude Code registers it
 # as a SessionStart hook via `$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh`.
@@ -46,8 +49,7 @@ set -euo pipefail
 # this explanation lives here instead of there.
 
 NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
-NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-}}"
-[ -n "${NOTES_BRANCH}" ] || exit 0
+NOTES_BRANCH="${NOTES_BRANCH:-${CLAUDE_PERSONAL_NOTES_BRANCH:-claude/personal-notes}}"
 
 NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
 NOTES_PATH="${NOTES_PATH:-${CLAUDE_PERSONAL_NOTES_PATH:-.claude/personal/cram-notes.md}}"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
-# Personal-only Claude Code notes for abdelrhmanbassiouny's fork.
+# Generic, opt-in personal Claude Code notes hook.
 #
-# These notes (draft-PR-by-default, bug-fix labeling, etc.) live on the
-# `claude/personal-notes` branch only and must never reach `main`. This hook
-# fetches that branch's file straight from the remote (without checking it out
-# or merging it into the working branch) and writes it to CLAUDE.local.md,
-# which Claude Code loads automatically as project memory but which stays out
-# of git history for every other branch (see .gitignore).
+# Populates CLAUDE.local.md (gitignored, never committed on any branch) from a
+# personal branch on `origin` that each contributor names for themselves via
+# local git config, so this stays a complete no-op for anyone who hasn't opted
+# in, and collision-free for multiple contributors sharing one origin remote
+# (each points at their own branch name instead of one hardcoded literal).
+#
+# Opt in once, locally, per clone (never committed):
+#   git config claude.personalNotesBranch <your-branch-name>
+#   git config claude.personalNotesPath   <path-on-that-branch>   # optional
+#
+# With claude.personalNotesBranch unset, this exits immediately: no fetch, no
+# write, no effect for anyone who hasn't configured it.
 #
 # Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
-# the personal-notes branch or file isn't reachable (e.g. a fresh clone that
-# doesn't have it, or a fork that never created it).
+# the configured branch or path isn't reachable (e.g. a fresh clone, or a fork
+# that never created it).
 
-NOTES_BRANCH="origin/claude/personal-notes"
-NOTES_PATH=".claude/personal/cram-notes.md"
+NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
+[ -n "${NOTES_BRANCH}" ] || exit 0
 
-git fetch origin claude/personal-notes --quiet 2>/dev/null || exit 0
+NOTES_PATH="$(git config --get claude.personalNotesPath || true)"
+NOTES_PATH="${NOTES_PATH:-.claude/personal/cram-notes.md}"
 
-if git cat-file -e "${NOTES_BRANCH}:${NOTES_PATH}" 2>/dev/null; then
-  git show "${NOTES_BRANCH}:${NOTES_PATH}" > CLAUDE.local.md
+git fetch origin "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
+
+if git cat-file -e "origin/${NOTES_BRANCH}:${NOTES_PATH}" 2>/dev/null; then
+  git show "origin/${NOTES_BRANCH}:${NOTES_PATH}" > CLAUDE.local.md
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -19,6 +19,20 @@ set -euo pipefail
 # Safe to re-run: it only ever overwrites CLAUDE.local.md, and does nothing if
 # the configured branch or path isn't reachable (e.g. a fresh clone, or a fork
 # that never created it).
+#
+# How this script gets invoked (see ../settings.json): Claude Code registers it
+# as a SessionStart hook via `$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh`.
+# CLAUDE_PROJECT_DIR is an env var Claude Code itself injects into every hook
+# command's environment, resolving to this project's root - so that path is
+# correct regardless of Claude Code's own cwd when it runs the hook.
+#
+# Coexistence with your own settings: Claude Code merges the `hooks` arrays
+# across all settings layers (managed > CLI args > .claude/settings.local.json
+# > .claude/settings.json (this repo's, committed) > ~/.claude/settings.json)
+# by concatenation, not override. So this SessionStart hook runs alongside -
+# never instead of - any SessionStart hook you already have configured for
+# yourself. settings.json is strict JSON with no comment support, which is why
+# this explanation lives here instead of there.
 
 NOTES_BRANCH="$(git config --get claude.personalNotesBranch || true)"
 [ -n "${NOTES_BRANCH}" ] || exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -44,6 +44,14 @@ set -euo pipefail
 # the configured (or default) branch or path isn't reachable (e.g. a fresh
 # clone, or a fork that never created it).
 #
+# Remote fallback: if NOTES_REMOTE doesn't have the branch, this also tries
+# the current branch's own upstream remote (if it has one, and it differs
+# from NOTES_REMOTE) before giving up - see fetch_personal_notes_branch in
+# ./resolve-personal-notes-config.sh. Covers a clone whose checked-out branch
+# already tracks your fork under some other remote name, with no config
+# needed. The written header always names whichever remote actually served
+# the notes, so it's clear which one was used.
+#
 # Editing your notes: the written CLAUDE.local.md starts with a short header
 # (see below) naming the resolved branch/path and pointing at
 # ./save-personal-notes.sh. Since Claude Code loads CLAUDE.local.md as project
@@ -68,20 +76,22 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/resolve-personal-notes-config.sh"
 
-git fetch "${NOTES_REMOTE}" "${NOTES_BRANCH}" --quiet 2>/dev/null || exit 0
+fetch_personal_notes_branch || exit 0
 
-# FETCH_HEAD, not "${NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form NOTES_REMOTE
+# FETCH_HEAD, not "${ACTIVE_NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form remote
 # creates no remote-tracking ref, but FETCH_HEAD always points at what was
-# just fetched, whether NOTES_REMOTE was a remote name or a raw URL.
+# just fetched, whether the serving remote was a name or a raw URL.
 if git cat-file -e "FETCH_HEAD:${NOTES_PATH}" 2>/dev/null; then
   {
     cat <<HEADER
 <!--
-Personal notes, synced from '${NOTES_BRANCH}' (${NOTES_PATH}) by session-start.sh.
+Personal notes, synced from '${NOTES_BRANCH}' (${NOTES_PATH}) on remote
+'${ACTIVE_NOTES_REMOTE}' by session-start.sh.
 To edit: change the notes below this line, then run
   "\$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
-to push the change back to '${NOTES_BRANCH}'. This header is regenerated
-every session from git config/environment/default - editing it has no effect.
+to push the change back. This header is regenerated every session from git
+config/environment/default (plus a same-branch-upstream fallback) - editing
+it has no effect.
 -->
 <!-- END-PERSONAL-NOTES-HEADER -->
 HEADER

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -56,8 +56,19 @@ set -euo pipefail
 # (see below) naming the resolved branch/path and pointing at
 # ./save-personal-notes.sh. Since Claude Code loads CLAUDE.local.md as project
 # memory every session, that header is always in context - so asking Claude to
-# "edit my personal notes" needs no other setup: it edits the file below the
-# header, then runs the save script to push the change back.
+# "edit my personal notes" needs no other setup: it edits the notes between
+# the BEGIN-PERSONAL-NOTES/END-PERSONAL-NOTES markers, then runs the save
+# script to push the change back.
+#
+# PR progress: on any branch with a sensible "current PR" (i.e. not the
+# default branch, a detached HEAD, or the personal-notes branch itself - see
+# pr_progress_path in ./resolve-personal-notes-config.sh), CLAUDE.local.md
+# also gets a second section for that branch's plan/progress/next-steps,
+# keyed to the branch name and stored on the personal-notes branch just like
+# the notes above - so it is never committed to the PR branch itself, and
+# survives session restarts automatically. Always present (as a scaffold, if
+# nothing's been saved yet) on such a branch, so the agent is nudged to
+# initialize and maintain it from the start. See ./save-pr-progress.sh.
 #
 # How this script gets invoked (see ../settings.json): Claude Code registers it
 # as a SessionStart hook via `$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh`.
@@ -81,20 +92,63 @@ fetch_personal_notes_branch || exit 0
 # FETCH_HEAD, not "${ACTIVE_NOTES_REMOTE}/${NOTES_BRANCH}": a URL-form remote
 # creates no remote-tracking ref, but FETCH_HEAD always points at what was
 # just fetched, whether the serving remote was a name or a raw URL.
+
+OUTPUT_FILE="$(mktemp)"
+WROTE_ANYTHING=0
+
 if git cat-file -e "FETCH_HEAD:${NOTES_PATH}" 2>/dev/null; then
-  {
-    cat <<HEADER
+  cat <<HEADER >> "${OUTPUT_FILE}"
 <!--
 Personal notes, synced from '${NOTES_BRANCH}' (${NOTES_PATH}) on remote
 '${ACTIVE_NOTES_REMOTE}' by session-start.sh.
-To edit: change the notes below this line, then run
+To edit: change the notes between the markers below, then run
   "\$CLAUDE_PROJECT_DIR/.claude/hooks/save-personal-notes.sh"
-to push the change back. This header is regenerated every session from git
-config/environment/default (plus a same-branch-upstream fallback) - editing
-it has no effect.
+to push the change back. This header and the markers are regenerated every
+session from git config/environment/default (plus a same-branch-upstream
+fallback) - editing them has no effect; only content between the markers is
+ever saved.
 -->
-<!-- END-PERSONAL-NOTES-HEADER -->
+<!-- BEGIN-PERSONAL-NOTES -->
 HEADER
-    git show "FETCH_HEAD:${NOTES_PATH}"
-  } > CLAUDE.local.md
+  git show "FETCH_HEAD:${NOTES_PATH}" >> "${OUTPUT_FILE}"
+  echo "<!-- END-PERSONAL-NOTES -->" >> "${OUTPUT_FILE}"
+  WROTE_ANYTHING=1
+fi
+
+PROGRESS_PATH="$(pr_progress_path || true)"
+if [ -n "${PROGRESS_PATH}" ]; then
+  [ "${WROTE_ANYTHING}" = "1" ] && printf '\n' >> "${OUTPUT_FILE}"
+  cat <<PROGRESS_HEADER >> "${OUTPUT_FILE}"
+<!--
+PR progress for branch '$(git rev-parse --abbrev-ref HEAD)', synced from
+'${NOTES_BRANCH}' (${PROGRESS_PATH}) on remote '${ACTIVE_NOTES_REMOTE}' by
+session-start.sh. Maintain the current plan, what's done, and what's next
+here throughout work on this PR. It is never merged: it lives only on
+'${NOTES_BRANCH}', never on this branch. A stale file left behind after the
+PR merges is harmless (just unread from then on) - delete it directly on
+'${NOTES_BRANCH}' if you want to tidy it up.
+To edit: change the notes between the markers below, then run
+  "\$CLAUDE_PROJECT_DIR/.claude/hooks/save-pr-progress.sh"
+to push the change back. This header and the markers are regenerated every
+session - editing them has no effect; only content between the markers is
+ever saved.
+-->
+<!-- BEGIN-PR-PROGRESS -->
+PROGRESS_HEADER
+  if git cat-file -e "FETCH_HEAD:${PROGRESS_PATH}" 2>/dev/null; then
+    git show "FETCH_HEAD:${PROGRESS_PATH}" >> "${OUTPUT_FILE}"
+  else
+    cat <<'SCAFFOLD' >> "${OUTPUT_FILE}"
+No progress recorded yet for this branch. Initialize it now: a short plan,
+what's done so far, and what's next. Keep it current as you work.
+SCAFFOLD
+  fi
+  echo "<!-- END-PR-PROGRESS -->" >> "${OUTPUT_FILE}"
+  WROTE_ANYTHING=1
+fi
+
+if [ "${WROTE_ANYTHING}" = "1" ]; then
+  mv "${OUTPUT_FILE}" CLAUDE.local.md
+else
+  rm -f "${OUTPUT_FILE}"
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,7 @@ class_diagram.pdf
 *_evaluated_tree.svg
 *_rdr.dot
 *_rdr.svg
+
+# Personal, per-user Claude Code memory (populated by .claude/hooks/session-start.sh
+# from the claude/personal-notes branch). Never committed on any branch.
+CLAUDE.local.md


### PR DESCRIPTION
Adds an opt-in, no-op-by-default SessionStart hook that lets any contributor keep personal Claude Code notes (CLAUDE.local.md, gitignored) populated from a branch/path they configure locally, without ever touching shared branches.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/44