### PR TITLE
Add a programmatic Oracle expert for fitting ripple-down-rules without recorded answers

### DIFF
--- a/krrood/src/krrood/ripple_down_rules/exceptions.py
+++ b/krrood/src/krrood/ripple_down_rules/exceptions.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from typing_extensions import TYPE_CHECKING
+from typing_extensions import Any, TYPE_CHECKING
 
 from krrood.exceptions import InputError, DataclassException
 
 if TYPE_CHECKING:
+    from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
     from krrood.ripple_down_rules.experts import Expert
 
 
@@ -92,4 +93,61 @@ class NonInteractiveTerminalError(InputError):
             "Provide expert answers programmatically, e.g. via "
             "Human(use_loaded_answers=True), instead of relying on an interactive prompt in "
             "a non-interactive environment such as CI."
+        )
+
+
+@dataclass
+class NoDistinguishingAttributeFound(InputError):
+    """
+    Raised by :class:`krrood.ripple_down_rules.experts.Oracle` when none of a case's
+    simple (bool/int/float/str/None) attributes differ from the corner case it conflicts
+    with, so no differentiating condition can be constructed for it.
+    """
+
+    case: Any
+    """
+    The case being classified.
+    """
+    corner_case: Any
+    """
+    The corner case that the rule under refinement was created from.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"Could not find any simple attribute that differentiates {self.case} from "
+            f"its corner case {self.corner_case}."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Add a simple (bool/int/float/str) attribute to the case that differs from "
+            "the corner case, or provide this answer manually instead of using the "
+            "Oracle expert."
+        )
+
+
+@dataclass
+class OracleCannotInferConclusionWithoutTarget(InputError):
+    """
+    Raised by :class:`krrood.ripple_down_rules.experts.Oracle` when asked for a
+    conclusion on a case query with no known target value: the oracle only ever
+    describes a target it is already given, it never guesses one.
+    """
+
+    case_query: CaseQuery
+    """
+    The case query with no known target value.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"The Oracle expert cannot infer a conclusion for {self.case_query} since it "
+            f"has no known target value."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Provide a target value on the case query (CaseQuery._target), or use a "
+            "different expert that can genuinely infer conclusions, such as Human or AI."
         )

--- a/krrood/src/krrood/ripple_down_rules/experts.py
+++ b/krrood/src/krrood/ripple_down_rules/experts.py
@@ -8,27 +8,35 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import is_dataclass
 from textwrap import dedent, indent
-from typing_extensions import Tuple, Dict
+from sqlalchemy.orm import DeclarativeBase as SQLTable
+from typing_extensions import Any, Tuple, Dict
 
 from typing_extensions import Optional, TYPE_CHECKING, List
 
 from krrood.ripple_down_rules.datastructures.callable_expression import (
     CallableExpression,
 )
-from krrood.ripple_down_rules.datastructures.case import show_current_and_corner_cases
+from krrood.ripple_down_rules.datastructures.case import (
+    create_case,
+    show_current_and_corner_cases,
+)
 from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
 from krrood.ripple_down_rules.datastructures.enums import PromptFor
 from krrood.ripple_down_rules.exceptions import (
+    NoDistinguishingAttributeFound,
     NoSavePathFoundForExpertAnswers,
     NoLoadPathFoundForExpertAnswers,
+    OracleCannotInferConclusionWithoutTarget,
 )
 from krrood.ripple_down_rules.user_interface.template_file_creator import (
     TemplateFileCreator,
 )
 from krrood.ripple_down_rules.utils import (
+    dataclass_to_dict,
     extract_function_or_class_file,
     get_imports_from_scope,
     get_class_file_path,
+    row_to_dict,
 )
 from krrood.utils import get_scope_from_imports
 
@@ -481,3 +489,103 @@ class Human(Expert):
             sys.exit()
         case_query.target = expression
         return expression
