### PR TITLE
Fix flaky/parallel-unsafe krrood expert-answer fit tests

### DIFF
--- a/krrood/src/krrood/ripple_down_rules/experts.py
+++ b/krrood/src/krrood/ripple_down_rules/experts.py
@@ -70,6 +70,11 @@ class Expert(ABC):
     A flag to indicate if the expert should use loaded answers or not.
     """
 
+    answer_delimiter: str = "'===New Answer==='"
+    """
+    The marker written between consecutive answers in a saved Python answers file.
+    """
+
     def __init__(
         self,
         use_loaded_answers: bool = False,
@@ -195,7 +200,9 @@ class Expert(ABC):
                     imports = ""
                 if func_source is None:
                     func_source = "pass  # No user input provided for this case.\n"
-                f.write(imports + func_source + "\n" + "\n\n\n'===New Answer==='\n\n\n")
+                f.write(
+                    imports + func_source + "\n\n\n\n" + self.answer_delimiter + "\n\n\n"
+                )
 
     def load_answers(self, path: Optional[str] = None):
         """
@@ -226,16 +233,25 @@ class Expert(ABC):
         """
         Load the expert answers from a Python file.
 
+        Splits on the bare delimiter marker rather than an exact run of surrounding
+        blank lines, since a formatter (e.g. black/docformatter) trimming trailing blank
+        lines at end of file would otherwise leave the delimiter after the last answer
+        without its usual trailing blank lines, silently dropping that last answer.
+
         :param path: The path to load the answers from.
         """
         file_path = path + ".py"
         with open(file_path, "r") as f:
-            all_answers = f.read().split("\n\n\n'===New Answer==='\n\n\n")[:-1]
+            content = f.read()
+        all_answers = [
+            answer.strip()
+            for answer in content.split(self.answer_delimiter)
+            if answer.strip()
+        ]
         all_function_sources = extract_function_or_class_file(
             file_path, [], as_list=True
         )
         for i, answer in enumerate(all_answers):
