### PR TITLE
World synchronization: batched state changes + watermark-based sync

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/messages.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/messages.py
@@ -51,6 +51,23 @@ class MetaData(SubclassJSONSerializer):
 
 
 @dataclass
+class StateWatermark:
+    """
+    A position in the stream of messages that one publisher sent.
+
+    Positions of different publishers are not comparable, which is why the publisher is
+    part of the watermark. A process that has to know whether it caught up with a change
+    of another process compares this against what it applied from that publisher.
+    """
+
+    origin: MetaData
+    """The publisher whose stream this position belongs to."""
+
+    sequence_number: int
+    """The position in the stream of that publisher."""
+
+
+@dataclass
 class Message(ABC):
     """
     Abstract base class for all messages.
@@ -59,28 +76,13 @@ class Message(ABC):
     meta_data: MetaData
     """Message origin meta data."""
 
-    publication_event_id: UUID = field(default_factory=uuid.uuid4, kw_only=True)
-    """UUID uniquely identifying the event (world update / state update / ...) that originated this message.
+    sequence_number: int = field(default=0, kw_only=True)
+    """Position of this message in the stream of messages its publisher sent.
 
-    Recipients can use this UUID in responses to refer to this event.
-    Allows the publication/subscription mechanism to track what messages have been received and acknowledged.
+    Counts up by one per publication, so a recipient can tell how far it has caught up
+    with that publisher, and a publisher can tell others what to catch up with. Assigned
+    when the message is published; a message that was never published has no position.
     """
-
-
-@dataclass
-class Acknowledgment:
-    """
-    Message acknowledging receipt of a published event.
-
-    :param publication_event_id: The UUID of the publication event being acknowledged.
-    :param node_meta_data: The metadata identifying the acknowledging node.
-    """
-
-    publication_event_id: UUID
-    """The UUID of the publication event being acknowledged."""
-
-    node_meta_data: MetaData
-    """The metadata identifying the acknowledging node."""
 
 
 @dataclass

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/tf_publisher.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/tf_publisher.py
@@ -186,6 +186,16 @@ class TFPublisher(StateChangeCallback):
         self.tf_model_cb.notify_model_change()
         self.on_state_change()
 
+    def stop(self):
+        """
+        Deregister this publisher and the model callback it owns.
+
+        The model callback registers itself on the world, so stopping only the state
+        callback would leave it publishing on a node that may already be gone.
+        """
+        self.tf_model_cb.stop()
+        super().stop()
+
     @classmethod
     def create_with_ignore_robot(cls, robot: AbstractRobot, node: Node) -> Self:
         """

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
@@ -1,12 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 import threading
-import time
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import timedelta
 from functools import cached_property
-from typing import ClassVar, Optional, Set, Type, List, Dict
+from typing import ClassVar, Optional, Type, List, Dict
 from uuid import UUID
 
 import numpy as np
@@ -26,7 +26,7 @@ from semantic_digital_twin.adapters.ros.messages import (
     Message,
     ModificationBlock,
     LoadModel,
-    Acknowledgment,
+    StateWatermark,
     WorldUpdate,
 )
 from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
@@ -40,6 +40,8 @@ from semantic_digital_twin.exceptions import (
     MissingPublishChangesKWARG,
     ApplyMissedMessagesWhileWorldIsBeingModifiedError,
     StateUpdateContainsUnknownDegreesOfFreedomError,
+    WorldHasMultipleSynchronizersError,
+    WorldHasNoSynchronizerError,
 )
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.world_entity import (
@@ -47,31 +49,43 @@ from semantic_digital_twin.world_description.world_entity import (
 )
 
 
+class PublicationProgress(ABC):
+    """
+    Reports how far its own changes were published to the other processes.
+
+    Whoever hands out a :class:`StateWatermark` of its own stream tells others what they
+    have to catch up with before they may read the world it publishes.
+    """
+
+    @property
+    @abstractmethod
+    def published_sequence_number(self) -> int:
+        """
+        Position of the message that was published last.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def latest_published_watermark(self) -> StateWatermark:
+        """
+        The position of the last published message, together with its publisher.
+        """
+        raise NotImplementedError
+
+
 @dataclass
-class Synchronizer(WorldEntityWithClassBasedID):
+class Synchronizer(WorldEntityWithClassBasedID, PublicationProgress):
     """
     Abstract synchronizer to manage world synchronizations between processes running
     semantic digital twin.
 
-    It manages publishers and subscribers, ensuring proper cleanup after use.
-    The communication is JSON string based.
+    It manages publishers and subscribers, ensuring proper cleanup after use. The
+    communication is JSON string based.
 
-    .. warning::
-
-        When ``synchronous=True``, publication blocks until **all** current subscribers acknowledge receipt or
-        a 5-second timeout elapses. If a subscriber process crashes or exits without unsubscribing, the publisher
-        will wait for the full timeout on every synchronous publish because the dead process
-        never acknowledges.
-
-        To mitigate this, always clean up synchronizers when shutting down:
-
-        .. code-block:: python
-
-            import atexit
-            atexit.register(synchronizer.close)
-
-        This gives some assurance that the ROS subscriber is destroyed on exit, so other publishers
-        will no longer expect an acknowledgment from the terminated process.
+    Every published message carries its position in this synchronizer's stream, and
+    every applied message is remembered per publisher, so that two processes can tell
+    each other what to catch up with without comparing world models they cannot compare.
     """
 
     node: RosNode = field(kw_only=True)
@@ -84,19 +98,6 @@ class Synchronizer(WorldEntityWithClassBasedID):
     The topic name of the publisher and subscriber.
     """
 
-    synchronous: bool = False
-    """
-    If ``True``, publish blocks until all subscribers acknowledge receipt.
-    """
-
-    acknowledge_topic_name: Optional[str] = "/acknowledge"
-    """
-    The name of the acknowledgment topic.
-
-    Synchronous publication of world state waits until all subscribers have acknowledged
-    on this topic.
-    """
-
     publisher: Optional[Publisher] = field(init=False, default=None)
     """
     The publisher used to publish the world state.
@@ -107,72 +108,31 @@ class Synchronizer(WorldEntityWithClassBasedID):
     The subscriber to the world state.
     """
 
-    acknowledge_publisher: Optional[Publisher] = field(init=False, default=None)
-    """
-    The publisher used to send acknowledgment messages on the acknowledge topic.
-    """
-
-    acknowledge_subscriber: Optional[Subscription] = field(init=False, default=None)
-    """
-    The subscriber that receives acknowledgment messages from other nodes.
-    """
-
     message_type: ClassVar[Optional[Type[Message]]] = None
     """
     The type of the message that is sent and received.
     """
 
-    wait_for_synchronization_timeout: float = field(default=30.0)
+    _published_sequence_number: int = field(default=0, init=False, repr=False)
     """
-    Timeout in seconds for waiting for synchronization.
-    """
-
-    _current_publication_event_id: Optional[UUID] = None
-    """
-    The UUID of the most recently published message awaiting acknowledgment.
+    Position of the message this synchronizer published last.
     """
 
-    _expected_acknowledgment_count: int = 0
-    """
-    Number of remote subscribers that must acknowledge the current event before
-    synchronous publication unblocks.
-    """
-
-    _received_acknowledgments: Set[MetaData] = field(default_factory=set)
-    """
-    Metadata of subscribers that have acknowledged the current event so far.
-    """
-
-    _acknowledge_condition_variable: threading.Condition = field(
-        default_factory=threading.Condition
+    _applied_sequence_numbers: Dict[MetaData, int] = field(
+        default_factory=dict, init=False, repr=False
     )
     """
-    Condition variable used to block synchronous publication until all expected
-    acknowledgments have been received.
+    The highest position applied so far, per publisher.
     """
 
-    _publish_lock: threading.Lock = field(default_factory=threading.Lock)
-    """
-    Serializes :meth:`publish` so concurrent publications cannot unintentionally
-    override the shared acknowledgment-tracking state (``_current_publication_event_id``
-    / ``_received_acknowledgments``).
-    """
-
-    _subscriber_discovery_grace_period: timedelta = field(
-        default=timedelta(seconds=0.2), init=False
+    _sequence_number_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
     )
     """
-    Maximum time that :meth:`_snapshot_subscribers_after_discovery_settles` waits for a
-    just-created remote subscriber to be reflected in this node's ROS graph cache before
-    treating the observed subscriber count as final.
-    """
+    Guards the published and applied positions.
 
-    _subscriber_discovery_poll_interval: timedelta = field(
-        default=timedelta(seconds=0.02), init=False
-    )
-    """
-    Interval between subscriber-count samples taken while waiting for ROS graph
-    discovery to settle in :meth:`_snapshot_subscribers_after_discovery_settles`.
+    Messages are published and applied on different threads, and both positions are read
+    by whoever waits for one of them.
     """
 
     def __post_init__(self):
@@ -184,15 +144,6 @@ class Synchronizer(WorldEntityWithClassBasedID):
         )
         self.publisher = self.node.create_publisher(
             std_msgs.msg.String, topic=self.topic_name, qos_profile=10
-        )
-        self.acknowledge_subscriber = self.node.create_subscription(
-            std_msgs.msg.String,
-            topic=self.acknowledge_topic_name,
-            callback=self.acknowledge_callback,
-            qos_profile=10,
-        )
-        self.acknowledge_publisher = self.node.create_publisher(
-            std_msgs.msg.String, topic=self.acknowledge_topic_name, qos_profile=10
         )
 
     @cached_property
@@ -227,101 +178,40 @@ class Synchronizer(WorldEntityWithClassBasedID):
 
             self._subscription_callback(deserialized_message)
 
-    def acknowledge_message(self, message: message_type):
-        if self.acknowledge_publisher is None:
-            return
-        acknowledgment = Acknowledgment(
-            publication_event_id=message.publication_event_id,
-            node_meta_data=self.meta_data,
+    @property
+    def published_sequence_number(self) -> int:
+        with self._sequence_number_lock:
+            return self._published_sequence_number
+
+    @property
+    def latest_published_watermark(self) -> StateWatermark:
+        return StateWatermark(
+            origin=self.meta_data, sequence_number=self.published_sequence_number
         )
-        self.acknowledge_publisher.publish(
-            std_msgs.msg.String(data=json.dumps(to_json(acknowledgment)))
-        )
 
-    def acknowledge_callback(self, msg: std_msgs.msg.String):
+    def has_applied(self, watermark: StateWatermark) -> bool:
         """
-        Called when subscribers of the sync topic acknowledge receipt of synchronization
-        notifications.
+        Whether everything up to ``watermark`` was applied to this world.
 
-        :param msg: The incoming ROS string message containing a serialized
-            acknowledgment.
+        A publisher this world never heard from is treated as being at the start of its
+        stream, so its first message is still awaited.
         """
-        acknowledgment = from_json(json.loads(msg.data))
+        with self._sequence_number_lock:
+            applied = self._applied_sequence_numbers.get(watermark.origin, 0)
+        return applied >= watermark.sequence_number
 
-        with self._acknowledge_condition_variable:
-            if (
-                self._expected_acknowledgment_count == 0
-                or self._current_publication_event_id is None
-            ):
-                # Not waiting for any acknowledgments at the moment
-                return
-
-            if (
-                acknowledgment.publication_event_id
-                != self._current_publication_event_id
-            ):
-                # This acknowledgment is not about the event we want to have acknowledged
-                return
-
-            self._received_acknowledgments.add(acknowledgment.node_meta_data)
-
-            if (
-                len(self._received_acknowledgments)
-                >= self._expected_acknowledgment_count
-            ):
-                self._acknowledge_condition_variable.notify_all()
-                return
-
-    def _snapshot_subscribers(self) -> int:
+    def record_applied(self, message: Message):
         """
-        Count the remote subscribers to the synchronization topic.
+        Remember how far this world caught up with the publisher of ``message``.
 
-        The publishing node's own subscription is excluded because self-originated
-        messages are already filtered out in :meth:`subscription_callback`.
-
-        :return: Number of remote subscriptions on this synchronizer's topic.
+        Called when a message is applied rather than when it is received, so that a
+        buffered message does not count as caught up with.
         """
-        infos = self.node.get_subscriptions_info_by_topic(self.topic_name)
-        own_name = self.node.get_name()
-        own_count = sum(1 for info in infos if info.node_name == own_name)
-        return len(infos) - own_count
-
-    def _snapshot_subscribers_after_discovery_settles(self) -> int:
-        """
-        Snapshot the subscriber count, giving ROS graph discovery a short grace period
-        to settle first.
-
-        ROS graph discovery is asynchronous, so a remote subscriber created moments ago
-        may not yet be reflected in this node's local graph cache, making
-        :meth:`_snapshot_subscribers` under-count it. Publishing synchronously with an
-        under-counted expectation lets :meth:`publish` return as soon as the (too few)
-        expected acknowledgments arrive, silently breaking the synchronous contract for
-        subscribers discovery had not caught up with yet. Polling until two consecutive
-        samples agree, or the grace period elapses, narrows that window without adding
-        latency once discovery has already settled.
-
-        If the count never stabilizes within the grace period, the highest count seen is
-        used rather than the most recent one: an under-count silently breaks the
-        synchronous contract (the bug this method fixes), whereas an over-count only
-        costs the existing, already-logged ``wait_for_synchronization_timeout`` wait -
-        a strictly safer failure mode than the one being fixed.
-
-        :return: The subscriber count once observed stable across two consecutive
-            samples, or the highest sample seen once the grace period elapses.
-        """
-        deadline = (
-            time.monotonic() + self._subscriber_discovery_grace_period.total_seconds()
-        )
-        previous_count = self._snapshot_subscribers()
-        highest_count_seen = previous_count
-        while time.monotonic() < deadline:
-            time.sleep(self._subscriber_discovery_poll_interval.total_seconds())
-            current_count = self._snapshot_subscribers()
-            highest_count_seen = max(highest_count_seen, current_count)
-            if current_count == previous_count:
-                return current_count
-            previous_count = current_count
-        return highest_count_seen
+        with self._sequence_number_lock:
+            origin = message.meta_data
+            self._applied_sequence_numbers[origin] = max(
+                self._applied_sequence_numbers.get(origin, 0), message.sequence_number
+            )
 
     @abstractmethod
     def _subscription_callback(self, msg: message_type):
@@ -332,33 +222,19 @@ class Synchronizer(WorldEntityWithClassBasedID):
 
     def publish(self, msg: Message):
         """