+
+
+class Oracle(Expert):
+    """
+    A programmatic expert that answers ripple-down-rule queries by comparing a case's
+    attributes with those of the corner case it conflicts with, instead of asking a
+    human or replaying pre-recorded answers.
+
+    Every case query fit against this expert must already carry a known target value:
+    the oracle never guesses a conclusion, it only ever describes which of the case's
+    simple (bool/int/float/str) attributes single it out from the corner case, mirroring
+    how a human expert would compare two rows of a table and point at the column that
+    differs.
+    """
+
+    simple_attribute_value_types: Tuple[type, ...] = (bool, int, float, str, type(None))
+    """
+    The attribute value types the oracle is willing to build a differentiating condition
+    from.
+    """
+
+    def ask_for_conditions(
+        self, case_query: CaseQuery, last_evaluated_rule: Optional[Rule] = None
+    ) -> CallableExpression:
+        condition_source = self._differentiating_condition_source(
+            case_query, last_evaluated_rule
+        )
+        condition = CallableExpression(condition_source, bool, scope=case_query.scope)
+        self.all_expert_answers.append((condition.scope, condition_source))
+        case_query.conditions = condition
+        return condition
+
+    def ask_for_conclusion(self, case_query: CaseQuery) -> Optional[CallableExpression]:
+        if case_query._target is None:
+            raise OracleCannotInferConclusionWithoutTarget(case_query)
+        return case_query.target
+
+    def _differentiating_condition_source(
+        self, case_query: CaseQuery, last_evaluated_rule: Optional[Rule]
+    ) -> str:
+        """
+        Build the source of a condition that is true for the case in the given case
+        query, and, if a corner case is available, false for that corner case.
+
+        :param case_query: The case query containing the case to build a condition for.
+        :param last_evaluated_rule: The last evaluated rule, whose corner case (if any)
+            the built condition must exclude.
+        :return: The source code of a ``return`` statement usable as a
+            :class:`CallableExpression`.
+        """
+        corner_case = (
+            last_evaluated_rule.corner_case if last_evaluated_rule is not None else None
+        )
+        if corner_case is None:
+            return "return True"
+        attribute_name, attribute_value = self._first_distinguishing_attribute(
+            case_query.case, corner_case, exclude={case_query.attribute_name.lower()}
+        )
+        return f"return case.{attribute_name} == {attribute_value!r}"
+
+    def _first_distinguishing_attribute(
+        self, case: Any, corner_case: Any, exclude: set
+    ) -> Tuple[str, Any]:
+        """
+        Find the first simple attribute that differs between a case and its corner case.
+
+        :param case: The case to classify.
+        :param corner_case: The corner case to differentiate the case from.
+        :param exclude: Attribute names to never consider, such as the attribute the
+            case query is trying to determine a value for.
+        :return: The name and value of the first differing simple attribute, taken from
+            ``case``.
+        :raises NoDistinguishingAttributeFound: if no such attribute exists.
+        """
+        case_attributes = self._attribute_dict(case)
+        corner_case_attributes = self._attribute_dict(corner_case)
+        for name, value in case_attributes.items():
+            if name in exclude or not isinstance(
+                value, self.simple_attribute_value_types
+            ):
+                continue
+            if corner_case_attributes.get(name, object()) != value:
+                return name, value
+        raise NoDistinguishingAttributeFound(case, corner_case)
+
+    @staticmethod
+    def _attribute_dict(obj: Any) -> Dict[str, Any]:
+        """
+        Get a name-to-value mapping of an object's attributes, regardless of whether it
+        is a SQLAlchemy mapped instance, a dataclass, or any other object.
+
+        :param obj: The object to get the attributes of.
+        :return: The name-to-value mapping of the object's attributes.
+        """
+        if isinstance(obj, SQLTable):
+            return row_to_dict(obj)
+        elif is_dataclass(obj):
+            return dataclass_to_dict(obj)
+        else:
+            return dict(create_case(obj).items())

