### PR TITLE
Fix collision_matrix_tool's SIGINT handler racing rospy shutdown

### DIFF
--- a/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
+++ b/giskardpy/scripts/ros2-tools/collision_matrix_tool.py
@@ -877,8 +877,13 @@ class Application(QMainWindow):
 
 
 def handle_sigint(sig, frame):
-    """Handler for the SIGINT signal."""
-    rospy.shutdown()
+    """Handler for the SIGINT signal.
+
+    Only requests the event loop to quit here -- rospy.shutdown() joins the spinner thread and
+    destroys the rclpy node, which is unsafe to run from a signal handler interrupting Qt's event
+    loop. The single rospy.shutdown() call after app.exec_() returns handles it instead, whether the
+    loop ended via this signal or a normal window close.
+    """
     QApplication.quit()
 
 


### PR DESCRIPTION
handle_sigint now only requests the Qt event loop to quit instead of calling rospy.shutdown() directly from the signal handler, which raced native rclpy teardown against the running Qt event loop and caused test_script_launch_and_kill to see a non-clean exit.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/59