-        Publish a message to the synchronization topic.
+        Publish a message to the synchronization topic, stamped with its position in
+        this synchronizer's stream.
+
+        Waits for its turn in the stream of publications of the world, so that a message
+        cannot overtake the changes that were published before the one it describes.
 
         :param msg: The message to publish.
         """
-        if not self.synchronous:
+        with self._world.get_world_model_manager().publishing_in_order():
+            with self._sequence_number_lock:
+                self._published_sequence_number += 1
+                msg.sequence_number = self._published_sequence_number
             self.publisher.publish(std_msgs.msg.String(data=json.dumps(to_json(msg))))
-            return
-
-        with self._publish_lock, self._acknowledge_condition_variable:
-            self._current_publication_event_id = msg.publication_event_id
-            self._expected_acknowledgment_count = (
-                self._snapshot_subscribers_after_discovery_settles()
-            )
-            self._received_acknowledgments = set()
-            self.publisher.publish(std_msgs.msg.String(data=json.dumps(to_json(msg))))
-
-            success = self._acknowledge_condition_variable.wait_for(
-                lambda: len(self._received_acknowledgments)
-                >= self._expected_acknowledgment_count,
-                timeout=self.wait_for_synchronization_timeout,
-            )
-            if not success:
-                self.node.get_logger().warning("Message was not acknowledged, timeout")
-
-            self._current_publication_event_id = None
-            self._expected_acknowledgment_count = 0
-            self._received_acknowledgments = set()
 
     def close(self):
         """
@@ -368,17 +244,9 @@ class Synchronizer(WorldEntityWithClassBasedID):
             self.node.destroy_subscription(self.subscriber)
             self.subscriber = None
 
-        if self.acknowledge_subscriber is not None:
-            self.node.destroy_subscription(self.acknowledge_subscriber)
-            self.acknowledge_subscriber = None
-
         if self.publisher is not None:
             self.node.destroy_publisher(self.publisher)
             self.publisher = None
-
-        if self.acknowledge_publisher is not None:
-            self.node.destroy_publisher(self.acknowledge_publisher)
-            self.acknowledge_publisher = None
 
 
 @dataclass
@@ -402,8 +270,33 @@ class ModelReloadSynchronizer(Synchronizer):
 
     topic_name: str = "/semantic_digital_twin/reload_model"
 
+    defer_incoming_reloads: bool = False
+    """
+    If ``True``, an incoming reload is remembered instead of applied on the receiving
+    thread.
+
+    Use this when another thread owns the world and has to decide itself when it may be
+    replaced, for example a controller that must not have the world changed under a
+    running motion.
+    """
+
+    pending_reload: Optional[LoadModel] = field(default=None, init=False, repr=False)
+    """
+    The reload that was received but not applied yet.
+
+    Only the most recent one is kept, because a reload replaces the whole world model
+    and therefore makes every earlier request obsolete.
+    """
+
     def __post_init__(self):
         super().__post_init__()
+
+    @property
+    def has_pending_reload(self) -> bool:
+        """
+        Whether a reload is waiting to be applied.
+        """
+        return self.pending_reload is not None
 
     def publish_reload_model(self):
         """
@@ -420,6 +313,22 @@ class ModelReloadSynchronizer(Synchronizer):
         self.publish(message)
 
     def _subscription_callback(self, msg: LoadModel):
+        if self.defer_incoming_reloads:
+            self.pending_reload = msg
+            return
+        self.apply_reload(msg)
+
+    def apply_pending_reload(self):
+        """
+        Apply the reload that was deferred, if there is one.
+        """
+        if self.pending_reload is None:
+            return
+        message = self.pending_reload
+        self.pending_reload = None
+        self.apply_reload(message)
+
+    def apply_reload(self, msg: LoadModel):
         """
         Update the world with the new model by fetching it from the database.
 
@@ -433,6 +342,7 @@ class ModelReloadSynchronizer(Synchronizer):
         new_world = self.session.scalars(query).one().from_dao()
         self._replace_world(new_world)
         self._world._notify_model_change(publish_changes=False)
+        self.record_applied(msg)
 
     def _replace_world(self, new_world: World):
         """
@@ -458,48 +368,70 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
     ordering guarantees — a model update published before a state update will always be
     received first, eliminating the cross-topic race that causes ``KeyError`` when state
     messages arrive before the model update that introduced the referenced DOF UUIDs.
-
-    The ``synchronize_model`` and ``synchronize_state`` flags control whether outgoing
-    changes are published.  Incoming messages from other nodes are always received and
-    applied regardless of these flags.
     """
 
     message_type: ClassVar[Optional[Type[Message]]] = WorldUpdate
 
     topic_name: str = "/semantic_digital_twin/world_sync"
 
-    synchronize_model: bool = True
+    defer_incoming_updates: bool = False
     """
-    If ``True``, model changes on this world are published to the synchronization topic.
+    If ``True``, incoming messages are buffered instead of applied on the subscription
+    thread.
 
-    If ``False``, this synchronizer acts as a receive-only participant for model
-    changes.
-    """
-
-    synchronize_state: bool = True
-    """
-    If ``True``, state changes on this world are published to the synchronization topic.
-
-    If ``False``, this synchronizer acts as a receive-only participant for state
-    changes.
+    Outgoing publishing is unaffected, unlike with ``pause()``. Use this when another
+    thread owns the world and has to decide itself when an update may be applied, for
+    example a controller that must not have the world changed under a running motion.
     """
 
     missed_messages: List[WorldUpdate] = field(
         default_factory=list, init=False, repr=False
     )
     """
-    Buffer for messages received while the synchronizer is paused.
+    Buffer for messages that were received but not applied yet.
 
-    These messages can be applied later by calling ``apply_missed_messages()``.
+    These messages can be applied later by calling ``apply_missed_messages()`` or, up to
+    the next model modification, ``apply_missed_state_updates()``.
     """
 
+    _missed_message_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+    """
+    Guards ``missed_messages``.
+
+    The subscription thread appends while the owning thread drains. Deliberately not
+    ``_world_lock``: receiving a message must never wait for the world.
+    """
+
+    @classmethod
+    def for_world(cls, world: World) -> WorldSynchronizer:
+        """
+        The synchronizer that publishes the changes of ``world``.
+
+        :raises WorldHasNoSynchronizerError: If the world publishes its changes nowhere.
+        :raises WorldHasMultipleSynchronizersError: If several synchronizers publish the
+            changes of the world, leaving it undecided which stream to refer to.
+        """
+        synchronizers = [
+            callback
+            for callback in world.get_world_model_manager().model_change_callbacks
+            if isinstance(callback, cls)
+        ]
+        if not synchronizers:
+            raise WorldHasNoSynchronizerError(world=world)
+        if len(synchronizers) > 1:
+            raise WorldHasMultipleSynchronizersError(
+                world=world, synchronizer_count=len(synchronizers)
+            )
+        return synchronizers[0]
+
     def __post_init__(self):
+        # Called explicitly instead of via super(): Synchronizer does not chain to its own
+        # base, so only naming both branches of the MRO runs the ros setup and the callback
+        # registration.
         Synchronizer.__post_init__(self)
-        if self.synchronize_model:
-            self._world.get_world_model_manager().model_change_callbacks.append(self)
-        if self.synchronize_state:
-            self._world.state.state_change_callbacks.append(self)
-        self.update_previous_world_state()
+        ModelChangeCallback.__post_init__(self)
 
     def on_model_change(self, **kwargs):
         publish_changes = kwargs.get("publish_changes")
@@ -541,14 +473,12 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         """
         Publishes ``update`` now, or defers it until the world lock is released.
 
-        When this callback fires from within a ``modify_world`` context, ``_world_lock``
-        is held by the modifying thread. Publishing (and, in synchronous mode, waiting
-        for acknowledgments) while holding the lock would block the receiving executor
-        that must acquire the lock to apply and acknowledge, resulting in a cross-
-        process deadlock. We therefore defer the publish to the world's
-        ``pending_publications``, which are flushed after the lock is released. Outside
-        a modification (usually just during state changes) no lock is held, so we
-        publish directly.
+        A modification that is still running has not produced its model block yet, so
+        publishing a state change from inside it would send degrees of freedom that the
+        receivers cannot know yet. Deferring to the world's ``pending_publications``,
+        which are flushed after the lock is released, keeps a state update behind the
+        model update that introduces what it refers to. Outside a modification (usually
+        just during state changes) no lock is held, so we publish directly.
         """
         if self._world.world_is_being_modified:
             self._world.get_world_model_manager().pending_publications.append(
@@ -586,11 +516,26 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         }
 
     def _subscription_callback(self, message: WorldUpdate):
-        if self._is_paused:
-            self.missed_messages.append(message)
-        else:
-            self.apply_message(message)
-            self.acknowledge_message(message)
+        if self._is_paused or self.defer_incoming_updates:
+            with self._missed_message_lock:
+                self.missed_messages.append(message)
+            return
+        self.apply_message(message)
+
+    @property
+    def has_buffered_model_modification(self) -> bool:
+        """
+        Whether any buffered message carries a model modification.
+
+        A model modification invalidates anything compiled against the current world
+        structure, so an owner of the world uses this to decide whether it can keep
+        going.
+        """
+        with self._missed_message_lock:
+            return any(
+                message.modification_block is not None
+                for message in self.missed_messages
+            )
 
     def apply_message(self, message: WorldUpdate):
         """
@@ -604,6 +549,7 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
                 self._apply_model(message.modification_block)
             if message.state_update is not None:
                 self._apply_state(message.state_update)
+        self.record_applied(message)
 
     def _apply_model(self, modification_block_message: ModificationBlock):
         """
@@ -644,7 +590,39 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
 
     def apply_missed_messages(self):
         """
-        Apply buffered messages accumulated while the synchronizer was paused.
+        Apply every buffered message.
+
+        :raises ApplyMissedMessagesWhileWorldIsBeingModifiedError: If called while a
+            ``modify_world`` context is active on this synchronizer's world.
+        """
+        self._apply_leading_messages(len(self.missed_messages))
+
+    def apply_missed_state_updates(self):
+        """
+        Apply the buffered messages up to the next model modification.
+
+        Everything from that modification onwards stays buffered, so the order in which
+        the messages were published survives. Use this to keep consuming state while a
+        model modification cannot be applied yet.
+
+        :raises ApplyMissedMessagesWhileWorldIsBeingModifiedError: If called while a
+            ``modify_world`` context is active on this synchronizer's world.
+        """
+        self._apply_leading_messages(self._count_leading_state_only_messages())
+
+    def _count_leading_state_only_messages(self) -> int:
+        """
+        Number of buffered messages before the first one carrying a model modification.
+        """
+        with self._missed_message_lock:
+            for position, message in enumerate(self.missed_messages):
+                if message.modification_block is not None:
+                    return position
+            return len(self.missed_messages)
+
+    def _apply_leading_messages(self, count: int):
+        """
+        Apply the first ``count`` buffered messages.
 
         Each message is applied independently so that model-change notifications fire
         between messages, which is required for state messages that follow model
@@ -656,17 +634,18 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         """
         if self._world.world_is_being_modified:
             raise ApplyMissedMessagesWhileWorldIsBeingModifiedError()
-        if not self.missed_messages:
-            return
-        pending_messages = self.missed_messages
-        self.missed_messages = []
+        with self._missed_message_lock:
+            pending_messages = self.missed_messages[:count]
+            if not pending_messages:
+                return
+            # Mutate in place instead of rebinding: the subscription thread appends to
+            # the same list and its message must survive the drain.
+            del self.missed_messages[: len(pending_messages)]
         # Hold the world lock across the whole batch so the buffered messages apply atomically: a
         # concurrent modify_world on another thread serializes behind it instead of interleaving.
         with self._world._world_lock:
             for message in pending_messages:
                 self.apply_message(message)
-        for message in pending_messages:
-            self.acknowledge_message(message)
 
     def resume(self):
         """
@@ -675,21 +654,6 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         Missed messages are NOT applied automatically.
         """
         super().resume()
-
-    def stop(self):
-        if self.synchronize_model:
-            try:
-                self._world.get_world_model_manager().model_change_callbacks.remove(
-                    self
-                )
-            except ValueError:
-                pass
-        if self.synchronize_state:
-            try:
-                self._world.state.state_change_callbacks.remove(self)
-            except ValueError:
-                pass
-        super().stop()
 
     def close(self):
         self.stop()

--- a/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations, absolute_import
 
 from dataclasses import dataclass, field, Field
 from pathlib import Path
-from typing import Dict, Set, Any
+from typing import Dict, Set
 from uuid import UUID
 
 import mujoco
@@ -17,8 +17,8 @@ from typing_extensions import (
 )
 
 from krrood.adapters.exceptions import JSONSerializationError
-from krrood.symbolic_math.symbolic_math import SymbolicMathType
 from krrood.exceptions import DataclassException
