### PR TITLE
Translate any propositional where expression into a random event

### DIFF
--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -4,27 +4,59 @@ from typing_extensions import Type
 
 from krrood.entity_query_language.core.variable import Variable
 from krrood.entity_query_language.factories import ConditionType
-from krrood.entity_query_language.operators.comparator import Comparator
-from krrood.entity_query_language.query.operations import Where
 from krrood.exceptions import DataclassException, InputError
 
 
 @dataclass
-class WhereExpressionNotInDisjunctiveNormalForm(DataclassException):
+class WhereExpressionIsFirstOrder(DataclassException):
     """
-    Raised when a `Where` expression is not in disjunctive normal form.
-
-    Check `is_disjunctive_normal_form` for more information and to see if the expression
-    is in disjunctive normal form.
+    Raised when a quantified `Where` expression is asked to be translated into a random
+    event, since a product algebra is propositional and constrains a fixed set of
+    variables instead of the objects a quantifier ranges over.
     """
 
     where_expression: ConditionType
+    """
+    The quantified expression that has no random event representation.
+    """
 
     def error_message(self) -> str:
-        return f"The where expression {self.where_expression} is not in disjunctive normal form."
+        return (
+            f"The where expression {self.where_expression} quantifies over a variable, "
+            f"which no fixed set of random event variables represents."
+        )
 
     def suggest_correction(self) -> str:
-        return ""
+        return (
+            "State the condition over the attributes that are parameterized instead of "
+            "quantifying, or evaluate the quantified condition on the query results."
+        )
+
+
+@dataclass
+class WhereExpressionHasNoRandomEventRepresentation(DataclassException):
+    """
+    Raised when a part of a `Where` expression constrains something that no random event
+    variable stands for, for example a comparison between two variables.
+    """
+
+    where_expression: ConditionType
+    """
+    The expression that has no random event representation.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"The where expression {self.where_expression} is neither a logical operator "
+            f"nor a comparison between a variable and a literal, so it constrains no "
+            f"random event variable."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Compare a variable against a literal value, and combine such comparisons "
+            "with and_, or_ and not_ only."
+        )
 
 
 @dataclass

--- a/krrood/src/krrood/parametrization/random_events_translator.py
+++ b/krrood/src/krrood/parametrization/random_events_translator.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import itertools
 import operator
-from collections import deque
 from dataclasses import dataclass
 from functools import cached_property
-from typing import assert_never, List, Dict
+from typing import assert_never, Dict
 
 import numpy as np
 
@@ -16,12 +15,19 @@ from krrood.entity_query_language.core.mapped_variable import MappedVariable
 from krrood.entity_query_language.core.variable import Literal
 from krrood.entity_query_language.factories import ConditionType
 from krrood.entity_query_language.operators.comparator import Comparator
-from krrood.entity_query_language.operators.core_logical_operators import OR, AND
+from krrood.entity_query_language.operators.core_logical_operators import OR, AND, Not
+from krrood.entity_query_language.operators.logical_quantifiers import (
+    QuantifiedConditional,
+)
 from krrood.parametrization.exceptions import (
-    WhereExpressionNotInDisjunctiveNormalForm,
+    WhereExpressionHasNoRandomEventRepresentation,
+    WhereExpressionIsFirstOrder,
 )
 from random_events.interval import closed_open, closed, open
 from random_events.product_algebra import Event, SimpleEvent
+
+
+# %% translating a where expression into a random event
 
 
 @dataclass
@@ -29,21 +35,17 @@ class WhereExpressionToRandomEventTranslator:
     """
     Class that translates a query into a random event.
 
-    Requires that the query is in disjunctive normal form.
-
-    Check the documentation of `is_disjunctive_normal_form` for more information.
+    Conjunction, disjunction and negation are translated into the corresponding
+    operations of the product algebra, which normalizes the result itself, so the query
+    may have any propositional shape. Quantified conditions are refused, since a product
+    algebra constrains a fixed set of variables and states nothing about the objects a
+    quantifier ranges over.
     """
 
     conditions_root: ConditionType
     """
