### PR TITLE
Import joint dynamics and link inertials from URDF

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from scipy.spatial.transform import Rotation
 from typing_extensions import Dict, Optional, Tuple, Union, List
 from urdf_parser_py import urdf as urdfpy
 from xacro import process_file
@@ -17,6 +16,7 @@ from semantic_digital_twin.spatial_types.derivatives import Derivatives, Derivat
 from semantic_digital_twin.spatial_types.spatial_types import (
     HomogeneousTransformationMatrix,
     Point3,
+    RotationMatrix,
     Vector3,
 )
 from semantic_digital_twin.utils import (
@@ -354,12 +354,9 @@ class URDFParser:
             ixz=urdf_inertia.ixz,
             iyz=urdf_inertia.iyz,
         )
-        link_R_inertial = Rotation.from_euler("xyz", roll_pitch_yaw).as_matrix()
-        inertia_in_link_frame = InertiaTensor(
-            data=link_R_inertial
-            @ inertia_in_inertial_frame.data
-            @ link_R_inertial.transpose()
-        )
+        link_R_inertial = RotationMatrix.from_rpy(*roll_pitch_yaw).to_np()[:3, :3]
+        inertia = link_R_inertial @ inertia_in_inertial_frame.data @ link_R_inertial.T
+        inertia_in_link_frame = InertiaTensor(data=inertia)
 
         return Inertial(
             mass=link.inertial.mass,

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from scipy.spatial.transform import Rotation
 from typing_extensions import Dict, Optional, Tuple, Union, List
 from urdf_parser_py import urdf as urdfpy
 from xacro import process_file
@@ -15,6 +16,7 @@ from semantic_digital_twin.exceptions import NegativeConnectionVelocity
 from semantic_digital_twin.spatial_types.derivatives import Derivatives, DerivativeMap
 from semantic_digital_twin.spatial_types.spatial_types import (
     HomogeneousTransformationMatrix,
+    Point3,
     Vector3,
 )
 from semantic_digital_twin.utils import (
@@ -40,6 +42,10 @@ from semantic_digital_twin.world_description.geometry import (
     Mesh,
     Scale,
     Color,
+)
+from semantic_digital_twin.world_description.inertial_properties import (
+    Inertial,
+    InertiaTensor,
 )
 from semantic_digital_twin.world_description.shape_collection import ShapeCollection
 from semantic_digital_twin.world_description.world_entity import Body, Connection
@@ -316,7 +322,50 @@ class URDFParser:
         collisions = self.parse_geometry(link.collisions, body)
         body.visual = visuals
         body.collision = collisions
+        inertial = self.parse_inertial(link, body)
+        if inertial is not None:
+            body.inertial = inertial
         return body
+
+    def parse_inertial(self, link: urdfpy.Link, body: Body) -> Optional[Inertial]:
+        """
+        Parses the inertial properties of a URDF link.
+
+        URDF expresses the inertia tensor in the inertial frame of the link, so it is
+        rotated into the link frame, which is the frame :class:`Inertial` expects.
+
+        :param link: The URDF link whose ``inertial`` element is parsed.
+        :param body: The body the properties belong to, used as their reference frame.
+        :return: The inertial properties, or ``None`` if the link declares none.
+        """
+        if link.inertial is None:
+            return None
+
+        origin = link.inertial.origin
+        center_of_mass = origin.xyz if origin is not None else [0.0, 0.0, 0.0]
+        roll_pitch_yaw = origin.rpy if origin is not None else [0.0, 0.0, 0.0]
+
+        urdf_inertia = link.inertial.inertia
+        inertia_in_inertial_frame = InertiaTensor.from_values(
+            ixx=urdf_inertia.ixx,
+            iyy=urdf_inertia.iyy,
+            izz=urdf_inertia.izz,
+            ixy=urdf_inertia.ixy,
+            ixz=urdf_inertia.ixz,
+            iyz=urdf_inertia.iyz,
+        )
+        link_R_inertial = Rotation.from_euler("xyz", roll_pitch_yaw).as_matrix()
+        inertia_in_link_frame = InertiaTensor(
+            data=link_R_inertial
+            @ inertia_in_inertial_frame.data
+            @ link_R_inertial.transpose()
+        )
+
+        return Inertial(
+            mass=link.inertial.mass,
+            center_of_mass=Point3(*center_of_mass, reference_frame=body),
+            inertia=inertia_in_link_frame,
+        )
 
     def parse_geometry(
         self,

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/urdf.py
@@ -23,6 +23,7 @@ from semantic_digital_twin.utils import (
     robot_name_from_urdf_string,
 )
 from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.connection_properties import JointDynamics
 from semantic_digital_twin.world_description.connections import (
     RevoluteConnection,
     PrismaticConnection,
@@ -275,8 +276,30 @@ class URDFParser:
             offset=offset,
             axis=Vector3(*map(int, joint.axis), reference_frame=parent),
             raw_dof=dof,
+            dynamics=self.parse_dynamics(joint),
         )
         return result
+
+    def parse_dynamics(self, joint: urdfpy.Joint) -> JointDynamics:
+        """
+        Parses the dynamic properties of a URDF joint.
+
+        Properties the joint leaves undeclared keep their default. URDF has no notion of
+        an armature, which models the rotor inertia of a transmission, so that one is
+        always left to the simulator.
+
+        :param joint: The URDF joint whose ``dynamics`` element is parsed.
+        :return: The dynamic properties of the joint.
+        """
+        if joint.dynamics is None:
+            return JointDynamics()
+
+        damping = joint.dynamics.damping
+        dry_friction = joint.dynamics.friction
+        return JointDynamics(
+            damping=damping if damping is not None else 0.0,
+            dry_friction=dry_friction if dry_friction is not None else 0.0,
+        )
 
     def parse_link(self, link: urdfpy.Link, parent_frame: PrefixedName) -> Body:
         """

--- a/test/semantic_digital_twin_test/test_adapters/test_urdf.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_urdf.py
@@ -1,12 +1,17 @@
 import os.path
 from dataclasses import dataclass
+from math import pi
 
+import numpy as np
 import pytest
+from urdf_parser_py import urdf as urdfpy
 
 from semantic_digital_twin.adapters.urdf import URDFParser
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.robots.pr2 import PR2
 from semantic_digital_twin.robots.tiago import Tiago
 from semantic_digital_twin.world_description.connections import FixedConnection
+from semantic_digital_twin.world_description.world_entity import Body
 
 
 @dataclass
@@ -137,6 +142,47 @@ def test_undeclared_joint_dynamics_default_to_zero(pr2_parser):
     assert dynamics.damping == 0.0
     assert dynamics.dry_friction == 0.0
     assert dynamics.armature == 0.0
+
+
+def test_declared_link_inertial_is_imported(pr2_parser):
+    world = pr2_parser.parse()
+    inertial = world.get_body_by_name("l_elbow_flex_link").inertial
+    assert inertial.mass == 1.90327
+    assert inertial.center_of_mass.to_np()[:3].tolist() == [0.01014, 0.00032, -0.01211]
+    assert inertial.inertia.to_values() == (
+        0.00346541989,
+        0.00441606455,
+        0.00359156824,
+        0.00004066825,
+        0.00043171614,
+        -0.00003968914,
+    )
+
+
+def test_inertia_tensor_is_expressed_in_the_link_frame(table_parser):
+    link = urdfpy.Link(
+        name="rotated_inertial_link",
+        inertial=urdfpy.Inertial(
+            mass=2.0,
+            inertia=urdfpy.Inertia(
+                ixx=0.002, iyy=0.003, izz=0.004, ixy=0.0, ixz=0.0, iyz=0.0
+            ),
+            origin=urdfpy.Pose(xyz=[0.0, 0.0, 0.0], rpy=[0.0, 0.0, pi / 2]),
+        ),
+    )
+    body = Body(name=PrefixedName("rotated_inertial_link"))
+
+    inertial = table_parser.parse_inertial(link, body)
+    inertia_rotated_by_ninety_degrees_around_z = np.diag([0.003, 0.002, 0.004])
+    assert np.allclose(
+        inertial.inertia.data, inertia_rotated_by_ninety_degrees_around_z, atol=1e-12
+    )
+
+
+def test_undeclared_link_inertial_keeps_the_default(table_parser):
+    inertial = table_parser.parse().root.inertial
+    assert inertial.mass == 1.0
+    assert inertial.inertia.to_values() == (1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
 
 
 def test_xacro():

--- a/test/semantic_digital_twin_test/test_adapters/test_urdf.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_urdf.py
@@ -5,6 +5,7 @@ import pytest
 
 from semantic_digital_twin.adapters.urdf import URDFParser
 from semantic_digital_twin.robots.pr2 import PR2
+from semantic_digital_twin.robots.tiago import Tiago
 from semantic_digital_twin.world_description.connections import FixedConnection
 
 
@@ -74,6 +75,14 @@ def pr2_parser():
     return URDFParser.from_file(file_path=PR2.get_ros_file_path())
 
 
+@pytest.fixture
+def tiago_parser():
+    """
+    Fixture providing a URDFParser for the Tiago model.
+    """
+    return URDFParser.from_file(file_path=Tiago.get_ros_file_path())
+
+
 def test_table_parsing(table_parser):
     world = table_parser.parse()
     world.validate()
@@ -113,6 +122,21 @@ def test_mimic_joints(pr2_parser):
     mimic_joint = world.get_connection_by_name("l_gripper_r_finger_joint")
 
     assert joint_to_be_mimicked.dofs == mimic_joint.dofs
+
+
+def test_declared_joint_dynamics_are_imported(tiago_parser):
+    world = tiago_parser.parse()
+    dynamics = world.get_connection_by_name("arm_left_1_joint").dynamics
+    assert dynamics.damping == 40.0
+    assert dynamics.dry_friction == 1.0
+
+
+def test_undeclared_joint_dynamics_default_to_zero(pr2_parser):
+    world = pr2_parser.parse()
+    dynamics = world.get_connection_by_name("r_gripper_motor_slider_joint").dynamics
+    assert dynamics.damping == 0.0
+    assert dynamics.dry_friction == 0.0
+    assert dynamics.armature == 0.0
 
 
 def test_xacro():


### PR DESCRIPTION
## Problem

`URDFParser` never read the `<dynamics>` or `<inertial>` elements, so everything it imported reached physics with placeholder values:

- every joint arrived as `JointDynamics(armature=0.0, dry_friction=0.0, damping=0.0)` — frictionless and undamped;
- every body arrived at `mass=1.0` with a unit inertia tensor.

This is an importer gap only: `Connection.dynamics` and `Body.inertial` already exist, `MujocoBuilder` already writes both into the MJCF, and `adapters/mjcf.py` already reads them back on the MJCF→world path.


## Change

- `parse_dynamics` reads `<dynamics damping=... friction=.../>` into `JointDynamics`. URDF has no armature (that is a simulator-side rotor inertia), so it stays at its default; undeclared attributes stay zero.
- `parse_inertial` reads `<inertial>` into `Inertial`. URDF gives the tensor in the inertial frame, so it is rotated into the link frame, which is the frame `Inertial` documents. Links that declare no `<inertial>` keep the `Body` default, so nothing regresses for descriptions without inertia.

## Tests

Five tests in `test_urdf.py`, on models the suite already uses — no new assets:

- Tiago — `arm_left_1_joint` declares `damping="40.0" friction="1.0"`, so it covers both attributes;
- PR2 — a movable joint that declares no `<dynamics>` stays at zero, and `l_elbow_flex_link` comes through with its real mass, centre of mass and off-diagonal inertia products;
- the table model — a description with no `<inertial>` at all keeps the `Body` default;
- the frame rotation is covered by calling `parse_inertial` with a `urdf_parser_py` link whose inertial frame is rotated 90° about z, since no description in the resources declares a rotated inertial frame.