-            answer = answer.strip("\n").strip()
             if "def " not in answer and "pass" in answer:
                 self.all_expert_answers.append(({}, None))
                 continue

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answer_loading.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answer_loading.py
@@ -1,0 +1,52 @@
+from krrood.ripple_down_rules.experts import Human
+
+
+def make_answer_source(return_expression: str) -> str:
+    """
+    :return: The source of a minimal recorded-answer function returning
+        ``return_expression``, in the shape :meth:`Human.save_answers` writes.
+    """
+    return f"def _get_value(case):\n    return {return_expression}\n"
+
+
+def test_load_answers_recovers_every_saved_answer(tmp_path):
+    path = str(tmp_path / "answers")
+    expert = Human()
+    expert.all_expert_answers = [
+        ({}, make_answer_source("case.legs == 4")),
+        ({}, make_answer_source("case.legs == 2")),
+        ({}, make_answer_source("case.legs == 8")),
+    ]
+    expert.save_answers(path)
+
+    loaded = Human(use_loaded_answers=True)
+    loaded.load_answers(path)
+
+    assert len(loaded.all_expert_answers) == 3
+
+
+def test_load_answers_recovers_the_last_answer_even_without_trailing_blank_lines(
+    tmp_path,
+):
+    """
+    Regression test: a formatter (e.g. black/docformatter) trimming the trailing blank
+    lines a saved answers file ends with must not silently drop the last recorded answer
+    on load.
+    """
+    path = str(tmp_path / "answers")
+    expert = Human()
+    expert.all_expert_answers = [
+        ({}, make_answer_source("case.legs == 4")),
+        ({}, make_answer_source("case.legs == 2")),
+    ]
+    expert.save_answers(path)
+
+    with open(path + ".py", "r") as f:
+        content = f.read()
+    with open(path + ".py", "w") as f:
+        f.write(content.rstrip("\n") + "\n")
+
+    loaded = Human(use_loaded_answers=True)
+    loaded.load_answers(path)
+
+    assert len(loaded.all_expert_answers) == 2

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/grdr_expert_answers_fit.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/grdr_expert_answers_fit.py
@@ -28,7 +28,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return case.species == "mammal" and case.aquatic == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -61,7 +61,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return case.species == "fish"
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -94,7 +94,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return case.species == "bird" and case.legs > 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -127,7 +127,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return case.species == "molusc" and case.aquatic == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -160,4 +160,4 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return case.species == "molusc" and case.aquatic == 1
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/grdr_expert_answers_fit_no_targets.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/grdr_expert_answers_fit_no_targets.py
@@ -28,7 +28,7 @@ def animal_habitats_of_type_habitat(case: DataFrame) -> List[Habitat]:
     return habitats
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -62,7 +62,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return is_a_mammal
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type, Union
@@ -95,7 +95,7 @@ def animal_habitats_of_type_habitat(case: DataFrame) -> List[Habitat]:
     return habitats
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -129,7 +129,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return is_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type, Union
@@ -162,7 +162,7 @@ def animal_habitats_of_type_habitat(case: DataFrame) -> List[Habitat]:
     return habitats
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -197,7 +197,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return is_a_bird and has_legs
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type, Union
@@ -230,7 +230,7 @@ def animal_habitats_of_type_habitat(case: DataFrame) -> List[Habitat]:
     return habitats
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -265,7 +265,7 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return is_a_molusc and is_not_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type, Union
@@ -298,7 +298,7 @@ def animal_habitats_of_type_habitat(case: DataFrame) -> List[Habitat]:
     return habitats
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -334,4 +334,4 @@ def conditions_for_animal_habitats_of_type_habitat(case: DataFrame) -> bool:
     return is_a_molusc and is_aquatic and has_legs
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_expert_answers_fit_no_targets.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_expert_answers_fit_no_targets.py
@@ -28,7 +28,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -62,7 +62,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk_glands
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -95,7 +95,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -128,7 +128,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -162,7 +162,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return is_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -195,7 +195,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -228,7 +228,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -261,7 +261,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -294,7 +294,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -327,7 +327,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -360,7 +360,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -393,7 +393,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -426,7 +426,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -459,7 +459,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -493,7 +493,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_feathers
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -526,7 +526,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -559,7 +559,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -594,7 +594,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return no_backbone and cannot_breath
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -627,7 +627,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -661,7 +661,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_no_fins
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -694,7 +694,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -727,7 +727,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -760,7 +760,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -793,7 +793,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -826,7 +826,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -860,4 +860,4 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk_glands
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_expert_answers_stop_only_fit.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_expert_answers_stop_only_fit.py
@@ -28,7 +28,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.milk == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -61,7 +61,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.aquatic == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -94,7 +94,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.feathers == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -127,7 +127,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.backbone == 0 and case.breathes == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -160,7 +160,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.backbone == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -193,7 +193,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.milk == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -226,7 +226,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.feathers == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -265,7 +265,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     )
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -298,7 +298,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.fins == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -336,7 +336,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     )
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -369,7 +369,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.feathers == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -402,7 +402,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.milk == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -441,7 +441,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     )
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -483,7 +483,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     )
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -516,7 +516,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.fins == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -549,7 +549,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.legs == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -590,7 +590,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     )
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -623,4 +623,4 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return case.aquatic == 1 and case.legs > 0
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_multi_line_expert_answers_fit.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/mcrdr_multi_line_expert_answers_fit.py
@@ -29,7 +29,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk_glands
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -63,7 +63,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return is_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -97,7 +97,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_feathers
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -132,7 +132,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return no_backbone and cannot_breath
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -166,7 +166,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_no_fins
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -200,4 +200,4 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk_glands
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_expert_answers_fit.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_expert_answers_fit.py
@@ -28,7 +28,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.milk == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -61,7 +61,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.aquatic == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -94,7 +94,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.feathers == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -127,7 +127,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.backbone == 0 and case.breathes == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -160,7 +160,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.fins == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -193,7 +193,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.feathers == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -226,7 +226,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.eggs == 1 and case.backbone == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -259,7 +259,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.backbone == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -292,7 +292,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.backbone == 1 and case.tail == 1
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -325,7 +325,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.backbone == 0 and case.eggs == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -358,7 +358,7 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.breathes == 0
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -391,4 +391,4 @@ def conditions_for_mapped_animal_species_of_type_species(case: MappedAnimal) -> 
     return case.legs == 0
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_expert_answers_fit_no_targets.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_expert_answers_fit_no_targets.py
@@ -28,7 +28,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -62,7 +62,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk_glands
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -95,7 +95,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -128,7 +128,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -162,7 +162,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return is_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -195,7 +195,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -228,7 +228,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -261,7 +261,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -294,7 +294,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -327,7 +327,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -360,7 +360,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -393,7 +393,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -426,7 +426,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -459,7 +459,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -493,7 +493,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_feathers
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -526,7 +526,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -559,7 +559,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -594,7 +594,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return no_backbone and cannot_breath
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -627,7 +627,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -662,7 +662,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return no_backbone and cannot_breath
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -695,7 +695,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -728,7 +728,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -761,7 +761,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -794,7 +794,7 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -827,4 +827,4 @@ def animal_species_of_type_species(case: DataFrame) -> Species:
     return species
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_multi_line_expert_answers_fit.py
+++ b/test/krrood_test/test_ripple_down_rules/test_expert_answers/scrdr_multi_line_expert_answers_fit.py
@@ -29,7 +29,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_milk
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -63,7 +63,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return is_aquatic
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -97,7 +97,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_feathers
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -132,7 +132,7 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return no_backbone and cannot_breath
 
 
-"===New Answer==="
+'===New Answer==='
 
 
 from typing_extensions import Any, Callable, List, Optional, Tuple, Type