-    The query in disjunctive normal form to translate.
+    The query to translate.
     """
-
-    def __post_init__(self):
-        if self.conditions_root is not None and not is_disjunctive_normal_form(
-            self.conditions_root
-        ):
-            raise WhereExpressionNotInDisjunctiveNormalForm(self.conditions_root)
 
     @cached_property
     def variables(self) -> Dict[MappedVariable, random_events.variable.Variable]:
@@ -74,110 +76,103 @@ class WhereExpressionToRandomEventTranslator:
     def translate(self) -> Event:
         """
         :return: The random event that corresponds to the query.
+        :raises WhereExpressionIsFirstOrder: When the query quantifies over a variable.
+        :raises WhereExpressionHasNoRandomEventRepresentation: When a part of the query
+            constrains nothing that a random event variable stands for.
         """
-        simple_events = []
+        return self._translate_expression(self.conditions_root).simplify()
 
-        # Traverse the logical tree starting from the conditions root
-        queue = deque([self.conditions_root])
-
-        while queue:
-            expression = queue.popleft()
-
-            if isinstance(expression, OR):
-                queue.extend(expression._children_)
-                continue
-
-            elif isinstance(expression, AND):
-                simple_event = self._translate_conjunction(expression)
-            elif isinstance(expression, Comparator):
-                simple_event = SimpleEvent.from_data(
-                    {v: v.domain for v in self.variables.values()}
-                )
-
-                self._translate_comparators(
-                    self._get_variable_from_comparator(expression),
-                    [expression],
-                    simple_event,
-                )
-            else:
-                assert_never(expression)
-            simple_events.append(simple_event)
-        return Event.from_simple_sets(*simple_events).simplify()
-
-    def _translate_conjunction(self, expression: AND) -> SimpleEvent:
+    def _translate_expression(self, expression: SymbolicExpression) -> Event:
         """
-        Translate a conjunction expression into a random event.
+        Translate a where expression of any propositional shape into a random event.
 
-        The conjunction must not contain any disjunctions anymore.
-
-        :param expression: The conjunction expression to translate.
-        :return: The random event corresponding to the conjunction.
+        :param expression: The expression to translate.
+        :return: The random event that holds exactly where the expression holds.
         """
-        result = SimpleEvent.from_data()
+        if isinstance(expression, QuantifiedConditional):
+            raise WhereExpressionIsFirstOrder(expression)
 
-        # check that it is always a comparison between a variable and a literal
-        for variable, comparators in self.comparators_grouped_by_variable(
-            expression
-        ).items():
-            self._translate_comparators(variable, comparators, result)
+        if isinstance(expression, AND):
+            return self._translate_expression(
+                expression.left
+            ) & self._translate_expression(expression.right)
 
-        return result
+        if isinstance(expression, OR):
+            return self._translate_expression(
+                expression.left
+            ) | self._translate_expression(expression.right)
 
-    def comparators_grouped_by_variable(
-        self, expression: SymbolicExpression
-    ) -> Dict[random_events.variable.Variable, List[Comparator]]:
+        if isinstance(expression, Not):
+            return self._translate_expression(expression._child_).complement()
+
+        if isinstance(expression, Literal):
+            return (
+                self.unconstrained_event()
+                if expression._value_
+                else self.impossible_event()
+            )
+
+        if not is_literal_comparator(expression):
+            raise WhereExpressionHasNoRandomEventRepresentation(expression)
+
+        return self._translate_comparator(expression)
+
+    def _translate_comparator(self, comparator: Comparator) -> Event:
         """
-        Group comparators by their variable given an expression.
+        Translate a comparison between a variable and a literal into a random event.
 