--- a/test/krrood_test/test_ripple_down_rules/test_oracle_expert.py
+++ b/test/krrood_test/test_ripple_down_rules/test_oracle_expert.py
@@ -1,0 +1,160 @@
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+from typing_extensions import Optional
+
+from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
+from krrood.ripple_down_rules.exceptions import (
+    NoDistinguishingAttributeFound,
+    OracleCannotInferConclusionWithoutTarget,
+)
+from krrood.ripple_down_rules.experts import Oracle
+from krrood.ripple_down_rules.rdr import SingleClassRDR
+
+
+class AnimalClass(Enum):
+    """
+    A minimal target enum mimicking the real-world Species enum, used to exercise Oracle
+    without depending on the zoo dataset or the network.
+    """
+
+    mammal = "mammal"
+    bird = "bird"
+    arachnid = "arachnid"
+
+
+@dataclass
+class Animal:
+    """
+    A minimal case mimicking a real-world animal entity with a mix of simple attributes,
+    used to exercise Oracle without depending on the zoo dataset or the network.
+    """
+
+    name: str
+    has_fur: bool
+    leg_count: int
+    animal_class: Optional[AnimalClass] = None
+
+
+@dataclass
+class RuleWithCornerCase:
+    """
+    A minimal stand-in for a ripple-down-rule node, carrying only the one field
+    (``corner_case``) that Oracle reads off the last evaluated rule.
+    """
+
+    corner_case: object
+
+
+def make_case_query(case: Animal, target: AnimalClass) -> CaseQuery:
+    return CaseQuery(case, "animal_class", (AnimalClass,), True, _target=target)
+
+
+class TestOracleBuildsAConditionTrueForTheCaseAndFalseForTheCornerCase:
+
+    def test_condition_is_true_for_the_case_and_false_for_the_corner_case(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        corner_case = Animal(name="parrot", has_fur=False, leg_count=2)
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+        last_evaluated_rule = RuleWithCornerCase(corner_case=corner_case)
+
+        condition = Oracle().ask_for_conditions(case_query, last_evaluated_rule)
+
+        assert condition(case) is True
+        assert condition(corner_case) is False
+
+    def test_picks_the_first_differing_attribute_in_declaration_order(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        corner_case = Animal(name="cat", has_fur=True, leg_count=4)
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+        last_evaluated_rule = RuleWithCornerCase(corner_case=corner_case)
+
+        condition = Oracle().ask_for_conditions(case_query, last_evaluated_rule)
+
+        assert "case.name" in condition.user_input
+
+    def test_never_builds_a_condition_on_the_attribute_being_predicted(self):
+        case = Animal(
+            name="dog", has_fur=True, leg_count=4, animal_class=AnimalClass.mammal
+        )
+        corner_case = Animal(
+            name="cat", has_fur=True, leg_count=4, animal_class=AnimalClass.bird
+        )
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+        last_evaluated_rule = RuleWithCornerCase(corner_case=corner_case)
+
+        condition = Oracle().ask_for_conditions(case_query, last_evaluated_rule)
+
+        assert "case.animal_class" not in condition.user_input
+        assert "case.name" in condition.user_input
+
+
+class TestOracleReturnsAnUnconditionalRuleWithNoCornerCase:
+
+    def test_returns_an_unconditional_rule_when_no_rule_was_evaluated_yet(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+
+        condition = Oracle().ask_for_conditions(case_query, last_evaluated_rule=None)
+
+        assert condition(case) is True
+
+
+class TestOracleRaisesWhenNoAttributeDistinguishesTheCaseFromItsCornerCase:
+
+    def test_raises_when_the_case_and_corner_case_are_identical(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        corner_case = Animal(name="dog", has_fur=True, leg_count=4)
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+        last_evaluated_rule = RuleWithCornerCase(corner_case=corner_case)
+
+        with pytest.raises(NoDistinguishingAttributeFound):
+            Oracle().ask_for_conditions(case_query, last_evaluated_rule)
+
+
+class TestOracleNeverGuessesAConclusion:
+
+    def test_returns_the_known_target_as_the_conclusion(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        case_query = make_case_query(case, target=AnimalClass.mammal)
+
+        conclusion = Oracle().ask_for_conclusion(case_query)
+
+        assert conclusion(case) == AnimalClass.mammal
+
+    def test_raises_when_the_case_query_has_no_known_target(self):
+        case = Animal(name="dog", has_fur=True, leg_count=4)
+        case_query = CaseQuery(case, "animal_class", (AnimalClass,), True)
+
+        with pytest.raises(OracleCannotInferConclusionWithoutTarget):
+            Oracle().ask_for_conclusion(case_query)
+
+
+class TestOracleFitsASingleClassRDRWithoutAnyPreRecordedAnswers:
+
+    def test_fits_and_classifies_a_small_multi_class_dataset(self):
+        cases = [
+            Animal(name="dog", has_fur=True, leg_count=4),
+            Animal(name="cat", has_fur=True, leg_count=4),
+            Animal(name="parrot", has_fur=False, leg_count=2),
+            Animal(name="eagle", has_fur=False, leg_count=2),
+            Animal(name="spider", has_fur=False, leg_count=8),
+        ]
+        targets = [
+            AnimalClass.mammal,
+            AnimalClass.mammal,
+            AnimalClass.bird,
+            AnimalClass.bird,
+            AnimalClass.arachnid,
+        ]
+        case_queries = [
+            CaseQuery(case, "animal_class", (AnimalClass,), True, _target=target)
+            for case, target in zip(cases, targets)
+        ]
+
+        scrdr = SingleClassRDR()
+        scrdr.fit(case_queries, expert=Oracle())
+
+        for case, target in zip(cases, targets):
+            assert scrdr.classify(case) == target

--- a/test/krrood_test/test_ripple_down_rules/test_rdr_alchemy.py
+++ b/test/krrood_test/test_ripple_down_rules/test_rdr_alchemy.py
@@ -18,7 +18,7 @@ from .datasets import (
     load_zoo_dataset,
 )
 from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
-from krrood.ripple_down_rules.experts import Human
+from krrood.ripple_down_rules.experts import Human, Oracle
 from krrood.ripple_down_rules.rdr import SingleClassRDR, MultiClassRDR, GeneralRDR
 from krrood.ripple_down_rules.utils import make_set
 from .test_helpers.helpers import get_fit_scrdr
@@ -99,6 +99,24 @@ class TestAlchemyRDR(TestCase):
 
         cat = scrdr.classify(result[50])
         assert cat == self.targets[50]
+
+    def test_fit_scrdr_with_oracle_expert_needs_no_pre_recorded_answers(self):
+        """
+        Regression test for the pre-recorded expert-answer fixtures running out of
+        answers on the full zoo dataset (raising NonInteractiveTerminalError): fitting
+        against the same full dataset with the programmatic Oracle expert instead of a
+        Human replaying a fixed, finite answer file must classify every case correctly,
+        without ever needing a human or an interactive shell.
+        """
+        scrdr = SingleClassRDR()
+        case_queries = [
+            CaseQuery(c, "species", (Species,), True, _target=t)
+            for c, t in zip(self.all_cases, self.targets)
+        ]
+        scrdr.fit(case_queries, expert=Oracle(), animate_tree=False)
+
+        for case, target in zip(self.all_cases, self.targets):
+            assert scrdr.classify(case) == target
 
     def test_fit_mcrdr_stop_only(self):
         use_loaded_answers = True


### PR DESCRIPTION
Adds `Oracle`, a new `Expert` implementation for krrood's ripple-down-rules that answers ask_for_conditions/ask_for_conclusion programmatically instead of replaying a fixed, finite answer file or prompting a human — closing a real gap where the recorded test_expert_answers/*.py fixtures don't have enough recorded conditions to fully differentiate the real 101-row, 7-species zoo dataset.

Full detail and test plan: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/74