+from krrood.symbolic_math.symbolic_math import SymbolicMathType
 from semantic_digital_twin.datastructures.definitions import JointStateType
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 
@@ -837,6 +837,52 @@ class StateUpdateContainsUnknownDegreesOfFreedomError(UsageError):
 
     def suggest_correction(self) -> str:
         return ""
+
+
+@dataclass
+class WorldHasNoSynchronizerError(UsageError):
+    """
+    Raised when the synchronizer of a world is asked for, but the world publishes its
+    changes nowhere.
+    """
+
+    world: World
+    """
+    The world without a synchronizer.
+    """
+
+    def error_message(self) -> str:
+        return f"{self.world} does not publish its changes to other processes."
+
+    def suggest_correction(self) -> str:
+        return "Create a WorldSynchronizer for this world."
+
+
+@dataclass
+class WorldHasMultipleSynchronizersError(UsageError):
+    """
+    Raised when the synchronizer of a world is asked for, but several of them publish
+    its changes, leaving it undecided which stream a watermark would refer to.
+    """
+
+    world: World
+    """
+    The world with more than one synchronizer.
+    """
+
+    synchronizer_count: int
+    """
+    How many synchronizers publish the changes of the world.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"{self.synchronizer_count} synchronizers publish the changes of "
+            f"{self.world}."
+        )
+
+    def suggest_correction(self) -> str:
+        return "Close all but one of them."
 
 
 @dataclass

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -11208,6 +11208,28 @@ class WorldModelManagerDAO(
     )
 
 
+class WorldStateBatchContextManagerDAO(
+    Base, DataAccessObject[semantic_digital_twin.world.WorldStateBatchContextManager]
+):
+    __tablename__ = "WorldStateBatchContextManagerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    publish_changes: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+
 class JointDynamicsDAO(
     Base,
     DataAccessObject[

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -4359,30 +4359,6 @@ class RoboCasaObjectResolverDAO(
     }
 
 
-class AcknowledgmentDAO(
-    Base, DataAccessObject[semantic_digital_twin.adapters.ros.messages.Acknowledgment]
-):
-    __tablename__ = "AcknowledgmentDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    publication_event_id: Mapped[uuid.UUID] = mapped_column(
-        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
-    )
-
-    node_meta_data_id: Mapped[int] = mapped_column(
-        ForeignKey("MetaDataDAO.database_id", use_alter=True),
-        nullable=True,
-        use_existing_column=True,
-    )
-
-    node_meta_data: Mapped[MetaDataDAO] = relationship(
-        "MetaDataDAO", uselist=False, foreign_keys=[node_meta_data_id], post_update=True
-    )
-
-
 class MessageDAO(
     Base, DataAccessObject[semantic_digital_twin.adapters.ros.messages.Message]
 ):
@@ -4392,9 +4368,8 @@ class MessageDAO(
         Integer, primary_key=True, use_existing_column=True
     )
 
-    publication_event_id: Mapped[uuid.UUID] = mapped_column(
-        sqlalchemy.sql.sqltypes.UUID, nullable=False, use_existing_column=True
-    )
+    sequence_number: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
     polymorphic_type: Mapped[str] = mapped_column(
         String(255), nullable=False, use_existing_column=True
     )
@@ -4480,6 +4455,28 @@ class ModificationBlockDAO(
         "inherit_condition": database_id == MessageDAO.database_id,
         "polymorphic_load": "selectin",
     }
+
+
+class StateWatermarkDAO(
+    Base, DataAccessObject[semantic_digital_twin.adapters.ros.messages.StateWatermark]
+):
+    __tablename__ = "StateWatermarkDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    sequence_number: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    origin_id: Mapped[int] = mapped_column(
+        ForeignKey("MetaDataDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    origin: Mapped[MetaDataDAO] = relationship(
+        "MetaDataDAO", uselist=False, foreign_keys=[origin_id], post_update=True
+    )
 
 
 class WorldModelSnapshotDAO(
@@ -9133,6 +9130,68 @@ class WorldEntityWithIDNotInKwargsDAO(
     )
 
 
+class WorldHasMultipleSynchronizersErrorDAO(
+    UsageErrorDAO,
+    DataAccessObject[
+        semantic_digital_twin.exceptions.WorldHasMultipleSynchronizersError
+    ],
+):
+    __tablename__ = "WorldHasMultipleSynchronizersErrorDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(UsageErrorDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    synchronizer_count: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "WorldHasMultipleSynchronizersErrorDAO",
+        "inherit_condition": database_id == UsageErrorDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class WorldHasNoSynchronizerErrorDAO(
+    UsageErrorDAO,
+    DataAccessObject[semantic_digital_twin.exceptions.WorldHasNoSynchronizerError],
+):
+    __tablename__ = "WorldHasNoSynchronizerErrorDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(UsageErrorDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "WorldHasNoSynchronizerErrorDAO",
+        "inherit_condition": database_id == UsageErrorDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
 class WorldValidationErrorDAO(
     LogicalErrorDAO,
     DataAccessObject[semantic_digital_twin.exceptions.WorldValidationError],
@@ -12474,13 +12533,6 @@ class SynchronizerDAO(
     topic_name: Mapped[typing.Optional[builtins.str]] = mapped_column(
         sqlalchemy.sql.sqltypes.Text, use_existing_column=True
     )
-    synchronous: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
-    acknowledge_topic_name: Mapped[typing.Optional[builtins.str]] = mapped_column(
-        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
-    )
-    wait_for_synchronization_timeout: Mapped[builtins.float] = mapped_column(
-        use_existing_column=True
-    )
 
     __mapper_args__ = {
         "polymorphic_identity": "SynchronizerDAO",
@@ -12501,6 +12553,10 @@ class ModelReloadSynchronizerDAO(
         ForeignKey(SynchronizerDAO.database_id),
         primary_key=True,
         use_existing_column=True,
+    )
+
+    defer_incoming_reloads: Mapped[builtins.bool] = mapped_column(
+        use_existing_column=True
     )
 
     __mapper_args__ = {
@@ -12884,8 +12940,9 @@ class WorldSynchronizerDAO(
         use_existing_column=True,
     )
 
-    synchronize_model: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
-    synchronize_state: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
+    defer_incoming_updates: Mapped[builtins.bool] = mapped_column(
+        use_existing_column=True
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "WorldSynchronizerDAO",

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -158,6 +158,55 @@ class ResetStateContextManager:
 
 
 @dataclass
+class WorldStateBatchContextManager:
+    """
+    Context manager collapsing many state changes of a `World` into a single
+    notification.
+
+    Writing a whole configuration one degree of freedom at a time otherwise recomputes
+    the forward kinematics and notifies every observer once per degree of freedom, which
+    turns one logical change into a burst of individual ones.
+    """
+
+    publish_changes: bool = True
+    """
+    Whether the single notification of this batch publishes the changes it collected.
+    """
+
+    world: World = field(kw_only=True, repr=False)
+    """
+    The world whose state changes are collected.
+    """
+
+    def __enter__(self) -> WorldStateBatchContextManager:
+        if self.world._state_change_batch_depth == 0:
+            self.world._state_change_batch_publishes_changes = self.publish_changes
+        elif self.world._state_change_batch_publishes_changes != self.publish_changes:
+            raise MismatchingPublishChangesAttribute(
+                self.world._state_change_batch_publishes_changes, self.publish_changes
+            )
+        self.world._state_change_batch_depth += 1
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[Exception],
+        exc_tb: Optional[type],
+    ) -> None:
+        self.world._state_change_batch_depth -= 1
+        if self.world._state_change_batch_depth > 0:
+            return
+        has_collected_change = self.world._state_change_batch_has_collected_change
+        publish_changes = self.world._state_change_batch_publishes_changes
+        self.world._state_change_batch_has_collected_change = False
+        self.world._state_change_batch_publishes_changes = True
+        if not has_collected_change:
+            return
+        self.world.notify_state_change(publish_changes=publish_changes)
+
+
+@dataclass
 class WorldModelUpdateContextManager:
     """
     Context manager for updating the state of a given `World` instance.
@@ -467,6 +516,25 @@ class World(HasSimulatorProperties):
     world_is_being_modified: bool = False
     """
     Is set to True, when a world.modify_world context is used.
+    """
+
+    _state_change_batch_depth: int = field(default=0, init=False, repr=False)
+    """
+    How many nested :meth:`batch_state_changes` contexts are currently open.
+    """
+
+    _state_change_batch_has_collected_change: bool = field(
+        default=False, init=False, repr=False
+    )
+    """
+    Whether a state change was notified while the current batch is open.
+    """
+
+    _state_change_batch_publishes_changes: bool = field(
+        default=True, init=False, repr=False
+    )
+    """
+    The ``publish_changes`` the currently open batch was entered with.
     """
 
     name: Optional[str] = None
@@ -1769,7 +1837,15 @@ class World(HasSimulatorProperties):
         """
         If you have changed the state of the world, call this function to trigger
         necessary events and increase the state version.
+
+        Inside a :meth:`batch_state_changes` context the notification is collected and
+        emitted once when that context ends, with the ``publish_changes`` of that
+        context: the setters that write the state cannot know they are part of a batch,
+        so the batch is what decides whether its changes are published.
         """
+        if self._state_change_batch_depth > 0:
+            self._state_change_batch_has_collected_change = True
+            return
         if not self.is_empty():
             self._forward_kinematic_manager.recompute()
         self.state._notify_state_change(publish_changes=publish_changes, **kwargs)
@@ -2363,6 +2439,22 @@ class World(HasSimulatorProperties):
         self, publish_changes: bool = True
     ) -> WorldModelUpdateContextManager:
         return WorldModelUpdateContextManager(
+            world=self, publish_changes=publish_changes
+        )
+
+    def batch_state_changes(
+        self, publish_changes: bool = True
+    ) -> WorldStateBatchContextManager:
+        """
+        Collect the state changes made inside the context into a single notification.
+
+        Use this when writing several degrees of freedom that belong to one logical
+        change, such as a whole configuration.
+
+        :param publish_changes: Whether the resulting notification publishes the
+            changes.
+        """
+        return WorldStateBatchContextManager(
             world=self, publish_changes=publish_changes
         )
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import threading
 import uuid
+from contextlib import contextmanager
 from copy import deepcopy, copy
 from dataclasses import dataclass, field
 from functools import wraps, cached_property
@@ -26,6 +27,7 @@ from typing_extensions import (
     Callable,
     Any,
     Iterable,
+    Iterator,
     TYPE_CHECKING,
     get_args,
 )
@@ -260,12 +262,16 @@ class WorldModelUpdateContextManager:
                 self.world.world_is_being_modified = False
                 model_manager._current_modifications_will_be_published = None
         finally:
-            # keep outside the if block, as it needs to be released as many times as it was acquired
-            self.world._world_lock.release()
-            # Flush deferred publications only after the lock is fully released, so a synchronous
-            # publish does not block the receiving executor that needs the lock to apply/acknowledge.
-            if run_pending_publications:
-                self.world._model_manager.flush_pending_publications()
+            # Claim the turn of this modification in the stream of publications before the
+            # world lock is released, so that a thread waiting for that lock cannot publish
+            # what it then reads before this modification has published its own changes.
+            with self.world._model_manager.publishing_in_order():
+                # keep outside the if block, as it needs to be released as many times as it was acquired
+                self.world._world_lock.release()
+                # Flush deferred publications only after the lock is fully released, so that
+                # the modification they describe is complete and readable by whoever reacts to them.
+                if run_pending_publications:
+                    self.world._model_manager.flush_pending_publications()
 
 
 def atomic_world_modification(func=None, modification: Type[WorldModification] = None):
@@ -388,10 +394,31 @@ class WorldModelManager:
     """
     Network publications deferred while the world is being modified.
 
-    They are flushed (executed) only after ``_world_lock`` has been released, so that a
-    synchronous publish waiting for acknowledgments never blocks the receiving executor
-    that must acquire the lock to apply/ack.
+    They are flushed (executed) only after ``_world_lock`` has been released, so that
+    what they describe is complete by the time it leaves this process.
     """
+
+    _publication_order_lock: threading.RLock = field(
+        init=False, default_factory=threading.RLock, repr=False
+    )
+    """
+    Serializes the publications leaving this world.
+
+    Reentrant, because flushing the deferred publications holds it while each of them
+    publishes.
+    """
+
+    @contextmanager
+    def publishing_in_order(self) -> Iterator[None]:
+        """
+        Claim the turn of the caller in the stream of publications of this world.
+
+        A modification claims its turn before it releases ``_world_lock``, so a thread
+        that was waiting for that lock cannot announce the state it then reads before
+        the model change it belongs to has been published.
+        """
+        with self._publication_order_lock:
+            yield
 
     def update_model_version_and_notify_callbacks(self, **kwargs) -> None:
         """
@@ -408,9 +435,8 @@ class WorldModelManager:
         Execute and clear all publications that were deferred during a world
         modification.
 
-        Must be called *after* ``_world_lock`` is released so that publishing (and, in
-        synchronous mode, waiting for acknowledgments) does not happen while holding the
-        lock.
+        Must be called *after* ``_world_lock`` is released, so that the modification the
+        publications describe is complete.
         """
         pending = self.pending_publications
         self.pending_publications = []

--- a/test/semantic_digital_twin_test/conftest.py
+++ b/test/semantic_digital_twin_test/conftest.py
@@ -1,12 +1,14 @@
 import os
 
 import pytest
+import sqlalchemy
 
 from krrood.class_diagrams.class_diagram import ClassDiagram
 from krrood.symbol_graph.symbol_graph import SymbolGraph, Symbol
 from krrood.ontomatic.property_descriptor.attribute_introspector import (
     DescriptorAwareIntrospector,
 )