-        :param expression: The expression where all comparators in the descendents
-            should be grouped by variables.
-        :return: A dictionary mapping ObjectAccessVariables to lists of their
-            corresponding comparators.
+        The event is built over every variable of the query rather than over the
+        compared one alone, because the product algebra combines events by the variables
+        they already carry and would otherwise drop the variables an operand does not
+        mention.
+
+        :param comparator: The comparison to translate.
+        :return: The random event that holds exactly where the comparison holds.
         """
-        # Collect all Comparator descendants and group them by their accessed variable
-        grouped: Dict[random_events.variable.Variable, List[Comparator]] = {}
-        for expr in expression._descendants_:
-            if not isinstance(expr, Comparator):
-                continue
-            key = self._get_variable_from_comparator(expr)
-            grouped.setdefault(key, []).append(expr)
-        return grouped
+        result = self.unconstrained_simple_event()
+        variable = self._get_variable_from_comparator(comparator)
 
-    def _translate_comparators(
-        self,
-        variable: random_events.variable.Variable,
-        comparators: List[Comparator],
-        result: SimpleEvent,
-    ) -> None:
+        if isinstance(comparator.right._value_, type(Ellipsis)):
+            return result.as_composite_set()
+
+        match comparator.operation:
+            case operator.eq:
+                self._translate_eq(comparator, variable, result)
+            case operator.ne:
+                self._translate_ne(comparator, variable, result)
+            case operator.gt:
+                self._translate_gt(comparator, variable, result)
+            case operator.lt:
+                self._translate_lt(comparator, variable, result)
+            case operator.ge:
+                self._translate_ge(comparator, variable, result)
+            case operator.le:
+                self._translate_le(comparator, variable, result)
+            case _:
+                assert_never(comparator.operation)
+
+        return result.as_composite_set()
+
+    def unconstrained_simple_event(self) -> SimpleEvent:
         """