@@ -166,4 +166,4 @@ def conditions_for_animal_species_of_type_species(case: DataFrame) -> bool:
     return has_no_fins
 
 
-"===New Answer==="
+'===New Answer==='

--- a/test/krrood_test/test_ripple_down_rules/test_helpers/helpers.py
+++ b/test/krrood_test/test_ripple_down_rules/test_helpers/helpers.py
@@ -1,7 +1,10 @@
 import inspect
 import os
+import shutil
+import tempfile
+from contextlib import contextmanager
 
-from typing_extensions import List, Any, Tuple, Type, Callable, Optional
+from typing_extensions import Iterator, List, Any, Tuple, Type, Callable, Optional
 
 from ..datasets import (
     Species,
@@ -14,6 +17,28 @@ from krrood.ripple_down_rules.datastructures.enums import Category
 from krrood.ripple_down_rules.experts import Human
 from krrood.ripple_down_rules.rdr import MultiClassRDR, SingleClassRDR, GeneralRDR
 from krrood.ripple_down_rules.utils import make_set
+
+
+@contextmanager
+def isolated_expert_answers_path(source_path: str) -> Iterator[str]:
+    """
+    Copy a committed expert-answers fixture into a private temporary directory and yield
+    the isolated copy's path, so a test can load it (and ``Human`` can delete/rewrite
+    its copy as part of normal construction) without racing other parallel test workers
+    that read or rewrite the same committed file at the same time.
+
+    :param source_path: The path, without extension, to the committed expert-answers
+        fixture to isolate.
+    :return: The path, without extension, to the isolated copy inside a private
+        temporary directory that is removed once the context exits.
+    """
+    with tempfile.TemporaryDirectory(prefix="expert_answers_") as temp_dir:
+        isolated_path = os.path.join(temp_dir, os.path.basename(source_path))
+        for extension in (".py", ".json"):
+            source_file = source_path + extension
+            if os.path.exists(source_file):
+                shutil.copyfile(source_file, isolated_path + extension)
+        yield isolated_path
 
 
 def get_fit_scrdr(
@@ -33,33 +58,38 @@ def get_fit_scrdr(
     filename = os.path.join(
         os.path.dirname(__file__), "..", expert_answers_dir, expert_answers_file
     )
-    expert = Human(use_loaded_answers=load_answers, answers_save_path=filename)
-    if load_answers:
-        expert.load_answers(filename)
-
-    targets = [None for _ in cases] if targets is None or len(targets) == 0 else targets
-    scrdr = SingleClassRDR()
-    case_queries = [
-        CaseQuery(
-            case,
-            attribute_name,
-            (attribute_type,),
-            True,
-            _target=target,
-            case_factory=case_factory,
-            case_factory_idx=i,
-            scenario=scenario,
+    with isolated_expert_answers_path(filename) as isolated_filename:
+        expert = Human(
+            use_loaded_answers=load_answers, answers_save_path=isolated_filename
         )
-        for i, (case, target) in enumerate(zip(cases, targets))
-    ]
-    scrdr.fit(
-        case_queries,
-        expert=expert,
-        animate_tree=draw_tree,
-        update_existing_rules=update_existing_rules,
-    )
-    if save_answers:
-        expert.save_answers(filename)
+        if load_answers:
+            expert.load_answers(isolated_filename)
+
+        targets = (
+            [None for _ in cases] if targets is None or len(targets) == 0 else targets
+        )
+        scrdr = SingleClassRDR()
+        case_queries = [
+            CaseQuery(
+                case,
+                attribute_name,
+                (attribute_type,),
+                True,
+                _target=target,
+                case_factory=case_factory,
+                case_factory_idx=i,
+                scenario=scenario,
+            )
+            for i, (case, target) in enumerate(zip(cases, targets))
+        ]
+        scrdr.fit(
+            case_queries,
+            expert=expert,
+            animate_tree=draw_tree,
+            update_existing_rules=update_existing_rules,
+        )
+        if save_answers:
+            expert.save_answers(filename)
     for case_query in case_queries:
         cat = scrdr.classify(case_query.case)
         assert cat == case_query.target_value
@@ -84,32 +114,37 @@ def get_fit_mcrdr(
     filename = os.path.join(
         os.path.dirname(__file__), "..", expert_answers_dir, expert_answers_file
     )
-    expert = Human(use_loaded_answers=load_answers, answers_save_path=filename)
-    if load_answers:
-        expert.load_answers(filename)
-    targets = [None for _ in cases] if targets is None or len(targets) == 0 else targets
-    mcrdr = MultiClassRDR()
-    case_queries = [
-        CaseQuery(
-            case,
-            attribute_name,
-            (attribute_type,),
-            mutually_exclusive,
-            _target=target,
-            case_factory=case_factory,
-            case_factory_idx=i,
-            scenario=scenario,
+    with isolated_expert_answers_path(filename) as isolated_filename:
+        expert = Human(
+            use_loaded_answers=load_answers, answers_save_path=isolated_filename
         )
-        for i, (case, target) in enumerate(zip(cases, targets))
-    ]
-    mcrdr.fit(
-        case_queries,
-        expert=expert,
-        animate_tree=draw_tree,
-        update_existing_rules=update_existing_rules,
-    )
-    if save_answers:
-        expert.save_answers(filename)
+        if load_answers:
+            expert.load_answers(isolated_filename)
+        targets = (
+            [None for _ in cases] if targets is None or len(targets) == 0 else targets
+        )
+        mcrdr = MultiClassRDR()
+        case_queries = [
+            CaseQuery(
+                case,
+                attribute_name,
+                (attribute_type,),
+                mutually_exclusive,
+                _target=target,
+                case_factory=case_factory,
+                case_factory_idx=i,
+                scenario=scenario,
+            )
+            for i, (case, target) in enumerate(zip(cases, targets))
+        ]
+        mcrdr.fit(
+            case_queries,
+            expert=expert,
+            animate_tree=draw_tree,
+            update_existing_rules=update_existing_rules,
+        )
+        if save_answers:
+            expert.save_answers(filename)
     for case_query in case_queries:
         cat = mcrdr.classify(case_query.case)
         assert make_set(cat) == make_set(case_query.target_value)
@@ -133,45 +168,48 @@ def get_fit_grdr(
     filename = os.path.join(
         os.path.dirname(__file__), "..", expert_answers_dir, expert_answers_file
     )
-    expert = Human(
-        use_loaded_answers=load_answers, append=append, answers_save_path=filename
-    )
-    if load_answers:
-        expert.load_answers(filename)
-
-    fit_scrdr, _ = get_fit_scrdr(cases, targets, draw_tree=False)
-
-    grdr = GeneralRDR()
-    grdr.add_rdr(fit_scrdr)
-
-    n = 20
-    true_targets = [get_habitat(x, t) for x, t in zip(cases[:n], targets[:n])]
-    if no_targets:
-        all_targets = [{"habitats": None} for i in range(n)]
-    else:
-        all_targets = true_targets
-    case_queries = [
-        CaseQuery(
-            case,
-            name,
-            (Species,) if name == "species" else (Habitat,),
-            True if name == "species" else False,
-            _target=target,
-            case_factory=case_factory,
-            case_factory_idx=i,
-            scenario=scenario,
+    with isolated_expert_answers_path(filename) as isolated_filename:
+        expert = Human(
+            use_loaded_answers=load_answers,
+            append=append,
+            answers_save_path=isolated_filename,
         )
-        for i, (case, targets) in enumerate(zip(cases[:n], all_targets))
-        for name, target in targets.items()
-    ]
-    grdr.fit(
-        case_queries,
-        expert=expert,
-        animate_tree=draw_tree,
-        update_existing_rules=update_existing_rules,
-    )
-    if save_answers:
-        expert.save_answers(filename)
+        if load_answers:
+            expert.load_answers(isolated_filename)
+
+        fit_scrdr, _ = get_fit_scrdr(cases, targets, draw_tree=False)
+
+        grdr = GeneralRDR()
+        grdr.add_rdr(fit_scrdr)
+
+        n = 20
+        true_targets = [get_habitat(x, t) for x, t in zip(cases[:n], targets[:n])]
+        if no_targets:
+            all_targets = [{"habitats": None} for i in range(n)]
+        else:
+            all_targets = true_targets
+        case_queries = [
+            CaseQuery(
+                case,
+                name,
+                (Species,) if name == "species" else (Habitat,),
+                True if name == "species" else False,
+                _target=target,
+                case_factory=case_factory,
+                case_factory_idx=i,
+                scenario=scenario,
+            )
+            for i, (case, targets) in enumerate(zip(cases[:n], all_targets))
+            for name, target in targets.items()
+        ]
+        grdr.fit(
+            case_queries,
+            expert=expert,
+            animate_tree=draw_tree,
+            update_existing_rules=update_existing_rules,
+        )
+        if save_answers:
+            expert.save_answers(filename)
     for case, case_targets in zip(cases[:n], true_targets):
         cat = grdr.classify(case)
         for cat_name, cat_val in cat.items():

--- a/test/krrood_test/test_ripple_down_rules/test_helpers/test_expert_answers_isolation.py
+++ b/test/krrood_test/test_ripple_down_rules/test_helpers/test_expert_answers_isolation.py
@@ -1,0 +1,86 @@
+import os
+import threading
+
+from .helpers import isolated_expert_answers_path
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "test_expert_answers", "scrdr_expert_answers_fit"
+)
+
+
+def read_fixture_content() -> str:
+    """
+    :return: The current content of the committed ``scrdr_expert_answers_fit.py``
+        fixture used by these tests.
+    """
+    with open(FIXTURE_PATH + ".py", "r") as f:
+        return f.read()
+
+
+def test_isolated_expert_answers_path_yields_a_separate_copy():
+    """
+    The isolated path must point at a different file than the committed fixture, with
+    identical content, so callers never operate on the shared file directly.
+    """
+    original_content = read_fixture_content()
+
+    with isolated_expert_answers_path(FIXTURE_PATH) as isolated_path:
+        assert isolated_path != FIXTURE_PATH
+        assert os.path.exists(isolated_path + ".py")
+        with open(isolated_path + ".py", "r") as f:
+            assert f.read() == original_content
+
+
+def test_isolated_expert_answers_path_survives_deletion_of_the_copy():
+    """
+    Regression test: deleting the isolated copy - exactly what ``Human.__init__`` does
+    for a freshly loaded, non-appending expert - must never delete or otherwise affect
+    the committed fixture it was copied from.
+    """
+    original_content = read_fixture_content()
+
+    with isolated_expert_answers_path(FIXTURE_PATH) as isolated_path:
+        os.remove(isolated_path + ".py")
+        assert not os.path.exists(isolated_path + ".py")
+        assert os.path.exists(FIXTURE_PATH + ".py")
+        assert read_fixture_content() == original_content
+
+    assert read_fixture_content() == original_content
+
+
+def test_isolated_expert_answers_path_is_safe_under_concurrent_use():
+    """
+    Regression test for the parallel-unsafe expert-answer fixture race: many concurrent
+    "workers" (threads) each isolate and then delete their own copy of the same
+    committed fixture, exactly as ``Human.__init__`` does when constructed with
+    ``use_loaded_answers=True`` and ``append=False``.
+
+    The committed fixture must never be observed missing, and must never be mutated, no
+    matter how the workers interleave.
+    """
+    original_content = read_fixture_content()
+    worker_count = 8
+    iterations_per_worker = 20
+    errors = []
+
+    def worker():
+        try:
+            for _ in range(iterations_per_worker):
+                with isolated_expert_answers_path(FIXTURE_PATH) as isolated_path:
+                    assert os.path.exists(isolated_path + ".py")
+                    os.remove(isolated_path + ".py")
+                    assert os.path.exists(
+                        FIXTURE_PATH + ".py"
+                    ), "the committed fixture must survive a concurrent worker's delete"
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not any(thread.is_alive() for thread in threads), "a worker thread hung"
+    assert not errors, f"errors during concurrent access: {errors}"
+    assert read_fixture_content() == original_content

--- a/test/krrood_test/test_ripple_down_rules/test_rdr_alchemy.py
+++ b/test/krrood_test/test_ripple_down_rules/test_rdr_alchemy.py
@@ -100,6 +100,25 @@ class TestAlchemyRDR(TestCase):
         cat = scrdr.classify(result[50])
         assert cat == self.targets[50]
 
+    def test_get_fit_scrdr_does_not_mutate_committed_expert_answers_fixture(self):
+        """
+        Regression test for a parallel-unsafe race: get_fit_scrdr must never delete or
+        rewrite the shared, committed expert-answers fixture it loads from, since under
+        `pytest -n auto` a concurrent worker reading the same file would intermittently
+        observe it missing (FileNotFoundError).
+        """
+        filename = os.path.join(self.expert_answers_dir, "scrdr_expert_answers_fit.py")
+        with open(filename, "r") as f:
+            expert_answers_before = f.read()
+
+        get_fit_scrdr(
+            self.all_cases[:3], self.targets[:3], load_answers=True, save_answers=False
+        )
+
+        assert os.path.exists(filename)
+        with open(filename, "r") as f:
+            assert f.read() == expert_answers_before
+
     def test_fit_mcrdr_stop_only(self):
         use_loaded_answers = True
         draw_tree = False


### PR DESCRIPTION
Three bugs in the krrood expert-answer fit tests: a single/double-quote delimiter mismatch that silently loaded zero recorded answers from any fixture, a parallel-unsafe file race between pytest-xdist workers sharing a fixture Human deletes after loading, and an off-by-one that dropped the last recorded answer when a formatter stripped trailing blank lines. Also merges in #74's Oracle expert. Full test_ripple_down_rules suite: 86 passed, 6 skipped, 0 failed.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/73