### PR TITLE
docs: commits must be authored in the contributor's name, not an assistant's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,12 @@
 ## Domain-Specific Conventions
 - When dealing with spatial types and connections, adhere to the style guide documented in `semantic_digital_twin/doc/style_guide.md`
 
+## Version Control
+- Commits must be authored in the name of the human user running the tool, using their own configured git `user.name` and `user.email`. Never author or amend a commit as an assistant/agent identity.
+- Do not attribute authorship or co-authorship to an assistant: no `Co-Authored-By:` trailer for Claude or any assistant, and no `noreply@anthropic.com` (or similar) as author or committer. The commit's authorship reflects the person responsible for it.
+- It is fine — and encouraged — to acknowledge assistant help in the commit message body with a short plain line, for example `Made with the help of Claude`. Keep it a note, not an author/co-author trailer.
+- This applies to every contributor and every tool.
+
 ## Misc
 - If you find a package that could be replaced by a more powerful one, let us know
 - Always use the Python interpreter that is set as the current project interpreter for running tests and commands


### PR DESCRIPTION
Adds a Version Control section to AGENTS.md requiring commits be authored under the human contributor's own git identity, with no AI author/co-author trailer.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/45