-        Translate comparators for a given variable into a random event in-place.
-
-        :param variable: The variable for which to translate comparators.
-        :param comparators: The comparators to translate.
-        :param result: The random event to update in-place.
-        :return: None
+        :return: The simple event that leaves every variable of the query on its full
+            domain.
         """
-        result[variable] = variable.domain
-        for comparator in comparators:
+        return SimpleEvent.from_data(
+            {variable: variable.domain for variable in self.variables.values()}
+        )
 
-            if isinstance(comparator.right._value_, type(Ellipsis)):
-                continue
+    def unconstrained_event(self) -> Event:
+        """
+        :return: The event that holds everywhere, the identity of intersection.
+        """
+        return self.unconstrained_simple_event().as_composite_set()
 
-            match comparator.operation:
-                case operator.eq:
-                    self._translate_eq(comparator, variable, result)
-                case operator.ne:
-                    self._translate_ne(comparator, variable, result)
-                case operator.gt:
-                    self._translate_gt(comparator, variable, result)
-                case operator.lt:
-                    self._translate_lt(comparator, variable, result)
-                case operator.ge:
-                    self._translate_ge(comparator, variable, result)
-                case operator.le:
-                    self._translate_le(comparator, variable, result)
-                case _:
-                    assert_never(comparator.operation)
+    def impossible_event(self) -> Event:
+        """
+        :return: The event that holds nowhere, the identity of union.
+        """
+        return self.unconstrained_event().complement()
 
     def _translate_eq(
         self,
@@ -241,77 +236,7 @@ class WhereExpressionToRandomEventTranslator:
         )
 
 
-def is_disjunctive_normal_form(condition_root: ConditionType) -> bool:
-    """
-    Checks if the given query is disjunctive normal form (DNF).
-
-    A query is in DNF if the following 3 statements are true:
-    1. All its comparators are literal comparators, i.e. comparators between one variable and one literal
-    2. All of its conjunctions (AND statements) only have literal comparators as children
-    3. There is at most one disjunction (OR statement) which has to be at the root.
-
-    Example:
-        Constant (Literal, e.g., 3, True, etc.) is DNF
-
-        (x > 3) is DNF
-
-        (x > 3) & (y < 5) is DNF
-
-        (x > 3) | (y < 5) is DNF
-
-        (x > 3) | ((y > 5) & (z < 2)) is DNF
-
-        (x > 3) & ((y > 5) | (z < 2)) is not DNF
-
-    :param condition_root: The condition root of the query to check
-    :return: True if the query is disjunctive normal form, False otherwise
-    """
-    return (
-        is_disjunction_of_conjunction_of_literal_comparators(condition_root)
-        or is_conjunction_of_literal_comparators(condition_root)
-        or is_literal_comparator(condition_root)
-        or isinstance(condition_root, Literal)
-    )
-
-
-def is_disjunction_of_conjunction_of_literal_comparators(expression: OR) -> bool:
-    """
-    Checks if the given expression is a disjunction of conjunctions of literal
-    comparators.
-
-    :param expression: The expression to check.
-    :return: True if the expression is a disjunction of conjunctions of literal
-        comparators, False otherwise.
-    """
-    if not isinstance(expression, OR):
-        return False
-    for child in expression._children_:
-        if not (
-            is_disjunction_of_conjunction_of_literal_comparators(child)
-            or is_conjunction_of_literal_comparators(child)
-            or is_literal_comparator(child)
-        ):
-            return False
-    return True
-
-
-def is_conjunction_of_literal_comparators(expression: AND) -> bool:
-    """
-    Checks if the given expression is a conjunction of literal comparators.
-
-    :param expression: The expression to check.
-    :return: True if the expression is a conjunction of literal comparators, False
-        otherwise.
-    """
-    if not isinstance(expression, AND):
-        return False
-    for child in expression._children_:
-        if not (
-            is_conjunction_of_literal_comparators(child) or is_literal_comparator(child)
-        ):
-            return False
-
-    return True
+# %% shape checks on where expressions
 
 
 def is_literal_comparator(expression: Comparator) -> bool:

--- a/krrood/src/krrood/parametrization/random_events_translator.py
+++ b/krrood/src/krrood/parametrization/random_events_translator.py
@@ -88,6 +88,10 @@ class WhereExpressionToRandomEventTranslator:
 
         :param expression: The expression to translate.
         :return: The random event that holds exactly where the expression holds.
+        :raises WhereExpressionIsFirstOrder: When the expression quantifies over a
+            variable.
+        :raises WhereExpressionHasNoRandomEventRepresentation: When the expression
+            constrains nothing that a random event variable stands for.
         """
         if isinstance(expression, QuantifiedConditional):
             raise WhereExpressionIsFirstOrder(expression)
@@ -137,17 +141,17 @@ class WhereExpressionToRandomEventTranslator:
 
         match comparator.operation:
             case operator.eq:
-                self._translate_eq(comparator, variable, result)
+                self._translate_equal(comparator, variable, result)
             case operator.ne:
-                self._translate_ne(comparator, variable, result)
+                self._translate_not_equal(comparator, variable, result)
             case operator.gt:
-                self._translate_gt(comparator, variable, result)
+                self._translate_greater_than(comparator, variable, result)
             case operator.lt:
-                self._translate_lt(comparator, variable, result)
+                self._translate_less_than(comparator, variable, result)
             case operator.ge:
-                self._translate_ge(comparator, variable, result)
+                self._translate_greater_than_or_equal(comparator, variable, result)
             case operator.le:
-                self._translate_le(comparator, variable, result)
+                self._translate_less_than_or_equal(comparator, variable, result)
             case _:
                 assert_never(comparator.operation)
 