+from krrood.ormatic.utils import create_engine, drop_database
 from krrood.utils import recursive_subclasses
 from semantic_digital_twin.adapters.urdf import URDFParser
 
@@ -34,6 +36,27 @@ def pytest_configure(config):
         introspector=DescriptorAwareIntrospector(),
     )
     SymbolGraph(_class_diagram=class_diagram)
+
+
+@pytest.fixture
+def in_memory_session_maker():
+    """
+    A session maker for an empty database that several sessions can share.
+
+    ``uri=true`` belongs into the query string: the pysqlite dialect reads it from there,
+    and without it sqlite opens a file named ``file::memory:`` in the working directory
+    instead of a shared in-memory database, which then outlives the test.
+    """
+    from semantic_digital_twin.orm.ormatic_interface import Base
+
+    engine = create_engine(
+        "sqlite+pysqlite:///file::memory:?cache=shared&uri=true",
+        connect_args={"check_same_thread": False},
+    )
+    drop_database(engine)
+    Base.metadata.create_all(engine)
+    yield sqlalchemy.orm.sessionmaker(bind=engine)
+    engine.dispose()
 
 
 @pytest.fixture

--- a/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
@@ -9,25 +9,24 @@ import uuid
 from dataclasses import dataclass, field
 from multiprocessing.synchronize import RLock
 from time import sleep
-from typing import Optional, Set, Tuple, List
+from typing import Callable, Optional, Set, Tuple, List
 from uuid import uuid4
 
 import numpy as np
 import pytest
 import rclpy
-import sqlalchemy
 import std_msgs.msg
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from krrood.adapters.json_serializer import JSONAttributeDiff, to_json, from_json
-from krrood.ormatic.utils import drop_database, create_engine
 from semantic_digital_twin.adapters.ros.messages import (
     MetaData,
     WorldStateUpdate,
     LoadModel,
-    Acknowledgment,
+    StateWatermark,
     WorldUpdate,
 )
 from semantic_digital_twin.adapters.ros.world_synchronizer import (
@@ -44,8 +43,10 @@ from semantic_digital_twin.exceptions import (
     ApplyMissedMessagesWhileWorldIsBeingModifiedError,
     StateUpdateContainsUnknownDegreesOfFreedomError,
     BrokenWorldModificationHistoryError,
+    WorldHasMultipleSynchronizersError,
+    WorldHasNoSynchronizerError,
 )
-from semantic_digital_twin.orm.ormatic_interface import Base, WorldMappingDAO
+from semantic_digital_twin.orm.ormatic_interface import WorldMappingDAO
 from semantic_digital_twin.robots.pr2 import PR2
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Handle,
@@ -83,10 +84,9 @@ from semantic_digital_twin.adapters.ros.messages import (
     WorldStateUpdate,
     ModificationBlock,
     LoadModel,
-    Acknowledgment,
     WorldUpdate,
 )
-from semantic_digital_twin.orm.ormatic_interface import Base, WorldMappingDAO
+from semantic_digital_twin.orm.ormatic_interface import WorldMappingDAO
 
 
 def create_dummy_world(w: Optional[World] = None) -> World:
@@ -266,16 +266,9 @@ def test_state_synchronization_world_model_change_after_init(rclpy_node):
     synchronizer_2.close()
 
 
-def test_model_reload(rclpy_node):
-    engine = create_engine(
-        "sqlite+pysqlite:///file::memory:?cache=shared",
-        connect_args={"check_same_thread": False, "uri": True},
-    )
-    drop_database(engine)
-    Base.metadata.create_all(engine)
-    session_maker = sqlalchemy.orm.sessionmaker(bind=engine)
-    session1 = session_maker()
-    session2 = session_maker()
+def test_model_reload(rclpy_node, in_memory_session_maker):
+    session1 = in_memory_session_maker()
+    session2 = in_memory_session_maker()
 
     w1 = create_dummy_world()
     w2 = World()
@@ -655,579 +648,6 @@ def test_synchronize_6dof(rclpy_node):
 
     ws1.close()
     ws2.close()
-
-
-def test_synchronous_state_synchronization(rclpy_node):
-    """
-    When synchronous=True the notify_state_change call blocks until all subscribers have
-    acknowledged receipt, so the remote world is already up-to-date when the call
-    returns.
-    """
-    import rclpy
-    from rclpy.executors import SingleThreadedExecutor
-
-    receiver_node = rclpy.create_node("test_sync_state_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="sync-state-receiver"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
-
-        synchronizer_1 = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-        )
-        synchronizer_2 = WorldSynchronizer(
-            node=receiver_node,
-            _world=w2,
-        )
-
-        # Allow time for publishers/subscribers to discover each other
-        time.sleep(0.2)
-
-        w1.state._data[0, 0] = 1.0
-        w1.notify_state_change()
-
-        # With synchronous publishing the state must already be propagated
-        # by the time notify_state_change returns.
-        assert w1.state._data[0, 0] == w2.state._data[0, 0]
-
-        synchronizer_1.close()
-        synchronizer_2.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
-
-
-def test_synchronous_model_synchronization(rclpy_node):
-    """
-    When synchronous=True the modify_world call blocks until all subscribers acknowledge
-    receipt, so the remote world is already up-to-date when the call returns.
-    """
-    import rclpy
-    from rclpy.executors import SingleThreadedExecutor
-
-    receiver_node = rclpy.create_node("test_sync_model_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="sync-model-receiver"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = World(name="w1")
-        w2 = World(name="w2")
-
-        synchronizer_1 = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-        )
-        synchronizer_2 = WorldSynchronizer(
-            node=receiver_node,
-            _world=w2,
-        )
-
-        # Allow time for publishers/subscribers to discover each other
-        time.sleep(0.5)
-
-        with w1.modify_world():
-            new_body = Body(name=PrefixedName("b3"))
-            b3_id = new_body.id
-            w1.add_kinematic_structure_entity(new_body)
-
-        # With synchronous publishing the model must already be propagated
-        # by the time modify_world returns.
-        assert len(w2.kinematic_structure_entities) == 1
-        assert w2.get_kinematic_structure_entity_by_id(b3_id)
-
-        synchronizer_1.close()
-        synchronizer_2.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
-
-
-def test_synchronous_publish_blocks_until_receiver_acknowledges(rclpy_node):
-    """
-    Test whether synchronous publication genuinely blocks the caller until the remote
-    subscriber acknowledges, rather than succeeding by coincidence.
-
-    Uses a second ROS node (distinct ``node_name``) so the acknowledgment protocol can
-    distinguish sender from receiver.  The receiver's acknowledgment publisher is
-    intercepted so that acknowledgments are captured but not sent.  We then verify that
-    the sender thread stays blocked, release the captured acknowledgments, and confirm
-    that the sender unblocks.
-    """
-    import rclpy
-    from rclpy.executors import SingleThreadedExecutor
-
-    receiver_node = rclpy.create_node("test_receiver_node")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="receiver-executor"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
-
-        synchronizer_1 = WorldSynchronizer(node=rclpy_node, _world=w1, synchronous=True)
-        synchronizer_2 = WorldSynchronizer(node=receiver_node, _world=w2)
-
-        # Allow time for publishers/subscribers to discover each other
-        time.sleep(0.2)
-
-        # Intercept the receiver's acknowledgment publisher: capture outgoing
-        # acknowledgments without actually publishing them so the sender never
-        # gets an acknowledgment from the receiver node.
-        real_acknowledgment_publisher = synchronizer_2.acknowledge_publisher
-        captured_acknowledgments = []
-
-        class _AcknowledgmentInterceptor:
-            """
-            Drop-in replacement that records but does not send acknowledgments.
-            """
-
-            def publish(self, msg):
-                captured_acknowledgments.append(msg)
-
-        synchronizer_2.acknowledge_publisher = _AcknowledgmentInterceptor()
-
-        # Trigger a synchronous state change in a background thread. It
-        # should block because the receiver's acknowledgment will never arrive.
-        w1.state._data[0, 0] = 1.0
-        publish_done = threading.Event()
-
-        def do_publish():
-            w1.notify_state_change()
-            publish_done.set()
-
-        thread = threading.Thread(target=do_publish, daemon=True)
-        thread.start()
-
-        # Give the executor enough time to deliver the message and process
-        # the sender's self-acknowledgment.  The sender must still be blocked
-        # because the receiver's acknowledgment was intercepted.
-        time.sleep(0.5)
-        assert (
-            not publish_done.is_set()
-        ), "Synchronous publish must block until the receiver acknowledges"
-
-        # Now release the captured acknowledgments via the real publisher.
-        for msg in captured_acknowledgments:
-            real_acknowledgment_publisher.publish(msg)
-
-        # The sender should unblock promptly.
-        thread.join(timeout=5)
-        assert (
-            publish_done.is_set()
-        ), "Synchronous publish must unblock after the receiver acknowledges"
-
-        # The state should also be propagated because the receiver's
-        # subscription callback still applied the message (only the
-        # acknowledgment was intercepted, not message processing).
-        assert w1.state._data[0, 0] == w2.state._data[0, 0]
-
-        synchronizer_2.acknowledge_publisher = real_acknowledgment_publisher
-        synchronizer_1.close()
-        synchronizer_2.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
-
-
-@dataclass
-class _SynchronizerWithNoOpSubscriptionHandling(Synchronizer):
-    """
-    Concrete :class:`Synchronizer` that ignores incoming messages, so tests can exercise
-    the base class's discovery/acknowledgment logic without a real message type.
-    """
-
-    def _subscription_callback(self, msg):
-        pass
-
-
-@dataclass
-class _FakeSubscriptionInfo:
-    """
-    Stand-in for the objects ``Node.get_subscriptions_info_by_topic`` returns, exposing
-    only the ``node_name`` attribute :meth:`Synchronizer._snapshot_subscribers` reads.
-    """
-
-    node_name: str
-    """
-    The name of the node the fake subscription belongs to.
-    """
-
-
-@dataclass
-class _DiscoveryLaggingNode:
-    """
-    Fake ``rclpy`` node whose ``get_subscriptions_info_by_topic`` walks through a
-    caller-supplied sequence of subscriber counts, simulating ROS graph discovery
-    gradually catching up with a remote subscriber created moments earlier.
-    """
-
-    own_name: str
-    """
-    The name reported by :meth:`get_name`, used to identify this node's own
-    subscriptions.
-    """
-
-    subscriber_counts: List[int]
-    """
-    The sequence of subscriber counts successive calls to
-    :meth:`get_subscriptions_info_by_topic` walk through.
-    """
-
-    _remaining_subscriber_counts: List[int] = field(init=False, repr=False)
-    """
-    Unconsumed prefix of :attr:`subscriber_counts`.
-    """
-
-    _last_subscriber_count: int = field(init=False, default=0, repr=False)
-    """
-    The most recently consumed subscriber count, repeated once :attr:`subscriber_counts`
-    is exhausted.
-    """
-
-    def __post_init__(self):
-        self._remaining_subscriber_counts = list(self.subscriber_counts)
-
-    def create_subscription(self, *args, **kwargs):
-        return None
-
-    def create_publisher(self, *args, **kwargs):
-        return None
-
-    def get_name(self) -> str:
-        return self.own_name
-
-    def get_subscriptions_info_by_topic(self, topic_name: str):
-        if self._remaining_subscriber_counts:
-            self._last_subscriber_count = self._remaining_subscriber_counts.pop(0)
-        return [
-            _FakeSubscriptionInfo(node_name=f"remote_subscriber_{i}")
-            for i in range(self._last_subscriber_count)
-        ]
-
-
-def test_snapshot_subscribers_waits_for_discovery_to_stabilize():
-    """
-    Regression test: a subscriber count that is still climbing (discovery catching up
-    with a just-created remote subscriber) must not be treated as final on the first
-    read, since an under-count would silently break the synchronous-publish contract in
-    :meth:`Synchronizer.publish`.
-    """
-    node = _DiscoveryLaggingNode(own_name="sender_node", subscriber_counts=[0, 1, 1])
-    synchronizer = _SynchronizerWithNoOpSubscriptionHandling(
-        node=node, topic_name="/test_topic"
-    )
-    synchronizer._subscriber_discovery_grace_period = timedelta(seconds=1.0)
-    synchronizer._subscriber_discovery_poll_interval = timedelta(seconds=0.01)
-
-    count = synchronizer._snapshot_subscribers_after_discovery_settles()
-
-    assert count == 1
-
-
-def test_snapshot_subscribers_falls_back_to_highest_sample_not_last_sample():
-    """
-    If the subscriber count fluctuates without ever settling, the highest sample seen
-    must be used, not merely the most recently read one: under-counting silently breaks
-    the synchronous-publish contract (the bug this method fixes), so a transient dip in
-    the final sample taken before the grace period elapses must not discard a higher
-    count that was already observed.
-    """
-    node = _DiscoveryLaggingNode(
-        own_name="sender_node", subscriber_counts=[0, 3, 1, 3, 1, 3, 1, 3, 1]
-    )
-    synchronizer = _SynchronizerWithNoOpSubscriptionHandling(
-        node=node, topic_name="/test_topic"
-    )
-    synchronizer._subscriber_discovery_grace_period = timedelta(seconds=0.05)
-    synchronizer._subscriber_discovery_poll_interval = timedelta(seconds=0.01)
-
-    count = synchronizer._snapshot_subscribers_after_discovery_settles()
-
-    assert count == 3
-
-
-def test_snapshot_subscribers_gives_up_after_grace_period_elapses():
-    """
-    If the subscriber count never stabilizes within the grace period, the settled
-    snapshot must return promptly instead of blocking indefinitely.
-    """
-    node = _DiscoveryLaggingNode(
-        own_name="sender_node", subscriber_counts=list(range(1000))
-    )
-    synchronizer = _SynchronizerWithNoOpSubscriptionHandling(
-        node=node, topic_name="/test_topic"
-    )
-    synchronizer._subscriber_discovery_grace_period = timedelta(seconds=0.05)
-    synchronizer._subscriber_discovery_poll_interval = timedelta(seconds=0.01)
-
-    start = time.monotonic()
-    count = synchronizer._snapshot_subscribers_after_discovery_settles()
-    elapsed = time.monotonic() - start
-
-    assert elapsed < 0.5
-    assert count >= 0
-
-
-def test_synchronous_publish_settles_promptly_with_multiple_real_subscribers(
-    rclpy_node,
-):
-    """
-    Regression test against real ROS discovery (no fakes): with several concurrently
-    created real subscribers and no graph churn, the highest-observed-count fallback in
-    :meth:`Synchronizer._snapshot_subscribers_after_discovery_settles` must settle on
-    the true, stable subscriber count, so synchronous publication returns promptly
-    instead of paying the ``wait_for_synchronization_timeout`` wait.
-    """
-    w1 = create_dummy_world()
-    synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=w1,
-        synchronous=True,
-        wait_for_synchronization_timeout=2.0,
-    )
-
-    receiver_nodes = []
-    receiver_executors = []
-    receiver_threads = []
-    receiver_worlds = []
-    receiver_synchronizers = []
-    try:
-        for index in range(3):
-            node = rclpy.create_node(f"real_discovery_receiver_{index}")
-            executor = SingleThreadedExecutor()
-            executor.add_node(node)
-            thread = threading.Thread(target=executor.spin, daemon=True)
-            thread.start()
-            world = create_dummy_world()
-            synchronizer = WorldSynchronizer(node=node, _world=world)
-            receiver_nodes.append(node)
-            receiver_executors.append(executor)
-            receiver_threads.append(thread)
-            receiver_worlds.append(world)
-            receiver_synchronizers.append(synchronizer)
-
-        time.sleep(0.3)
-
-        w1.state._data[0, 0] = 1.0
-        start = time.monotonic()
-        w1.notify_state_change()
-        elapsed = time.monotonic() - start
-
-        assert elapsed < synchronizer_1.wait_for_synchronization_timeout, (
-            "With a stable, accurately discovered subscriber count, synchronous "
-            "publish must not pay the timeout wait"
-        )
-        for world in receiver_worlds:
-            assert world.state._data[0, 0] == 1.0
-
-        synchronizer_1.close()
-    finally:
-        for synchronizer in receiver_synchronizers:
-            synchronizer.close()
-        for executor in receiver_executors:
-            executor.shutdown()
-        for thread in receiver_threads:
-            thread.join(timeout=2.0)
-        for node in receiver_nodes:
-            node.destroy_node()
-
-
-def test_overcounted_expected_acknowledgments_times_out_but_recovers_on_next_publish(
-    rclpy_node,
-):
-    """
-    Addresses the PR #448 review concern: falling back to the *highest* observed
-    subscriber count could make ``_expected_acknowledgment_count`` exceed the number of
-    subscribers that will actually acknowledge, if the highest sample was a transient
-    discovery artifact rather than the true, settled count.
-
-    An over-count must never turn into a real deadlock. It can only ever cost the
-    existing, already-logged ``wait_for_synchronization_timeout`` wait on the single
-    affected publish - the call must still return, the message must still have been
-    delivered to the real subscriber, and the very next publish must recompute the count
-    fresh and return promptly instead of staying wedged.
-    """
-    receiver_node = rclpy.create_node("test_overcount_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="overcount-receiver"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
-
-        synchronizer_1 = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-            wait_for_synchronization_timeout=1.0,
-        )
-        synchronizer_2 = WorldSynchronizer(node=receiver_node, _world=w2)
-
-        time.sleep(0.2)
-
-        real_snapshot = synchronizer_1._snapshot_subscribers_after_discovery_settles
-
-        def snapshot_overcounted_by_one():
-            # Simulate a highest-sample fallback that overshoots the true, live
-            # subscriber count by one - exactly the scenario the reviewer raised.
-            return real_snapshot() + 1
-
-        synchronizer_1._snapshot_subscribers_after_discovery_settles = (
-            snapshot_overcounted_by_one
-        )
-
-        w1.state._data[0, 0] = 1.0
-        publish_done = threading.Event()
-
-        def do_publish():
-            w1.notify_state_change()
-            publish_done.set()
-
-        start = time.monotonic()
-        thread = threading.Thread(target=do_publish, daemon=True)
-        thread.start()
-        thread.join(timeout=synchronizer_1.wait_for_synchronization_timeout + 3.0)
-        elapsed = time.monotonic() - start
-
-        assert publish_done.is_set(), (
-            "An over-counted expected-acknowledgment-count must time out, not block "
-            "forever - this is the reviewer's deadlock concern"
-        )
-        assert elapsed >= synchronizer_1.wait_for_synchronization_timeout
-        assert elapsed < synchronizer_1.wait_for_synchronization_timeout + 3.0
-
-        # The real subscriber still received and applied the message - only the
-        # (phantom) extra acknowledgment was missing.
-        assert w1.state._data[0, 0] == w2.state._data[0, 0]
-
-        # Restore accurate counting and confirm the synchronizer self-heals: the very
-        # next publish must not pay the timeout again.
-        synchronizer_1._snapshot_subscribers_after_discovery_settles = real_snapshot
-
-        w1.state._data[0, 1] = 2.0
-        start = time.monotonic()
-        w1.notify_state_change()
-        elapsed = time.monotonic() - start
-
-        assert elapsed < 1.5, (
-            "A transient over-count must not permanently wedge the synchronizer - the "
-            "next publish recomputes the count fresh and should return promptly"
-        )
-        assert w1.state._data[0, 1] == w2.state._data[0, 1]
-
-        synchronizer_1.close()
-        synchronizer_2.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
-
-
-def test_subscriber_disconnecting_during_discovery_grace_period_does_not_hang_forever(
-    rclpy_node,
-):
-    """
-    Exercises real ROS graph churn (no fakes): a subscriber that appears and then
-    disconnects again while
-    :meth:`Synchronizer._snapshot_subscribers_after_discovery_settles` is still polling
-    can make the settled count reflect a subscriber that is no longer actually there by
-    the time :meth:`Synchronizer.publish` sends the message.
-
-    Whether this particular run manages to trigger an over-count depends on ROS
-    discovery timing and is intentionally not asserted directly; what must always hold
-    is that publish is bounded by ``wait_for_synchronization_timeout``, never blocks
-    forever, and recovers on the next publish once the graph has settled.
-    """
-    w1 = create_dummy_world()
-    synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=w1,
-        synchronous=True,
-        wait_for_synchronization_timeout=1.0,
-    )
-    synchronizer_1._subscriber_discovery_grace_period = timedelta(seconds=0.3)
-    synchronizer_1._subscriber_discovery_poll_interval = timedelta(seconds=0.02)
-
-    flapping_node = rclpy.create_node("flapping_subscriber")
-    flapping_subscription = flapping_node.create_subscription(
-        std_msgs.msg.String,
-        topic=synchronizer_1.topic_name,
-        callback=lambda msg: None,
-        qos_profile=10,
-    )
-
-    def disconnect_shortly_after_appearing():
-        time.sleep(0.05)
-        flapping_node.destroy_subscription(flapping_subscription)
-
-    flap_thread = threading.Thread(
-        target=disconnect_shortly_after_appearing, daemon=True
-    )
-    flap_thread.start()
-
-    try:
-        w1.state._data[0, 0] = 1.0
-        publish_done = threading.Event()
-
-        def do_publish():
-            w1.notify_state_change()
-            publish_done.set()
-
-        start = time.monotonic()
-        thread = threading.Thread(target=do_publish, daemon=True)
-        thread.start()
-        thread.join(timeout=synchronizer_1.wait_for_synchronization_timeout + 3.0)
-        elapsed = time.monotonic() - start
-
-        assert (
-            publish_done.is_set()
-        ), "Real ROS discovery churn must not hang publish() forever"
-        assert elapsed < synchronizer_1.wait_for_synchronization_timeout + 3.0
-
-        # Recovery: once the flapping subscriber is gone and the graph has settled, the
-        # next synchronous publish (with zero live subscribers now) must return quickly
-        # rather than paying another timeout.
-        flap_thread.join(timeout=2.0)
-        time.sleep(0.5)
-
-        w1.state._data[0, 1] = 2.0
-        start = time.monotonic()
-        w1.notify_state_change()
-        elapsed = time.monotonic() - start
-        assert elapsed < 1.5
-
-        synchronizer_1.close()
-    finally:
-        flap_thread.join(timeout=2.0)
-        flapping_node.destroy_node()
 
 
 def test_compute_state_changes_no_changes(rclpy_node):
