### PR TITLE
Fix flaky grammar registry completeness check

### DIFF
--- a/test/krrood_test/test_eql/test_verbalization/test_grammar_registry.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_grammar_registry.py
@@ -35,6 +35,8 @@ def _discovered_grammar_rule_types():
     return {
         subclass
         for subclass in concrete_subclasses(PhraseRule)
+        # grammar_package.__name__ is the package's full dotted import path (e.g.
+        # "krrood.entity_query_language.verbalization.grammar"), matching subclass.__module__.
         if subclass.__module__.startswith(f"{grammar_package.__name__}.")
     }
 

--- a/test/krrood_test/test_eql/test_verbalization/test_grammar_registry.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_grammar_registry.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 
 import pytest
 
+from krrood.entity_query_language.verbalization import grammar as grammar_package
 from krrood.entity_query_language.verbalization.exceptions import AmbiguousRuleError
 from krrood.entity_query_language.verbalization.grammar.framework.phrase_rule import (
     PhraseRule,
@@ -22,6 +23,20 @@ from krrood.patterns.specificity_ranking import (
     maxima,
     sole_maximum,
 )
+
+
+def _discovered_grammar_rule_types():
+    """Concrete ``PhraseRule`` subclasses defined within the grammar package's own rule modules.
+
+    Excludes any subclass defined elsewhere (e.g. by unrelated tests exercising ``PhraseRule``'s
+    dispatch contract with throwaway subclasses) so completeness checks against ``RULES`` stay
+    independent of those subclasses' unrelated object lifetimes.
+    """
+    return {
+        subclass
+        for subclass in concrete_subclasses(PhraseRule)
+        if subclass.__module__.startswith(f"{grammar_package.__name__}.")
+    }
 
 
 def test_concrete_subclasses_excludes_abstract_bases():
@@ -45,8 +60,30 @@ def test_rules_registry_is_exactly_one_instance_per_concrete_rule():
     """The registry holds exactly one instance of every concrete ``PhraseRule`` subclass — proving
     auto-discovery is complete and free of duplicates."""
     discovered = {type(rule) for rule in RULES}
-    assert discovered == set(concrete_subclasses(PhraseRule))
+    assert discovered == _discovered_grammar_rule_types()
     assert len(RULES) == len(discovered)  # no duplicate instances
+
+
+def test_registry_completeness_check_ignores_phrase_rule_subclasses_defined_outside_grammar():
+    """A ``PhraseRule`` subclass defined outside the grammar package must not affect the registry's
+    completeness check.
+
+    Regression: ``concrete_subclasses(PhraseRule)`` reflects on every live subclass in the whole
+    process via ``__subclasses__()``, including throwaway subclasses other tests define to exercise
+    ``PhraseRule``'s dispatch contract (e.g. ``test_grammar_dispatch.py``'s ``ScopedRule``). Comparing
+    ``RULES`` against the raw, unscoped set made the completeness check fail depending on whether
+    such a subclass happened to still be alive when it ran — a flake tied to unrelated
+    garbage-collection timing rather than any real registry defect.
+    """
+
+    class TransientNonGrammarRule(PhraseRule):
+        construct = object
+
+        def build(self, node, context):
+            raise NotImplementedError
+
+    assert TransientNonGrammarRule in concrete_subclasses(PhraseRule)
+    assert TransientNonGrammarRule not in _discovered_grammar_rule_types()
 
 
 def test_maxima_returns_all_co_maximal_candidates():


### PR DESCRIPTION
Scopes the grammar registry completeness check to PhraseRule subclasses defined under the grammar package, so it's no longer flaky against throwaway PhraseRule subclasses defined elsewhere in the test suite (garbage-collection timing dependent).

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/61