@@ -174,7 +178,7 @@ class WhereExpressionToRandomEventTranslator:
         """
         return self.unconstrained_event().complement()
 
-    def _translate_eq(
+    def _translate_equal(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,
@@ -184,7 +188,7 @@ class WhereExpressionToRandomEventTranslator:
             comparator.right._value_
         )
 
-    def _translate_ne(
+    def _translate_not_equal(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,
@@ -194,7 +198,7 @@ class WhereExpressionToRandomEventTranslator:
             comparator.right._value_
         ).complement()
 
-    def _translate_gt(
+    def _translate_greater_than(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,
@@ -202,7 +206,7 @@ class WhereExpressionToRandomEventTranslator:
     ) -> None:
         result[parametrization_variable] &= open(comparator.right._value_, np.inf)
 
-    def _translate_lt(
+    def _translate_less_than(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,
@@ -213,7 +217,7 @@ class WhereExpressionToRandomEventTranslator:
             comparator.right._value_,
         )
 
-    def _translate_le(
+    def _translate_less_than_or_equal(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,
@@ -224,7 +228,7 @@ class WhereExpressionToRandomEventTranslator:
             comparator.right._value_,
         )
 
-    def _translate_ge(
+    def _translate_greater_than_or_equal(
         self,
         comparator: Comparator,
         parametrization_variable: random_events.variable.Variable,

--- a/test/krrood_test/test_underspecified_knowledge/test_probable_variable.py
+++ b/test/krrood_test/test_underspecified_knowledge/test_probable_variable.py
@@ -1,21 +1,6 @@
-import numpy as np
-
 from krrood.entity_query_language.factories import (
-    variable,
-    entity,
-    and_,
-    or_,
     a,
-    an,
 )
-from krrood.entity_query_language.verbalization.pipeline import VerbalizationPipeline
-from krrood.parametrization.random_events_translator import (
-    WhereExpressionToRandomEventTranslator,
-    is_disjunctive_normal_form,
-)
-from random_events.interval import singleton, open, closed, closed_open
-from random_events.product_algebra import SimpleEvent, Event
-from random_events.variable import Continuous
 from ..dataset.example_classes import (
     KRROODPose,
     KRROODPosition,
@@ -23,111 +8,6 @@ from ..dataset.example_classes import (
     KRROODPositions,
 )
 from ..dataset.ormatic_interface import *  # type: ignore
-
-
-def test_underspecification_with_where():
-    underspecified_pose = a(KRROODPose)(
-        position=a(KRROODPosition)(x=..., y=..., z=...),
-        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
-    )
-    underspecified_pose.expression
-    q = underspecified_pose.where(
-        underspecified_pose.variable.position.y > 0.0,
-        underspecified_pose.variable.position.x == 0.0,
-        underspecified_pose.variable.position.y < 10.0,
-        underspecified_pose.variable.position.z >= -1.0,
-        underspecified_pose.variable.position.z <= 1.0,
-        underspecified_pose.variable.orientation.x != 1.0,
-    )
-    t = WhereExpressionToRandomEventTranslator(
-        and_(*q._where_conditions_),
-    )
-    r = t.translate()
-
-    result_by_hand = SimpleEvent.from_data(
-        {
-            Continuous("KRROODPose.orientation.x"): ~singleton(1.0),
-            Continuous("KRROODPose.position.y"): open(0.0, 10),
-            Continuous("KRROODPose.position.z"): closed(-1.0, 1.0),
-            Continuous("KRROODPose.position.x"): singleton(0.0),
-        }
-    )
-
-    assert result_by_hand.as_composite_set() == r
-
-
-def test_dnf_checking():
-    pose_variable = variable(KRROODPose, None)
-
-    q1 = entity(pose_variable).where(
-        and_(
-            or_(
-                pose_variable.position.y > 0,
-                pose_variable.position.x == 0,
-            ),
-            or_(
-                pose_variable.position.z >= -1,
-                pose_variable.position.x == 0,
-            ),
-        )
-    )
-
-    assert not is_disjunctive_normal_form(q1._conditions_root_)
-
-    underspecified_pose = a(KRROODPose)(
-        position=a(KRROODPosition)(x=..., y=..., z=...),
-        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
-    )
-    underspecified_pose.expression
-    pose_variable = underspecified_pose.variable
-    q2 = underspecified_pose.where(
-        or_(
-            pose_variable.position.x == 0,
-            and_(
-                pose_variable.position.z >= -1,
-                pose_variable.position.z <= 1,
-                pose_variable.position.y < 10,
-            ),
-            and_(pose_variable.orientation.z > 0),
-        )
-    )
-
-    where_expression = and_(*q2._where_conditions_)
-    assert is_disjunctive_normal_form(where_expression)
-
-    t = WhereExpressionToRandomEventTranslator(
-        where_expression,
-    )
-    translated = t.translate()
-
-    variables = [
-        Continuous("KRROODPose.position.x"),
-        Continuous("KRROODPose.position.y"),
-        Continuous("KRROODPose.position.z"),
-        Continuous("KRROODPose.orientation.z"),
-    ]
-    [p_x, p_y, p_z, o_z] = variables
-
-    e1 = SimpleEvent.from_data(
-        {
-            p_x: singleton(0.0),
-        }
-    )
-    e1.fill_missing_variables(variables)
-    e2 = SimpleEvent.from_data(
-        {
-            p_z: closed(-1.0, 1.0),
-            p_y: closed_open(-np.inf, 10.0),
-        }
-    )
-    e2.fill_missing_variables(variables)
-    e3 = SimpleEvent.from_data({o_z: open(0.0, np.inf)})
-    e3.fill_missing_variables(variables)
-
-    result_by_hand = Event.from_simple_sets(e1, e2, e3)
-
-    assert (result_by_hand - translated).is_empty()
-    assert (translated - result_by_hand).is_empty()
 
 
 def test_query_writing_with_match_and_copy():

--- a/test/krrood_test/test_underspecified_knowledge/test_random_events_translator.py
+++ b/test/krrood_test/test_underspecified_knowledge/test_random_events_translator.py
@@ -1,0 +1,246 @@
+import numpy as np
+import pytest
+
+from krrood.entity_query_language.factories import (
+    a,
+    and_,
+    for_all,
+    not_,
+    or_,
+    variable,
+)
+from krrood.parametrization.exceptions import (
+    WhereExpressionHasNoRandomEventRepresentation,
+    WhereExpressionIsFirstOrder,
+)
+from krrood.parametrization.random_events_translator import (
+    WhereExpressionToRandomEventTranslator,
+)
+from random_events.interval import closed, closed_open, open, singleton
+from random_events.product_algebra import Event, SimpleEvent
+from random_events.variable import Continuous
+from ..dataset.example_classes import (
+    KRROODOrientation,
+    KRROODPose,
+    KRROODPosition,
+)
+from ..dataset.ormatic_interface import *  # type: ignore
+
+# %% helpers
+
+
+def underspecified_pose():
+    """
+    :return: A pose whose position and orientation are underspecified.
+    """
+    return a(KRROODPose)(
+        position=a(KRROODPosition)(x=..., y=..., z=...),
+        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
+    )
+
+
+def translate(condition) -> Event:
+    """
+    :param condition: The where condition to translate.
+    :return: The random event that corresponds to the condition.
+    """
+    return WhereExpressionToRandomEventTranslator(condition).translate()
+
+
+def translate_where_conditions(query) -> Event:
+    """
+    :param query: The query whose where conditions to translate.
+    :return: The random event that corresponds to the where conditions.
+    """
+    return translate(and_(*query._where_conditions_))
+
+
+def assert_equal_events(actual: Event, expected: Event) -> None:
+    """
+    Assert that two events describe the same set of points.
+
+    :param actual: The event under test.
+    :param expected: The event it is expected to equal.
+    """
+    assert (expected - actual).is_empty()
+    assert (actual - expected).is_empty()
+
+
+# %% conjunctions of comparators
+
+
+def test_underspecification_with_where():
+    pose = underspecified_pose()
+    query = pose.where(
+        pose.variable.position.y > 0.0,
+        pose.variable.position.x == 0.0,
+        pose.variable.position.y < 10.0,
+        pose.variable.position.z >= -1.0,
+        pose.variable.position.z <= 1.0,
+        pose.variable.orientation.x != 1.0,
+    )
+
+    translated = translate_where_conditions(query)
+
+    result_by_hand = SimpleEvent.from_data(
+        {
+            Continuous("KRROODPose.orientation.x"): ~singleton(1.0),
+            Continuous("KRROODPose.position.y"): open(0.0, 10),
+            Continuous("KRROODPose.position.z"): closed(-1.0, 1.0),
+            Continuous("KRROODPose.position.x"): singleton(0.0),
+        }
+    )
+
+    assert result_by_hand.as_composite_set() == translated
+
+
+# %% disjunctions of conjunctions
+
+
+def test_disjunction_of_conjunctions():
+    pose_variable = underspecified_pose().variable
+
+    translated = translate(
+        or_(
+            pose_variable.position.x == 0,
+            and_(
+                pose_variable.position.z >= -1,
+                pose_variable.position.z <= 1,
+                pose_variable.position.y < 10,
+            ),
+            and_(pose_variable.orientation.z > 0),
+        )
+    )
+
+    variables = [
+        Continuous("KRROODPose.position.x"),
+        Continuous("KRROODPose.position.y"),
+        Continuous("KRROODPose.position.z"),
+        Continuous("KRROODPose.orientation.z"),
+    ]
+    [position_x, position_y, position_z, orientation_z] = variables
+
+    fixed_x = SimpleEvent.from_data({position_x: singleton(0.0)})
+    fixed_x.fill_missing_variables(variables)
+    bounded_y_and_z = SimpleEvent.from_data(
+        {
+            position_z: closed(-1.0, 1.0),
+            position_y: closed_open(-np.inf, 10.0),
+        }
+    )
+    bounded_y_and_z.fill_missing_variables(variables)
+    positive_orientation_z = SimpleEvent.from_data({orientation_z: open(0.0, np.inf)})
+    positive_orientation_z.fill_missing_variables(variables)
+
+    assert_equal_events(
+        translated,
+        Event.from_simple_sets(fixed_x, bounded_y_and_z, positive_orientation_z),
+    )
+
+
+# %% conditions that are not in disjunctive normal form
+
+
+def test_where_condition_outside_disjunctive_normal_form():
+    pose = underspecified_pose()
+    pose_variable = pose.variable
+    query = pose.where(
+        or_(
+            pose_variable.position.x > 0.0,
+            pose_variable.position.y > 0.0,
+        ),
+        pose_variable.position.x < 10.0,
+    )
+
+    translated = translate_where_conditions(query)
+
+    position_x = Continuous("KRROODPose.position.x")
+    position_y = Continuous("KRROODPose.position.y")
+    variables = [position_x, position_y]
+
+    bounded_x = SimpleEvent.from_data({position_x: open(0.0, 10.0)})
+    bounded_x.fill_missing_variables(variables)
+    positive_y = SimpleEvent.from_data(
+        {
+            position_x: closed_open(-np.inf, 10.0),
+            position_y: open(0.0, np.inf),
+        }
+    )
+    positive_y.fill_missing_variables(variables)
+
+    assert_equal_events(translated, Event.from_simple_sets(bounded_x, positive_y))
+
+
+def test_disjunction_nested_in_conjunction_keeps_shared_variable():
+    pose_variable = underspecified_pose().variable
+
+    translated = translate(
+        and_(
+            pose_variable.position.x > 0.0,
+            or_(
+                pose_variable.position.x < 1.0,
+                pose_variable.position.x > 5.0,
+            ),
+        )
+    )
+
+    position_x = Continuous("KRROODPose.position.x")
+    lower_part = SimpleEvent.from_data({position_x: open(0.0, 1.0)})
+    upper_part = SimpleEvent.from_data({position_x: open(5.0, np.inf)})
+
+    assert_equal_events(translated, Event.from_simple_sets(lower_part, upper_part))
+
+
+# %% negated conditions
+
+
+def test_negation_equals_inverted_comparator():
+    pose_variable = underspecified_pose().variable
+
+    translated = translate(not_(pose_variable.position.x > 0.0))
+
+    assert_equal_events(translated, translate(pose_variable.position.x <= 0.0))
+
+
+def test_negated_conjunction_is_disjunction_of_negations():
+    pose_variable = underspecified_pose().variable
+
+    translated = translate(
+        not_(
+            and_(
+                pose_variable.position.x > 0.0,
+                pose_variable.position.y > 0.0,
+            )
+        )
+    )
+
+    assert_equal_events(
+        translated,
+        translate(
+            or_(
+                pose_variable.position.x <= 0.0,
+                pose_variable.position.y <= 0.0,
+            )
+        ),
+    )
+
+
+# %% conditions without a random event representation
+
+
+def test_quantified_where_condition():
+    pose = underspecified_pose()
+    position_variable = variable(KRROODPosition, [KRROODPosition(1.0, 2.0, 3.0)])
+    query = pose.where(
+        for_all(position_variable, position_variable.x > 0.0),
+    )
+
+    with pytest.raises(WhereExpressionIsFirstOrder):
+        translate_where_conditions(query)
+
+
+def test_comparison_between_two_variables_is_refused():
+    pose_variable = underspecified_pose().variable
+
+    with pytest.raises(WhereExpressionHasNoRandomEventRepresentation):
+        translate(pose_variable.position.x > pose_variable.position.y)


### PR DESCRIPTION
## What

`WhereExpressionToRandomEventTranslator` required its input to be in disjunctive normal form and rejected everything else. That precondition is not needed: instead of flattening the condition by hand, the translator now recurses over the condition tree and maps `AND`, `OR` and `Not` onto the corresponding operations of the product algebra, which normalizes the result itself. A `where` expression may therefore have any propositional shape — disjunctions nested inside conjunctions, negations, and combinations of both.

Every leaf is built over all variables of the query rather than over the compared one alone, because the product algebra combines events by the variables they already carry and would otherwise drop the variables an operand does not mention.

## Refused conditions

Quantified conditions (`for_all`, `exists`) are the only genuinely unmappable ones: a product algebra is propositional and constrains a fixed set of variables, so it states nothing about the objects a quantifier ranges over. They raise the new `WhereExpressionIsFirstOrder`. A part of a condition that constrains nothing a random event variable stands for, such as a comparison between two variables, raises the new `WhereExpressionHasNoRandomEventRepresentation`.

Both replace `WhereExpressionNotInDisjunctiveNormalForm`, and the now unused disjunctive normal form checks (`is_disjunctive_normal_form` and friends) are removed with it. `is_literal_comparator` stays, since it is what decides whether a leaf is representable.

## Tests

Every test of the translator now lives in `test_random_events_translator.py`, including `test_underspecification_with_where`, which moved out of `test_probable_variable.py`. The new ones were written before the implementation and fail against the old translator:

- a `where` condition outside disjunctive normal form, and a disjunction nested in a conjunction sharing a variable with it,
- `not_(x > 0)` equalling `x <= 0`, and De Morgan on a negated conjunction,
- a quantified `where` condition and a comparison between two variables, both refused.

Full `krrood` suite passes (1928 passed, 6 skipped; `test_code_generation` and `test_eql/test_typing` do not collect locally because `inflection` is missing, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCjykZP4vnSY462RQpbnQZ