@@ -1618,6 +1038,7 @@ def test_world_state_update_serialization_round_trip():
         meta_data=meta,
         ids=[uuid.uuid4(), uuid.uuid4()],
         states=[1.5, 2.5],
+        sequence_number=3,
     )
 
     serialized = to_json(original)
@@ -1628,7 +1049,7 @@ def test_world_state_update_serialization_round_trip():
     assert restored.meta_data.process_id == original.meta_data.process_id
     assert restored.ids == original.ids
     assert restored.states == original.states
-    assert restored.publication_event_id == original.publication_event_id
+    assert restored.sequence_number == 3
 
 
 def test_load_model_serialization_round_trip():
@@ -1636,7 +1057,7 @@ def test_load_model_serialization_round_trip():
     Verify that LoadModel survives a to_json/from_json round trip.
     """
     meta = MetaData(node_name="loader", process_id=99)
-    original = LoadModel(meta_data=meta, primary_key=7)
+    original = LoadModel(meta_data=meta, primary_key=7, sequence_number=5)
 
     serialized = to_json(original)
     restored = from_json(serialized)
@@ -1644,72 +1065,7 @@ def test_load_model_serialization_round_trip():
     assert isinstance(restored, LoadModel)
     assert restored.primary_key == 7
     assert restored.meta_data.node_name == "loader"
-    assert restored.publication_event_id == original.publication_event_id
-
-
-def test_acknowledgment_serialization_round_trip():
-    """
-    Verify that Acknowledgment survives a to_json/from_json round trip.
-    """
-    event_id = uuid.uuid4()
-    meta = MetaData(node_name="acknowledgment_node", process_id=1)
-    original = Acknowledgment(publication_event_id=event_id, node_meta_data=meta)
-
-    serialized = to_json(original)
-    restored = from_json(serialized)
-
-    assert isinstance(restored, Acknowledgment)
-    assert restored.publication_event_id == event_id
-    assert restored.node_meta_data.node_name == "acknowledgment_node"
-    assert restored.node_meta_data.process_id == 1
-
-
-def test_acknowledgement_with_missed_messages(rclpy_node):
-    import rclpy
-    from rclpy.executors import SingleThreadedExecutor
-
-    receiver_node = rclpy.create_node("test_sync_state_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="sync-state-receiver"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
-
-        synchronizer_1 = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-        )
-        synchronizer_2 = WorldSynchronizer(
-            node=receiver_node,
-            _world=w2,
-        )
-        synchronizer_2.pause()
-
-        # Allow time for publishers/subscribers to discover each other
-        time.sleep(0.5)
-
-        w1.state._data[0, 0] = 1.0
-        w1.notify_state_change()
-
-        # the notify should time out giving us the old state
-        assert w2.state._data[0, 0] == 0
-        synchronizer_2.apply_missed_messages()
-        # after apply message we should have the correct state
-        assert w1.state._data[0, 0] == w2.state._data[0, 0]
-
-        synchronizer_1.close()
-        synchronizer_2.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
+    assert restored.sequence_number == 5
 
 
 def test_simultaneous_state_and_model_updates(rclpy_node):
@@ -1787,9 +1143,10 @@ def test_two_parallel_modify_world_on_same_instance_are_serialized():
     assert sum(n.startswith("b_") for n in names) == 5
 
 
-def test_modify_world_then_sync_state_no_deadlock(rclpy_node):
+def test_state_changed_inside_a_model_change_arrives_with_the_model(rclpy_node):
     """
-    Synchronous state publish inside/after model change must not deadlock.
+    A state change made inside a modification reaches the other world together with the
+    model it belongs to.
     """
     receiver_node = rclpy.create_node("lock_order_receiver")
     receiver_executor = SingleThreadedExecutor()
@@ -1802,15 +1159,14 @@ def test_modify_world_then_sync_state_no_deadlock(rclpy_node):
         w1 = World(name="w1")
         w2 = World(name="w2")
 
-        ws1 = WorldSynchronizer(node=rclpy_node, _world=w1, synchronous=True)
+        ws1 = WorldSynchronizer(node=rclpy_node, _world=w1)
         ws2 = WorldSynchronizer(node=receiver_node, _world=w2)
 
         time.sleep(0.2)
 
         with w1.modify_world():
             w1.add_body(Body(name=PrefixedName("b")))
-            # trigger a synchronous publish while still reasonably close
-            # to the model change to stress ordering
+            # change the state while still inside the modification to stress ordering
             if len(w1.state) > 0:
                 w1.state._data[0, 0] = 0.5
                 w1.notify_state_change()
@@ -1827,9 +1183,9 @@ def test_modify_world_then_sync_state_no_deadlock(rclpy_node):
         receiver_node.destroy_node()
 
 
-def test_sync_model_vs_async_state_no_deadlock(rclpy_node):
+def test_model_change_arrives_while_state_updates_are_published(rclpy_node):
     """
