### PR TITLE
Add volume to shapes

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import math
 import os
 import shutil
 import tempfile
@@ -350,6 +351,17 @@ class Shape(ABC, SubclassJSONSerializer, HasSimulatorProperties):
 
     @property
     @abstractmethod
+    def volume(self) -> float:
+        """
+        :return: The volume this shape encloses.
+
+        ..note:: A primitive states the volume of the shape itself rather than of the
+            mesh standing in for it, since a mesh only approximates a curved surface
+            with a polygonal one and would report less than the shape holds.
+        """
+
+    @property
+    @abstractmethod
     def local_frame_bounding_box(self) -> BoundingBox:
         """
         Returns the bounding box of the shape.
@@ -430,6 +442,14 @@ class Mesh(Shape):
     """
     Filename of the mesh.
     """
+
+    @property
+    def volume(self) -> float:
+        """
+        :return: The volume the mesh's surface encloses, which is meaningful only for a
+            watertight mesh.
+        """
+        return self.mesh.volume
 
     @property
     def local_frame_bounding_box(self) -> BoundingBox:
@@ -830,6 +850,10 @@ class Sphere(Shape):
     """
 
     @property
+    def volume(self) -> float:
+        return 4.0 / 3.0 * math.pi * self.radius**3
+
+    @property
     def mesh(self) -> trimesh.Trimesh:
         """
         Returns a trimesh object representing the sphere.
@@ -877,12 +901,23 @@ class Cylinder(Shape):
     height: float = 0.5
 
     @property
+    def radius(self) -> float:
+        """
+        :return: Radius of the circle the cylinder's width spans.
+        """
+        return self.width / 2.0
+
+    @property
+    def volume(self) -> float:
+        return math.pi * self.radius**2 * self.height
+
+    @property
     def mesh(self) -> trimesh.Trimesh:
         """
         Returns a trimesh object representing the cylinder.
         """
         mesh = trimesh.creation.cylinder(
-            radius=self.width / 2, height=self.height, sections=16
+            radius=self.radius, height=self.height, sections=16
         )
         mesh.visual.vertex_colors = trimesh.visual.color.to_rgba(self.color.to_rgba())
         return mesh
@@ -930,6 +965,10 @@ class Box(Shape):
     """
 
     scale: Scale = field(default_factory=Scale)
+
+    @property
+    def volume(self) -> float:
+        return self.scale.x * self.scale.y * self.scale.z
 
     @property
     def mesh(self) -> trimesh.Trimesh:

--- a/test/semantic_digital_twin_test/test_geometry/test_shape.py
+++ b/test/semantic_digital_twin_test/test_geometry/test_shape.py
@@ -1,13 +1,22 @@
+import math
 import os
 from importlib.resources import files
 from pathlib import Path
 
 import numpy as np
+import pytest
 import trimesh
 
 from krrood.adapters.json_serializer import from_json, to_json
 
-from semantic_digital_twin.world_description.geometry import Box, Mesh, Scale, Texture
+from semantic_digital_twin.world_description.geometry import (
+    Box,
+    Cylinder,
+    Mesh,
+    Scale,
+    Sphere,
+    Texture,
+)
 
 
 def test_shape():
@@ -93,3 +102,33 @@ def test_textured_primitive_survives_serialization():
 
     assert restored.texture == box.texture
     assert restored == box
+
+
+# %% the volume a shape encloses
+
+
+def test_box_volume():
+    assert Box(scale=Scale(0.5, 2.0, 3.0)).volume == pytest.approx(3.0)
+
+
+def test_sphere_volume():
+    assert Sphere(radius=2.0).volume == pytest.approx(4.0 / 3.0 * math.pi * 8.0)
+
+
+def test_cylinder_volume():
+    """
+    A cylinder's volume follows from the circle its width spans, not from the polygon
+    its mesh approximates that circle with.
+    """
+    cylinder = Cylinder(width=2.0, height=3.0)
+
+    assert cylinder.volume == pytest.approx(math.pi * 3.0)
+    assert cylinder.volume > cylinder.mesh.volume
+
+
+def test_mesh_volume(tmp_path):
+    source = trimesh.creation.box(extents=(1.0, 2.0, 4.0))
+
+    mesh = Mesh.from_trimesh(mesh=source, dirname=str(tmp_path), file_type="stl")
+
+    assert mesh.volume == pytest.approx(8.0)


### PR DESCRIPTION
Adds a `volume` property to `Shape` and its subclasses.

- `Box`, `Sphere` and `Cylinder` compute the volume from their own parameters, so a curved shape is not understated by the polygonal mesh that approximates it.
- `Mesh` reports the volume its surface encloses.
- `Cylinder` gains a `radius` property, which its `mesh` now uses as well.

Covered by tests in `test/semantic_digital_twin_test/test_geometry/test_shape.py`, including one asserting that a cylinder's volume exceeds that of its own mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCjykZP4vnSY462RQpbnQZ