### PR TITLE
Fix CI-hanging infinite retry loop in krrood's IPython expert shell

### DIFF
--- a/krrood/src/krrood/ripple_down_rules/exceptions.py
+++ b/krrood/src/krrood/ripple_down_rules/exceptions.py
@@ -72,3 +72,24 @@ class NoLoadPathFoundForExpertAnswers(InputError):
 
     def suggest_correction(self) -> str:
         return ""
+
+
+@dataclass
+class NonInteractiveTerminalError(InputError):
+    """
+    Raised when the embedded Ipython expert shell is started without an interactive
+    terminal attached to stdin, since it would then have no way to prompt for input.
+    """
+
+    def error_message(self) -> str:
+        return (
+            "Cannot start the embedded Ipython expert shell: stdin is not an interactive "
+            "terminal, so the shell cannot prompt for input."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Provide expert answers programmatically, e.g. via "
+            "Human(use_loaded_answers=True), instead of relying on an interactive prompt in "
+            "a non-interactive environment such as CI."
+        )

--- a/krrood/src/krrood/ripple_down_rules/user_interface/ipython_custom_shell.py
+++ b/krrood/src/krrood/ripple_down_rules/user_interface/ipython_custom_shell.py
@@ -1,5 +1,5 @@
-import logging
 import os
+import sys
 from typing_extensions import Optional, List
 
 from IPython.core.magic import magics_class, Magics, line_magic
@@ -12,6 +12,7 @@ from krrood.ripple_down_rules.user_interface.template_file_creator import (
 )
 from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
 from krrood.ripple_down_rules.datastructures.enums import PromptFor
+from krrood.ripple_down_rules.exceptions import NonInteractiveTerminalError
 from krrood.ripple_down_rules.utils import (
     contains_return_statement,
     extract_dependencies,
@@ -188,16 +189,16 @@ class IPythonShell:
 
     def run(self):
         """
-        Run the embedded shell.
+        Run the embedded shell once and capture the resulting user input.
+
+        :raises NonInteractiveTerminalError: if stdin is not attached to an interactive
+            terminal, since the embedded shell would then have no way to prompt for
+            input.
         """
-        while True:
-            try:
-                self.shell()
-                self.update_user_input_from_code_lines()
-                break
-            except Exception as e:
-                logging.error(e)
-                print(f"{Fore.RED}ERROR:: {e}{Style.RESET_ALL}")
+        if not sys.stdin.isatty():
+            raise NonInteractiveTerminalError()
+        self.shell()
+        self.update_user_input_from_code_lines()
 
     def update_user_input_from_code_lines(self):
         """

--- a/test/krrood_test/test_ripple_down_rules/test_user_interface/test_ipython_shell_run.py
+++ b/test/krrood_test/test_ripple_down_rules/test_user_interface/test_ipython_shell_run.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
+from krrood.ripple_down_rules.exceptions import NonInteractiveTerminalError
+from krrood.ripple_down_rules.user_interface.ipython_custom_shell import IPythonShell
+
+
+def make_shell() -> IPythonShell:
+    case_query = CaseQuery(object(), "attribute", (int,), True)
+    return IPythonShell(case_query=case_query)
+
+
+class TestIPythonShellRunFailsFastOnNonInteractiveTerminal(TestCase):
+
+    def test_raises_without_invoking_the_embedded_shell(self):
+        shell = make_shell()
+        shell.shell = Mock(side_effect=IndexError("list index out of range"))
+        with patch("sys.stdin.isatty", return_value=False):
+            with self.assertRaises(NonInteractiveTerminalError):
+                shell.run()
+        shell.shell.assert_not_called()
+
+
+class TestIPythonShellRunDoesNotRetryForever(TestCase):
+
+    def test_propagates_the_first_failure_instead_of_looping(self):
+        shell = make_shell()
+        shell.shell = Mock(side_effect=IndexError("list index out of range"))
+        with patch("sys.stdin.isatty", return_value=True):
+            with self.assertRaises(IndexError):
+                shell.run()
+        shell.shell.assert_called_once()


### PR DESCRIPTION
IPythonShell.run() retried forever on every exception; in CI (no tty) this caused a ~69-minute hang. Now raises NonInteractiveTerminalError instead of looping.

Fork PR: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/71