-    A synchronous model publish must not deadlock with an async state publish.
+    A model change reaches the other world even while state updates are streaming.
     """
     receiver_node = rclpy.create_node("recv_node")
     from rclpy.executors import SingleThreadedExecutor
@@ -1844,7 +1200,7 @@ def test_sync_model_vs_async_state_no_deadlock(rclpy_node):
         w1 = World(name="w1")
         w2 = World(name="w2")
 
-        ws1 = WorldSynchronizer(node=rclpy_node, _world=w1, synchronous=True)
+        ws1 = WorldSynchronizer(node=rclpy_node, _world=w1)
         ws2 = WorldSynchronizer(node=receiver_node, _world=w2)
 
         # Seed a root
@@ -2178,174 +1534,6 @@ def test_world_synchronizer_missed_messages_applied_in_order(rclpy_node):
     ws2.close()
 
 
-def test_synchronize_model_false_suppresses_outgoing_model(rclpy_node):
-    """
-    When synchronize_model=False, local model changes are not published to peers.
-    """
-    world_1 = World(name="sync_model_false_w1")
-    world_2 = World(name="sync_model_false_w2")
-
-    world_synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_1,
-        synchronize_model=False,
-    )
-    world_synchronizer_2 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_2,
-    )
-
-    time.sleep(0.2)
-
-    with world_1.modify_world():
-        new_body = Body(name=PrefixedName("suppressed_body"))
-        world_1.add_kinematic_structure_entity(new_body)
-
-    time.sleep(0.3)
-
-    assert len(world_1.kinematic_structure_entities) == 1
-    assert (
-        len(world_2.kinematic_structure_entities) == 0
-    ), "world_2 must not receive model changes when synchronize_model=False on sender"
-
-    world_synchronizer_1.close()
-    world_synchronizer_2.close()
-
-
-def test_synchronize_model_false_still_receives_incoming_model(rclpy_node):
-    """
-    Even when synchronize_model=False, the synchronizer still applies incoming model
-    messages.
-    """
-    world_1 = World(name="recv_model_w1")
-    world_2 = World(name="recv_model_w2")
-
-    world_synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_1,
-    )
-    world_synchronizer_2 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_2,
-        synchronize_model=False,
-    )
-
-    time.sleep(0.2)
-
-    with world_1.modify_world():
-        new_body = Body(name=PrefixedName("incoming_body"))
-        body_identifier = new_body.id
-        world_1.add_kinematic_structure_entity(new_body)
-
-    time.sleep(0.3)
-
-    assert (
-        world_2.get_kinematic_structure_entity_by_id(body_identifier) is not None
-    ), "world_2 must still receive and apply model changes even when synchronize_model=False"
-
-    world_synchronizer_1.close()
-    world_synchronizer_2.close()
-
-
-def test_synchronize_state_false_suppresses_outgoing_state(rclpy_node):
-    """
-    When synchronize_state=False, local state changes are not published to peers.
-    """
-    world_1 = create_dummy_world()
-    world_2 = create_dummy_world()
-
-    world_synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_1,
-        synchronize_state=False,
-    )
-    world_synchronizer_2 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_2,
-    )
-
-    time.sleep(0.2)
-
-    world_1.state._data[0, 0] = 7.77
-    world_1.notify_state_change()
-
-    time.sleep(0.3)
-
-    assert world_2.state._data[0, 0] != pytest.approx(
-        7.77, abs=1e-6
-    ), "world_2 must not receive state changes when synchronize_state=False on sender"
-
-    world_synchronizer_1.close()
-    world_synchronizer_2.close()
-
-
-def test_synchronize_state_false_still_receives_incoming_state(rclpy_node):
-    """
-    Even when synchronize_state=False, the synchronizer still applies incoming state
-    messages.
-    """
-    world_1 = create_dummy_world()
-    world_2 = create_dummy_world()
-
-    world_synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_1,
-    )
-    world_synchronizer_2 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_2,
-        synchronize_state=False,
-    )
-
-    time.sleep(0.2)
-
-    world_1.state._data[0, 0] = 4.44
-    world_1.notify_state_change()
-
-    time.sleep(0.3)
-
-    assert world_2.state._data[0, 0] == pytest.approx(
-        4.44, abs=1e-9
-    ), "world_2 must still receive and apply state changes even when synchronize_state=False"
-
-    world_synchronizer_1.close()
-    world_synchronizer_2.close()
-
-
-def test_synchronize_both_false_suppresses_all_outgoing(rclpy_node):
-    """
-    When both flags are False, no outgoing messages are published.
-    """
-    world_1 = World(name="both_false_w1")
-    world_2 = World(name="both_false_w2")
-
-    world_synchronizer_1 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_1,
-        synchronize_model=False,
-        synchronize_state=False,
-    )
-    world_synchronizer_2 = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world_2,
-    )
-
-    time.sleep(0.2)
-
-    with world_1.modify_world():
-        new_body = Body(name=PrefixedName("silent_body"))
-        world_1.add_kinematic_structure_entity(new_body)
-
-    time.sleep(0.3)
-
-    assert (
-        len(world_2.kinematic_structure_entities) == 0
-    ), "world_2 must not receive anything when both synchronize flags are False"
-
-    world_synchronizer_1.close()
-    world_synchronizer_2.close()
-
-
 def test_stop_is_idempotent(rclpy_node):
     """
     Calling stop() twice must not raise ValueError.
@@ -2408,28 +1596,6 @@ def test_stop_deregisters_from_state_change_callbacks(rclpy_node):
     world_synchronizer.stop()
 
     assert world_synchronizer not in world.state.state_change_callbacks
-
-    world_synchronizer.close()
-
-
-def test_stop_with_synchronize_model_false_does_not_touch_model_callbacks(rclpy_node):
-    """
-    Stop() must not try to remove from model_change_callbacks when
-    synchronize_model=False.
-    """
-    world = World(name="stop_no_model_reg_world")
-    world_synchronizer = WorldSynchronizer(
-        node=rclpy_node,
-        _world=world,
-        synchronize_model=False,
-    )
-
-    assert (
-        world_synchronizer not in world.get_world_model_manager().model_change_callbacks
-    )
-
-    world_synchronizer.stop()
-    world_synchronizer.stop()
 
     world_synchronizer.close()
 
@@ -2520,30 +1686,6 @@ def test_apply_state_with_unknown_identifier_raises(rclpy_node):
         world_synchronizer._apply_state(all_unknown_state_update)
 
     world_synchronizer.close()
-
-
-def test_close_destroys_acknowledge_publisher_and_subscriber(rclpy_node):
-    """
-    After close(), both acknowledge_publisher and acknowledge_subscriber must be None.
-
-    Failure here means Synchronizer.close() is leaking acknowledge ROS resources.
-    """
-    world = World(name="ack_leak_world")
-    world_synchronizer = WorldSynchronizer(
-        node=rclpy_node, _world=world, synchronous=True
-    )
-
-    assert world_synchronizer.acknowledge_publisher is not None
-    assert world_synchronizer.acknowledge_subscriber is not None
-
-    world_synchronizer.close()
-
-    assert (
-        world_synchronizer.acknowledge_publisher is None
-    ), "acknowledge_publisher must be destroyed by close()"
-    assert (
-        world_synchronizer.acknowledge_subscriber is None
-    ), "acknowledge_subscriber must be destroyed by close()"
 
 
 def test_apply_missed_messages_inside_modify_world_raises(rclpy_node):
@@ -2646,12 +1788,8 @@ def test_apply_state_does_not_deadlock_when_callback_acquires_world_lock(rclpy_n
 
 def test_model_publish_does_not_hold_world_lock(rclpy_node):
     """
-    A model update must be published *after* ``_world_lock`` is released.
-
-    Currently ``on_model_change`` runs inside
-    ``WorldModelUpdateContextManager.__exit__`` while the lock is still held, which lets
-    an inbound apply on the receiving side block the executor and (in synchronous mode)
-    deadlock the ack round-trip.
+    A model update must be published *after* ``_world_lock`` is released, so that the
+    modification it describes is complete by the time it leaves this process.
     """
     w = World()
     ms = WorldSynchronizer(node=rclpy_node, _world=w)
@@ -2707,179 +1845,68 @@ def test_state_publish_does_not_hold_world_lock(rclpy_node):
     ), "State update was published while _world_lock was held."
 
 
-def test_bidirectional_synchronous_publish_does_not_stall(rclpy_node):
+def test_state_change_during_a_modification_is_published_after_its_model_change(
+    rclpy_node,
+):
     """
-    Two processes that synchronously publish at the same time must not stall.
-
-    With each synchronizer holding its own ``_world_lock`` while waiting for the peer's
-    acknowledgment, and the peer's single-threaded executor blocked trying to acquire
-    that same lock to apply the inbound message, both publishers stall until the ack
-    timeout.
+    A thread that waits for the world lock while a modification is running describes the
+    world that modification produced, so whatever it announces afterwards must leave
+    this process behind the model change of that modification.
     """
-    receiver_node = rclpy.create_node("bidir_sync_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="bidir-sync-receiver"
+    world = create_dummy_world()
+    synchronizer = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/publication_order_{uuid4().hex}"
     )
-    receiver_thread.start()
-    time.sleep(0.1)
+
+    published_updates: List[WorldUpdate] = []
+    original_publish = synchronizer.publish
+
+    def slowly_publishing_model_updates(update: WorldUpdate):
+        if update.modification_block is not None:
+            # Widen the window in which the announcing thread could overtake this update.
+            time.sleep(0.2)
+        published_updates.append(update)
+        return original_publish(update)
+
+    synchronizer.publish = slowly_publishing_model_updates
+
+    def announce_state_change():
+        # Waiting for the world lock is what puts this thread behind the modification.
+        with world._world_lock:
+            world.state._data[0, 0] = 1.5
+        world.notify_state_change()
 
     try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
+        with world.modify_world():
+            child_body = Body(name=PrefixedName("publication_order_child"))
+            world.add_body(child_body)
+            world.add_connection(
+                Connection6DoF.create_with_dofs(
+                    parent=world.root, child=child_body, world=world
+                )
+            )
+            announcing_thread = threading.Thread(target=announce_state_change)
+            announcing_thread.start()
+            time.sleep(0.1)
 
-        ms1 = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-            wait_for_synchronization_timeout=2.0,
-        )
-        ms2 = WorldSynchronizer(
-            node=receiver_node,
-            _world=w2,
-            synchronous=True,
-            wait_for_synchronization_timeout=2.0,
-        )
-        time.sleep(0.3)  # allow pub/sub discovery
+        announcing_thread.join(timeout=5.0)
+        assert not announcing_thread.is_alive()
 
-        done_1 = threading.Event()
-        done_2 = threading.Event()
-
-        def worker(world, suffix, done_event):
-            with world.modify_world():
-                Handle.create_with_new_body_in_world(name=f"h_{suffix}", world=world)
-            done_event.set()
-
-        start = time.time()
-        t1 = threading.Thread(target=worker, args=(w1, "1", done_1), daemon=True)
-        t2 = threading.Thread(target=worker, args=(w2, "2", done_2), daemon=True)
-        t1.start()
-        t2.start()
-        t1.join(timeout=8.0)
-        t2.join(timeout=8.0)
-        elapsed = time.time() - start
-
-        assert (
-            done_1.is_set() and done_2.is_set()
-        ), "Deadlock: bidirectional synchronous modify_world did not complete."
-        assert elapsed < 1.0, (
-            f"Bidirectional synchronous publish stalled ~{elapsed:.2f}s. Publishing while "
-            "_world_lock is held blocks the peer executor from applying/acknowledging."
-        )
-
-        ms1.close()
-        ms2.close()
+        model_update_positions = [
+            update.sequence_number
+            for update in published_updates
+            if update.modification_block is not None
+        ]
+        state_update_positions = [
+            update.sequence_number
+            for update in published_updates
+            if update.state_update is not None
+        ]
+        assert len(model_update_positions) == 1
+        assert state_update_positions
+        assert max(model_update_positions) < min(state_update_positions)
     finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
