### PR TITLE
Fix/mujoco builder bakes joint state

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
@@ -296,8 +296,10 @@ class KinematicStructureEntityConverter(EntityConverter, ABC):
         """
 
         kinematic_structure_entity_props = EntityConverter._convert(self, entity)
+        # The simulator joint supplies the variable part, so the static frame must
+        # exclude it (see Connection.reference_origin_expression).
         [px, py, pz, qx, qy, qz, qw] = (
-            entity.parent_connection.origin_as_position_quaternion().evaluate()[0]
+            entity.parent_connection.reference_origin_as_position_quaternion().evaluate()[0]
         )
         kinematic_structure_entity_pos = [px, py, pz]
         kinematic_structure_entity_quat = [qw, qx, qy, qz]

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
@@ -974,10 +974,21 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
             f"Origin can not be set for Connection: {self.__class__.__name__}"
         )
 
-    def origin_as_position_quaternion(self) -> Matrix:
-        position = self.origin_expression.to_position()[:3]
-        orientation = self.origin_expression.to_quaternion()
+    @staticmethod
+    def _as_position_quaternion(
+        parent_T_child: HomogeneousTransformationMatrix,
+    ) -> Matrix:
+        """
+        Stack a transform's translation and rotation into a single row.
+
+        :return: A 1x7 matrix of ``[x, y, z, qx, qy, qz, qw]``.
+        """
+        position = parent_T_child.to_position()[:3]
+        orientation = parent_T_child.to_quaternion()
         return Matrix.vstack([position, orientation]).T
+
+    def origin_as_position_quaternion(self) -> Matrix:
+        return self._as_position_quaternion(self.origin_expression)
 
     @property
     def dofs(self) -> list[DegreeOfFreedom]:

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
@@ -928,6 +928,21 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
         )
 
     @property
+    def reference_origin_expression(self) -> HomogeneousTransformationMatrix:
+        """
+        The parent-to-child transform at the reference configuration, excluding the
+        variable joint :attr:`_kinematics`.
+
+        .. note::
+            A simulator must place a body's static frame with this rather than
+            :attr:`origin_expression`: the latter depends on the current joint
+            state, which the simulator joint would then apply a second time.
+
+        :return: The constant parent-to-child transform with the joint at zero.
+        """
+        return self.parent_T_connection_expression @ self.connection_T_child_expression
+
+    @property
     def active_dofs(self) -> List[DegreeOfFreedom]:
         return []
 
@@ -989,6 +1004,16 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
 
     def origin_as_position_quaternion(self) -> Matrix:
         return self._as_position_quaternion(self.origin_expression)
+
+    def reference_origin_as_position_quaternion(self) -> Matrix:
+        """
+        The reference-configuration origin (see :attr:`reference_origin_expression`)
+        as a stacked position and quaternion, so a simulator can place a body's
+        static frame independently of the current joint state.
+
+        :return: A 1x7 matrix of ``[x, y, z, qx, qy, qz, qw]``.
+        """
+        return self._as_position_quaternion(self.reference_origin_expression)
 
     @property
     def dofs(self) -> list[DegreeOfFreedom]:

--- a/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
@@ -480,6 +480,80 @@ def test_spawn_body_with_connections():
         stop_multisim_if_running(multi_sim)
 
 
+def test_body_frame_excludes_joint_state_at_build_time():
+    """A body's static frame must be built at the reference (zero-joint) pose.
+
+    The joint is non-zero while the simulator is built and is evaluated at a
+    different angle, so a frame that baked in the build-time angle would have it
+    applied twice and drift away from the world forward kinematics.
+    """
+    world = World()
+    base_body = Body(name=PrefixedName("base"))
+    rotated_link = Body(name=PrefixedName("rotated_link"))
+    # A tip offset from the joint axis, so a rotation actually moves its position
+    # (the joint child sits on the axis and would not reveal the bug).
+    tip_link = Body(name=PrefixedName("tip"))
+    rotated_origin = HomogeneousTransformationMatrix.from_xyz_quaternion(
+        pos_x=0.3,
+        pos_y=0.0,
+        pos_z=0.9,
+        quat_w=0.707,
+        quat_x=0.707,
+        quat_y=0.0,
+        quat_z=0.0,
+    )
+    tip_offset = HomogeneousTransformationMatrix.from_xyz_rpy(x=0.5, y=0.2, z=0.0)
+    rotated_joint_dof = DegreeOfFreedom(name=PrefixedName("rotated_joint"))
+    with world.modify_world():
+        world.add_body(base_body)
+        world.add_degree_of_freedom(rotated_joint_dof)
+        world.add_connection(
+            RevoluteConnection(
+                name=rotated_joint_dof.name,
+                parent=base_body,
+                child=rotated_link,
+                axis=Vector3.Z(reference_frame=rotated_link),
+                raw_dof=rotated_joint_dof,
+                parent_T_connection_expression=rotated_origin,
+            )
+        )
+        world.add_connection(
+            FixedConnection(
+                parent=rotated_link,
+                child=tip_link,
+                parent_T_connection_expression=tip_offset,
+            )
+        )
+
+    build_time_angle = 0.7
+    with world.modify_world():
+        world.state[rotated_joint_dof.id].position = build_time_angle
+
+    multi_sim = MujocoSim(world=world, headless=headless, step_size=0.001)
+    try:
+        evaluation_angle = 0.3
+        with world.modify_world():
+            world.state[rotated_joint_dof.id].position = evaluation_angle
+
+        mujoco_model = multi_sim.simulator._mj_model
+        mujoco_data = multi_sim.simulator._mj_data
+        joint_id = mujoco.mj_name2id(
+            mujoco_model, mujoco.mjtObj.mjOBJ_JOINT, rotated_joint_dof.name.name
+        )
+        mujoco_data.qpos[mujoco_model.jnt_qposadr[joint_id]] = evaluation_angle
+        mujoco.mj_forward(mujoco_model, mujoco_data)
+
+        simulated_position = multi_sim.simulator.get_body_position(
+            tip_link.name.name
+        ).result[:3]
+        world_position = world.compute_forward_kinematics_np(world.root, tip_link)[
+            :3, 3
+        ]
+        numpy.testing.assert_allclose(simulated_position, world_position, atol=1e-4)
+    finally:
+        stop_multisim_if_running(multi_sim)
+
+
 def test_world_sim_state_sync():
     plane_half_thickness = 0.05
     box_half_size = 0.1

--- a/test/semantic_digital_twin_test/test_connections/test_connections.py
+++ b/test/semantic_digital_twin_test/test_connections/test_connections.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 from numpy.testing import assert_allclose
 
@@ -37,6 +39,53 @@ def test_create_with_dofs_threads_parent_T_connection_expression(world_with_two_
         )
         world.add_connection(connection)
     assert_allclose(connection.origin.to_np(), parent_T_connection.to_np(), atol=1e-9)
+
+
+def test_reference_origin_excludes_joint_state(world_with_two_bodies):
+    """The reference origin stays at the zero configuration, the origin follows the joint.
+
+    A simulator places a body's static frame once, at build time. Using the
+    joint-carrying origin there bakes the current joint state in, and the
+    simulator joint then applies it a second time.
+    """
+    world, parent, child = world_with_two_bodies
+    parent_T_connection = HomogeneousTransformationMatrix.from_xyz_rpy(x=0.3, y=0.4)
+    with world.modify_world():
+        connection = RevoluteConnection.create_with_dofs(
+            world,
+            parent,
+            child,
+            axis=Vector3.Z(),
+            parent_T_connection_expression=parent_T_connection,
+        )
+        world.add_connection(connection)
+
+    origin_at_zero = connection.origin_as_position_quaternion().evaluate()[0]
+    reference_at_zero = connection.reference_origin_as_position_quaternion().evaluate()[0]
+    assert_allclose(origin_at_zero, reference_at_zero, atol=1e-9)
+
+    joint_position = 0.7
+    with world.modify_world():
+        world.state[connection.active_dofs[0].id].position = joint_position
+
+    origin_when_rotated = connection.origin_as_position_quaternion().evaluate()[0]
+    reference_when_rotated = connection.reference_origin_as_position_quaternion().evaluate()[
+        0
+    ]
+
+    # The reference is unaffected by the joint, so it is safe as a static frame.
+    assert_allclose(reference_when_rotated, reference_at_zero, atol=1e-9)
+    # The origin carries the joint's half-angle quaternion about the z axis.
+    expected_origin = [
+        0.3,
+        0.4,
+        0.0,
+        0.0,
+        0.0,
+        math.sin(joint_position / 2.0),
+        math.cos(joint_position / 2.0),
+    ]
+    assert_allclose(origin_when_rotated, expected_origin, atol=1e-9)
 
 
 @pytest.mark.parametrize("drive_type", [OmniDrive, DifferentialDrive])


### PR DESCRIPTION
## Problem

When `MujocoSim` builds the MuJoCo model from a world, it converts every body into an MJCF `<body>`: `KinematicStructureEntityConverter` fills the body's `pos`/`quat` from `Connection.origin_as_position_quaternion()`, evaluated at the current world state. That origin expression *includes the variable joint*.

In MuJoCo, however, a `<body>`'s `pos`/`quat` is by definition the **constant** transform from the parent body's frame — the joint is never part of it. The joint's contribution lives in `qpos`, which MuJoCo composes on top of the body frame at every step, and `qpos` is filled from the same world joint state.

So if a joint sits at a non-zero value while the model is built, that value ends up in the chain twice: once baked into the body frame, once applied by the joint through `qpos`. Every downstream body's forward kinematics diverges from the world.

## Symptom

When the MuJoCo model is built while the world is at a non-zero joint state, the body poses inside MuJoCo differ from the world's forward kinematics — even though the joint values agree (`qpos` is filled from the same world state).

Measured with the regression test's scenario — `base →revolute(Z)→ rotated_link →fixed→ tip`, built at **0.7 rad**, evaluated at **0.3 rad** (both `qpos` and the world at 0.3):

| | tip position | 
|---|---|
| MuJoCo | `[0.4019, 0.0, 1.4288]` |
| world FK | `[0.7186, 0.0, 1.2388]` |

an error of **369 mm**. On a 7-joint robot seeded at 0.4 before building, the prismatic body is off by **exactly 0.4 m** — the build-time joint value, applied twice.

## Why it was not caught before

At the zero configuration the joint term is identity, so the joint-inclusive origin and the constant frame are exactly equal — the bug is invisible. Every existing simulator test builds from a freshly parsed URDF/MJCF world, i.e. at the zero configuration, and asserts structure (names, types, lifecycle), not body poses.

## When does the error show up

Only with this sequence: set the joints to a non-zero state, **then** build the simulator, **then** evaluate. It surfaced in a real cell that seeds the robot to its home pose before constructing the simulator — from that point on, every simulated pose was off by the home configuration.

## Solution

Add `Connection.reference_origin_expression` — the parent→child transform with the joint at its reference value:

```
reference_origin_expression = parent_T_connection @ connection_T_child
```

and fill the MuJoCo body `pos`/`quat` with it, restoring MuJoCo's contract: the body frame carries only the constant part, `qpos` alone supplies the joint. The joint-inclusive `origin_expression` is intentionally kept for callers that need the current pose — forward kinematics and the TF publisher, which compiles it with the joint variables left symbolic — hence a new property rather than a change in place.

Covered by two tests:

- `test_reference_origin_excludes_joint_state` (connection-level): the reference origin stays at the zero configuration while the origin follows the joint. Fast, no simulator, not behind the `CI=true` gate.
- `test_body_frame_excludes_joint_state_at_build_time` (end-to-end through `MujocoSim`): build with a joint at a non-zero angle, evaluate at a different one, assert the simulated body pose matches world FK. Fails without the fix (max diff 0.32 m).

Full `test_multi_sim.py`: 10 passed; `test_mujoco_with_tracy_dae_files` fails identically on `main` (ASCII-STL asset decoding, unrelated).