-
-
-def test_concurrent_publishes_do_not_clobber_ack_state(rclpy_node):
-    """
-    Two concurrent synchronous publishes must each wait for their own acknowledgment.
-
-    Today ``publish`` keeps the pending event id / ack set in single shared instance
-    fields, so a second publish overwrites ``_current_publication_event_id`` while the
-    first is still waiting — the first publisher's ack is then ignored and it stalls
-    until timeout. After the fix (publications are serialized per synchronizer) the
-    second publish cannot start until the first has finished, so the first keeps its own
-    event id and is released by its own ack.
-    """
-    receiver_node = rclpy.create_node("clobber_ack_receiver")
-    receiver_executor = SingleThreadedExecutor()
-    receiver_executor.add_node(receiver_node)
-    receiver_thread = threading.Thread(
-        target=receiver_executor.spin, daemon=True, name="clobber-ack-receiver"
-    )
-    receiver_thread.start()
-    time.sleep(0.1)
-
-    try:
-        w1 = create_dummy_world()
-        w2 = create_dummy_world()
-
-        sender = WorldSynchronizer(
-            node=rclpy_node,
-            _world=w1,
-            synchronous=True,
-            wait_for_synchronization_timeout=1.0,
-        )
-        receiver = WorldSynchronizer(node=receiver_node, _world=w2)
-        time.sleep(0.3)
-
-        # Capture (withhold) acknowledgments so the sender keeps waiting.
-        captured_acks = []
-
-        class _CapturingAckPublisher:
-            def publish(self, msg):
-                captured_acks.append(msg)
-
-        real_ack_publisher = receiver.acknowledge_publisher
-        receiver.acknowledge_publisher = _CapturingAckPublisher()
-
-        dof_id = list(w1.state.keys())[0]
-        update_a = WorldUpdate(
-            meta_data=sender.meta_data,
-            state_update=WorldStateUpdate(
-                meta_data=sender.meta_data, ids=[dof_id], states=[0.11]
-            ),
-        )
-        update_b = WorldUpdate(
-            meta_data=sender.meta_data,
-            state_update=WorldStateUpdate(
-                meta_data=sender.meta_data, ids=[dof_id], states=[0.22]
-            ),
-        )
-
-        a_duration = {}
-
-        def publish_a():
-            started = time.time()
-            sender.publish(update_a)
-            a_duration["value"] = time.time() - started
-
-        thread_a = threading.Thread(target=publish_a, daemon=True)
-        thread_a.start()
-
-        # Wait until the receiver has processed A (so A's publisher is now blocking on its ack).
-        assert wait_for_condition(
-            lambda: len(captured_acks) >= 1, timeout=3.0
-        ), "Receiver never acknowledged the first publish"
-
-        # Start a second concurrent publish. With the bug it runs immediately and clobbers the
-        # shared event id; once fixed it serializes behind A and does not start yet. We do NOT wait
-        # for B to be processed (after the fix it cannot be until A completes).
-        thread_b = threading.Thread(
-            target=lambda: sender.publish(update_b), daemon=True
-        )
-        thread_b.start()
-        time.sleep(0.2)  # give the buggy path time to clobber the shared event id
-
-        # Deliver A's acknowledgment. A must be released by *its own* ack regardless of B.
-        real_ack_publisher.publish(captured_acks[0])
-
-        thread_a.join(timeout=3.0)
-        assert "value" in a_duration, "First publisher never returned (hard deadlock)."
-        assert a_duration["value"] < 0.8, (
-            f"First synchronous publish stalled ~{a_duration['value']:.2f}s: a concurrent "
-            "publish clobbered the shared acknowledgment state."
-        )
-
-        # Best-effort cleanup: once A is done, B proceeds and produces its own ack; deliver any
-        # captured acks until B returns. Cleanup failures must not mask the assertion above.
-        wait_for_condition(lambda: len(captured_acks) >= 2, timeout=3.0)
-        for ack in list(captured_acks):
-            real_ack_publisher.publish(ack)
-        thread_b.join(timeout=3.0)
-
-        sender.close()
-        receiver.close()
-    finally:
-        receiver_executor.shutdown()
-        receiver_thread.join(timeout=2.0)
-        receiver_node.destroy_node()
+        synchronizer.close()
 
 
 def test_inbound_message_deserialization_holds_world_lock(rclpy_node):
@@ -3029,36 +2056,6 @@ def test_apply_missed_messages_is_atomic_against_concurrent_modify(rclpy_node):
         ms2.close()
 
 
-@pytest.mark.xfail(
-    reason="Fails when two synchronizers share one ROS node/process. "
-    "_snapshot_subscribers discounts every subscription on its own node, so a second world "
-    "synchronized in the same process is wrongly uncounted. Our current assumption is that synchronized"
-    "world runs in its own process/node, so peers are remote subscriptions and are counted correctly."
-    "If we decide that we want to support this, remove this xfail mark"
-)
-def test_snapshot_subscribers_counts_in_process_peer(rclpy_node):
-    """
-    Two worlds synchronized within one process (one node) are genuine peers, yet
-    ``_snapshot_subscribers`` subtracts *all* own-node subscriptions and reports zero,
-    so synchronous publication never waits for the in-process peer.
-    """
-    w1 = create_dummy_world()
-    w2 = create_dummy_world()
-
-    ms1 = WorldSynchronizer(node=rclpy_node, _world=w1)
-    ms2 = WorldSynchronizer(node=rclpy_node, _world=w2)
-    time.sleep(0.3)
-
-    try:
-        assert ms1._snapshot_subscribers() >= 1, (
-            "The in-process peer world's subscription was not counted; _snapshot_subscribers "
-            "must not discount distinct peers that merely share the node."
-        )
-    finally:
-        ms1.close()
-        ms2.close()
-
-
 def test_combined_update_model_and_state_applied_atomically(rclpy_node):
     """
     ``apply_message`` applies the model block and the state update under *separate*
@@ -3124,6 +2121,434 @@ def test_combined_update_model_and_state_applied_atomically(rclpy_node):
         "_world_lock was released between applying the model block and the state update; "
         "a combined WorldUpdate must be applied atomically under a single lock."
     )
+
+
+# %% deferring incoming updates without silencing outgoing ones
+
+
+@dataclass(eq=False)
+class DelayedApplyWorldSynchronizer(WorldSynchronizer):
+    """
+    A synchronizer that applies a single message slowly, so another thread can append to
+    the buffer while a drain is still running.
+    """
+
+    apply_delay: float = 0.3
+    """
+    Seconds spent in every ``apply_message`` before the message is really applied.
+    """
+
+    def apply_message(self, message: WorldUpdate):
+        time.sleep(self.apply_delay)
+        super().apply_message(message)
+
+
+def create_connected_worlds(
+    rclpy_node: Node, name: str
+) -> Tuple[World, World, WorldSynchronizer, WorldSynchronizer]:
+    """
+    Build a publishing world and a receiving world that share one prismatic connection.
+
+    The receiver applies inline while it is being set up; the caller switches it to
+    deferring afterwards.
+    """
+    publisher_world = World(name=f"{name}_publisher")
+    receiver_world = World(name=f"{name}_receiver")
+    publisher_synchronizer = WorldSynchronizer(node=rclpy_node, _world=publisher_world)
+    receiver_synchronizer = WorldSynchronizer(node=rclpy_node, _world=receiver_world)
+    time.sleep(0.2)
+
+    with publisher_world.modify_world():
+        parent_body = Body(name=PrefixedName(f"{name}_parent"))
+        child_body = Body(name=PrefixedName(f"{name}_child"))
+        publisher_world.add_body(parent_body)
+        publisher_world.add_body(child_body)
+        publisher_world.add_connection(
+            PrismaticConnection.create_with_dofs(
+                world=publisher_world,
+                parent=parent_body,
+                child=child_body,
+                axis=Vector3.X(),
+            )
+        )
+    assert wait_for_condition(
+        lambda: len(receiver_world.kinematic_structure_entities) == 2
+    ), "the receiver never picked up the initial model"
+    return (
+        publisher_world,
+        receiver_world,
+        publisher_synchronizer,
+        receiver_synchronizer,
+    )
+
+
+def publish_position(world: World, position: float) -> None:
+    """
+    Move the prismatic connection of the given world and announce the change.
+    """
+    connection = world.get_connections_by_type(PrismaticConnection)[0]
+    world.state[connection.dof.id].position = position
+    world.notify_state_change()
+
+
+def test_deferring_incoming_updates_keeps_outgoing_publishing_alive(rclpy_node):
+    """
+    Deferring is one-directional: a synchronizer that queues incoming updates must still
+    publish its own model and state changes, so an owner of the world does not have to
+    reach around the callbacks to publish.
+    """
+    world_1 = World(name="one_directional_deferring_1")
+    world_2 = World(name="one_directional_deferring_2")
+    synchronizer_1 = WorldSynchronizer(
+        node=rclpy_node, _world=world_1, defer_incoming_updates=True
+    )
+    synchronizer_2 = WorldSynchronizer(node=rclpy_node, _world=world_2)
+    time.sleep(0.2)
+
+    try:
+        with world_1.modify_world():
+            parent_body = Body(name=PrefixedName("one_directional_parent"))
+            child_body = Body(name=PrefixedName("one_directional_child"))
+            world_1.add_body(parent_body)
+            world_1.add_body(child_body)
+            world_1.add_connection(
+                PrismaticConnection.create_with_dofs(
+                    world=world_1,
+                    parent=parent_body,
+                    child=child_body,
+                    axis=Vector3.X(),
+                )
+            )
+        assert wait_for_condition(
+            lambda: len(world_2.kinematic_structure_entities) == 2
+        ), "the model modification of the deferring synchronizer was not published"
+
+        publish_position(world_1, 1.25)
+        assert wait_for_condition(
+            lambda: world_2.get_connections_by_type(PrismaticConnection)[0].position
+            == pytest.approx(1.25, abs=1e-9)
+        ), "the state change of the deferring synchronizer was not published"
+    finally:
+        synchronizer_1.close()
+        synchronizer_2.close()
+
+
+def test_state_updates_are_applied_up_to_the_next_model_modification(rclpy_node):
+    """
+    Draining stops at the first buffered model modification, so state that was published
+    before it can be consumed while the modification itself keeps waiting in order.
+    """
+    (
+        publisher_world,
+        receiver_world,
+        publisher_synchronizer,
+        receiver_synchronizer,
+    ) = create_connected_worlds(rclpy_node, "partial_drain")
+    receiver_synchronizer.defer_incoming_updates = True
+
+    try:
+        publish_position(publisher_world, 1.5)
+        # A fixed connection carries no degree of freedom, so this modification does not
+        # publish a state message of its own and the buffer stays predictable.
+        with publisher_world.modify_world():
+            late_body = Body(name=PrefixedName("partial_drain_late_body"))
+            publisher_world.add_body(late_body)
+            publisher_world.add_connection(
+                FixedConnection(parent=publisher_world.root, child=late_body)
+            )
+        publish_position(publisher_world, 2.5)
+        assert wait_for_condition(
+            lambda: len(receiver_synchronizer.missed_messages) == 3
+        ), "expected a state, a model and a second state message to be buffered"
+
+        receiver_synchronizer.apply_missed_state_updates()
+
+        assert receiver_world.get_connections_by_type(PrismaticConnection)[
+            0
+        ].position == pytest.approx(1.5, abs=1e-9)
+        assert len(receiver_world.kinematic_structure_entities) == 2
+        assert len(receiver_synchronizer.missed_messages) == 2
+        assert receiver_synchronizer.has_buffered_model_modification
+
+        receiver_synchronizer.apply_missed_messages()
+
+        assert len(receiver_world.kinematic_structure_entities) == 3
+        assert receiver_world.get_connections_by_type(PrismaticConnection)[
+            0
+        ].position == pytest.approx(2.5, abs=1e-9)
+        assert not receiver_synchronizer.has_buffered_model_modification
+    finally:
+        publisher_synchronizer.close()
+        receiver_synchronizer.close()
+
+
+def test_draining_state_updates_leaves_nothing_behind_without_model_modifications(
+    rclpy_node,
+):
+    """
+    Without a buffered model modification the drain consumes the whole buffer, so a
+    caller draining every cycle never accumulates a backlog.
+    """
+    (
+        publisher_world,
+        receiver_world,
+        publisher_synchronizer,
+        receiver_synchronizer,
+    ) = create_connected_worlds(rclpy_node, "full_state_drain")
+    receiver_synchronizer.defer_incoming_updates = True
+
+    try:
+        publish_position(publisher_world, 0.5)
+        publish_position(publisher_world, 1.5)
+        assert wait_for_condition(
+            lambda: len(receiver_synchronizer.missed_messages) == 2
+        )
+
+        receiver_synchronizer.apply_missed_state_updates()
+
+        assert receiver_synchronizer.missed_messages == []
+        assert receiver_world.get_connections_by_type(PrismaticConnection)[
+            0
+        ].position == pytest.approx(1.5, abs=1e-9)
+    finally:
+        publisher_synchronizer.close()
+        receiver_synchronizer.close()
+
+
+def test_deferred_model_reload_is_only_applied_on_demand(
+    rclpy_node, in_memory_session_maker
+):
+    """
+    A reload replaces the whole world, so a process controlling that world has to be
+    able to postpone it instead of having it applied on the receiving thread.
+    """
+    publisher_world = create_dummy_world()
+    receiver_world = World()
+    publisher_synchronizer = ModelReloadSynchronizer(
+        node=rclpy_node, _world=publisher_world, session=in_memory_session_maker()
+    )
+    receiver_synchronizer = ModelReloadSynchronizer(
+        node=rclpy_node,
+        _world=receiver_world,
+        session=in_memory_session_maker(),
+        defer_incoming_reloads=True,
+    )
+
+    try:
+        publisher_synchronizer.publish_reload_model()
+        assert wait_for_condition(lambda: receiver_synchronizer.has_pending_reload)
+        assert len(receiver_world.kinematic_structure_entities) == 0
+
+        receiver_synchronizer.apply_pending_reload()
+
+        assert len(receiver_world.kinematic_structure_entities) == 2
+        assert not receiver_synchronizer.has_pending_reload
+    finally:
+        publisher_synchronizer.close()
+        receiver_synchronizer.close()
+
+
+def test_message_arriving_during_a_drain_stays_buffered(rclpy_node):
+    """
+    The buffer is appended to on the subscription thread while its owner drains it, so
+    the drain must remove exactly the messages it applied and keep the rest.
+    """
+    world = World(name="drain_race")
+    synchronizer = DelayedApplyWorldSynchronizer(
+        node=rclpy_node,
+        _world=world,
+        defer_incoming_updates=True,
+        topic_name=f"/drain_race_{uuid4().hex}",
+    )
+    try:
+        empty_state_update = WorldStateUpdate(
+            meta_data=synchronizer.meta_data, ids=[], states=[]
+        )
+        synchronizer.missed_messages.append(
+            WorldUpdate(
+                meta_data=synchronizer.meta_data, state_update=empty_state_update
+            )
+        )
+        drain = threading.Thread(
+            target=synchronizer.apply_missed_messages, name="drain-race"
+        )
+        drain.start()
+        time.sleep(0.1)
+        late_message = WorldUpdate(
+            meta_data=synchronizer.meta_data, state_update=empty_state_update
+        )
+        synchronizer._subscription_callback(late_message)
+        drain.join(timeout=5.0)
+
+        assert not drain.is_alive()
+        assert synchronizer.missed_messages == [late_message]
+    finally:
+        synchronizer.close()
+
+
+# %% positions in the stream of a publisher
+
+
+def test_every_publication_advances_the_stream_position(rclpy_node):
+    """
+    Positions count the messages one synchronizer sent, so a reader of the stream can
+    tell how much of it it has seen.
+    """
+    world = World(name="stream_position")
+    synchronizer = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/stream_position_{uuid4().hex}"
+    )
+    try:
+        assert synchronizer.published_sequence_number == 0
+
+        for expected_position in (1, 2, 3):
+            synchronizer.publish(
+                WorldUpdate(
+                    meta_data=synchronizer.meta_data,
+                    state_update=WorldStateUpdate(
+                        meta_data=synchronizer.meta_data, ids=[], states=[]
+                    ),
+                )
+            )
+            assert synchronizer.published_sequence_number == expected_position
+            assert (
+                synchronizer.latest_published_watermark.sequence_number
+                == expected_position
+            )
+            assert synchronizer.latest_published_watermark.origin == (
+                synchronizer.meta_data
+            )
+    finally:
+        synchronizer.close()
+
+
+def test_applying_an_update_records_the_position_of_its_publisher(rclpy_node):
+    """
+    Catching up is tracked per publisher, because positions of different publishers say
+    nothing about each other.
+    """
+    (
+        publisher_world,
+        receiver_world,
+        publisher_synchronizer,
+        receiver_synchronizer,
+    ) = create_connected_worlds(rclpy_node, "applied_position")
+    try:
+        publish_position(publisher_world, 0.75)
+        watermark = publisher_synchronizer.latest_published_watermark
+
+        assert wait_for_condition(
+            lambda: receiver_synchronizer.has_applied(watermark)
+        ), "the receiver never caught up with the published position"
+        assert receiver_synchronizer.has_applied(
+            StateWatermark(
+                origin=watermark.origin, sequence_number=watermark.sequence_number - 1
+            )
+        )
+        assert not receiver_synchronizer.has_applied(
+            StateWatermark(
+                origin=watermark.origin, sequence_number=watermark.sequence_number + 1
+            )
+        )
+    finally:
+        publisher_synchronizer.close()
+        receiver_synchronizer.close()
+
+
+def test_a_publisher_that_was_never_heard_from_is_at_the_start_of_its_stream(
+    rclpy_node,
+):
+    """
+    Nothing of an unknown publisher was applied, so its first message is still awaited.
+    """
+    world = World(name="unknown_publisher")
+    synchronizer = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/unknown_publisher_{uuid4().hex}"
+    )
+    stranger = MetaData(node_name="stranger", process_id=1)
+    try:
+        assert synchronizer.has_applied(
+            StateWatermark(origin=stranger, sequence_number=0)
+        )
+        assert not synchronizer.has_applied(
+            StateWatermark(origin=stranger, sequence_number=1)
+        )
+    finally:
+        synchronizer.close()
+
+
+def test_a_buffered_update_does_not_count_as_caught_up_with(rclpy_node):
+    """
+    A deferred update has not reached the world yet, so whoever waits for it must keep
+    waiting until it is applied.
+    """
+    (
+        publisher_world,
+        receiver_world,
+        publisher_synchronizer,
+        receiver_synchronizer,
+    ) = create_connected_worlds(rclpy_node, "buffered_position")
+    receiver_synchronizer.defer_incoming_updates = True
+    try:
+        publish_position(publisher_world, 0.5)
+        watermark = publisher_synchronizer.latest_published_watermark
+        assert wait_for_condition(
+            lambda: len(receiver_synchronizer.missed_messages) == 1
+        ), "the update was never received"
+
+        assert not receiver_synchronizer.has_applied(watermark)
+
+        receiver_synchronizer.apply_missed_messages()
+
+        assert receiver_synchronizer.has_applied(watermark)
+    finally:
+        publisher_synchronizer.close()
+        receiver_synchronizer.close()
+
+
+def test_the_synchronizer_of_a_world_is_found_through_the_world(rclpy_node):
+    """
+    A client that was handed a world, but not the synchronizer publishing its changes,
+    still has to name the stream its watermarks belong to.
+    """
+    world = World(name="synchronizer_lookup")
+    synchronizer = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/synchronizer_lookup_{uuid4().hex}"
+    )
+    try:
+        assert WorldSynchronizer.for_world(world) is synchronizer
+    finally:
+        synchronizer.close()
+
+
+def test_a_world_that_publishes_nowhere_has_no_synchronizer():
+    """
+    Referring to the stream of a world that has none is a mistake worth naming.
+    """
+    world = World(name="no_synchronizer")
+
+    with pytest.raises(WorldHasNoSynchronizerError):
+        WorldSynchronizer.for_world(world)
+
+
+def test_several_synchronizers_leave_the_stream_of_a_world_undecided(rclpy_node):
+    """
+    Watermarks name one stream, so a world publishing through several synchronizers
+    cannot answer which one is meant.
+    """
+    world = World(name="ambiguous_synchronizer")
+    first = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/ambiguous_a_{uuid4().hex}"
+    )
+    second = WorldSynchronizer(
+        node=rclpy_node, _world=world, topic_name=f"/ambiguous_b_{uuid4().hex}"
+    )
+    try:
+        with pytest.raises(WorldHasMultipleSynchronizersError):
+            WorldSynchronizer.for_world(world)
+    finally:
+        first.close()
+        second.close()
 
 
 if __name__ == "__main__":

--- a/test/semantic_digital_twin_test/test_worlds/test_world.py
+++ b/test/semantic_digital_twin_test/test_worlds/test_world.py
@@ -11,11 +11,14 @@ import numpy as np
 import objgraph
 import pytest
 from numpy.testing import assert_raises
+from typing_extensions import Optional
 
 from semantic_digital_twin.adapters.urdf import URDFParser
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
+from semantic_digital_twin.callbacks.callback import StateChangeCallback
 from semantic_digital_twin.exceptions import (
     DuplicateWorldEntityError,
+    MismatchingPublishChangesAttribute,
     UsageError,
     MissingWorldModificationContextError,
     DofNotInWorldStateError,
@@ -229,6 +232,99 @@ def test_nested_with_blocks_illegal_state(world_setup):
             world.remove_connection(connection2)
         world.add_connection(connection1)
         world.add_connection(connection2)
+
+
+# %% batching state changes
+
+
+@dataclass(eq=False)
+class StateChangeCounter(StateChangeCallback):
+    """
+    Counts how often the world announced a state change.
+    """
+
+    count: int = field(default=0, init=False)
+    """
+    Number of state changes announced since this callback was registered.
+    """
+
+    publish_changes_of_last_call: Optional[bool] = field(default=None, init=False)
+    """
+    The ``publish_changes`` the most recent announcement carried.
+    """
+
+    def on_state_change(self, **kwargs):
+        self.count += 1
+        self.publish_changes_of_last_call = kwargs.get("publish_changes")
+
+
+def test_batching_state_changes_announces_them_once(world_setup):
+    world, l1, l2, _, _, _ = world_setup
+    prismatic_connection = world.get_connection(l1, l2)
+    counter = StateChangeCounter(_world=world)
+
+    with world.batch_state_changes():
+        prismatic_connection.position = 1.0
+        prismatic_connection.position = 2.0
+
+    assert counter.count == 1
+    assert prismatic_connection.position == 2.0
+
+
+def test_state_changes_outside_a_batch_are_announced_individually(world_setup):
+    world, l1, l2, _, _, _ = world_setup
+    prismatic_connection = world.get_connection(l1, l2)
+    counter = StateChangeCounter(_world=world)
+
+    prismatic_connection.position = 1.0
+    prismatic_connection.position = 2.0
+
+    assert counter.count == 2
+
+
+def test_batching_without_a_state_change_announces_nothing(world_setup):
+    world, _, _, _, _, _ = world_setup
+    counter = StateChangeCounter(_world=world)
+
+    with world.batch_state_changes():
+        pass
+
+    assert counter.count == 0
+
+
+def test_nested_batches_of_state_changes_announce_them_once(world_setup):
+    world, l1, l2, _, _, _ = world_setup
+    prismatic_connection = world.get_connection(l1, l2)
+    counter = StateChangeCounter(_world=world)
+
+    with world.batch_state_changes():
+        prismatic_connection.position = 1.0
+        with world.batch_state_changes():
+            prismatic_connection.position = 2.0
+        assert counter.count == 0
+
+    assert counter.count == 1
+
+
+def test_batching_state_changes_forwards_its_publish_changes(world_setup):
+    world, l1, l2, _, _, _ = world_setup
+    prismatic_connection = world.get_connection(l1, l2)
+    counter = StateChangeCounter(_world=world)
+
+    with world.batch_state_changes(publish_changes=False):
+        prismatic_connection.position = 1.0
+
+    assert counter.count == 1
+    assert counter.publish_changes_of_last_call is False
+
+
+def test_a_nested_batch_disagreeing_about_publishing_is_rejected(world_setup):
+    world, _, _, _, _, _ = world_setup
+
+    with pytest.raises(MismatchingPublishChangesAttribute):
+        with world.batch_state_changes(publish_changes=False):
+            with world.batch_state_changes(publish_changes=True):
+                pass
 
 
 def test_compute_fk_connection6dof(world_setup):


### PR DESCRIPTION
## Summary

Two related fixes to `WorldSynchronizer` and `World` state-change handling:

1. **Batch state changes into a single notification** so writing a whole
   configuration doesn't recompute forward kinematics and notify observers once
   per degree of freedom.
2. **Replace acknowledgment-based synchronous publishing with sequence-number
   watermarks**, fixing state updates being silently dropped when a subscriber
   fell behind, and closing a race where a thread could publish state it read
   before an earlier model change had gone out.

## Problem

- Writing several degrees of freedom one at a time turned one logical change
  into a burst of individual notifications, each recomputing forward
  kinematics.
- `synchronous=True` publication waited for every subscriber to acknowledge a
  message on a separate `/acknowledge` topic, with a fixed timeout. A
  subscriber that fell behind was indistinguishable from one that never
  received the update, so missed updates were simply dropped instead of being
  caught up on. A crashed/unsubscribed process without cleanup also caused
  every future synchronous publish to stall for the full timeout.
- A modification's publication was flushed only after the world lock was
  released, but nothing prevented a thread waiting on that lock from
  publishing state it had read before the modification ahead of it had
  actually published its own changes.

## Changes

### `World.batch_state_changes()`
- New `WorldStateBatchContextManager`: collects state-change notifications
  raised inside the `with` block and emits exactly one when the outermost
  context exits.
- Nesting is allowed only if all nested contexts agree on `publish_changes`;
  mismatches raise `MismatchingPublishChangesAttribute`, since the setters
  writing state cannot know they're inside a batch and so cannot decide this
  themselves.

### Watermark-based synchronization (replaces acknowledgments)
- `messages.py`: removed `Acknowledgment`/`publication_event_id`; added
  `StateWatermark` (publisher `MetaData` + `sequence_number`) and a
  `sequence_number` field on every `Message`, assigned at publish time.
- `Synchronizer` (`world_synchronizer.py`):
  - Tracks `published_sequence_number` (own outgoing position) and, per
    publisher, the highest `sequence_number` applied so far.
  - `has_applied(watermark)` / `record_applied(message)` let a process check
    or update how far it has caught up with another publisher's stream,
    without comparing world models directly.
  - Removed the acknowledge publisher/subscriber, `synchronous` flag,
    `wait_for_synchronization_timeout`, and the ROS-graph subscriber-discovery
    polling that synchronous mode needed.
- `WorldModelManager.publishing_in_order()`: a reentrant lock claimed by a
  modification *before* the world lock is released, and by `Synchronizer.publish`
  before assigning a sequence number. This guarantees a thread that was waiting
  on the world lock cannot publish state it read until the modification ahead
  of it in the queue has published its own changes first.
- `WorldSynchronizer.for_world(world)`: looks up the synchronizer registered as
  a model-change callback on a world; raises `WorldHasNoSynchronizerError` or
  `WorldHasMultipleSynchronizersError` if there isn't exactly one.
- Deferred application support:
  - `ModelReloadSynchronizer.defer_incoming_reloads` / `apply_pending_reload()`
    — for owners (e.g. a running controller) that must decide themselves when
    a model reload may be applied.
  - `WorldSynchronizer.defer_incoming_updates` — buffers incoming updates
    without pausing outgoing publication (unlike `pause()`).
  - `apply_missed_state_updates()` — applies only the buffered messages up to
    the next model modification, leaving the rest buffered in order, so state
    can keep flowing while a model modification can't yet be applied.
  - `missed_messages` access is now guarded by `_missed_message_lock`
    (deliberately not the world lock, since receiving a message must never
    block on the world).
- `TFPublisher.stop()`: now also stops the model-change callback it owns
  (previously only the state-change callback was stopped, leaving the model
  callback publishing to a possibly-destroyed node).

### Exceptions
- Added `WorldHasNoSynchronizerError`, `WorldHasMultipleSynchronizersError`.

## Tests

- `test_world.py`: coverage for `batch_state_changes` (single notification,
  nesting, mismatched `publish_changes` raising).
- `test_world_synchronizer.py`: substantially rewritten (1593 lines changed)
  to exercise watermark-based catch-up/ordering instead of acknowledgment
  waiting/timeouts; deferred reload/update application;
  `apply_missed_state_updates` boundary behavior.
- `conftest.py`: supporting fixture changes for the above.

## Notes

- `ormatic_interface.py` changes are generated (`scripts/regenerate_all_orm.py`)
  and not hand-reviewed per project convention.
- Made with the help of Claude.
