### PR TITLE
Fix issue with world synchronizer of missing messages while being paused

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
@@ -484,11 +484,9 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
     changes.
     """
 
-    missed_messages: List[WorldUpdate] = field(
-        default_factory=list, init=False, repr=False
-    )
+    missed_messages: List[str] = field(default_factory=list, init=False, repr=False)
     """
-    Buffer for messages received while the synchronizer is paused.
+    Serialized messages received while the synchronizer is paused.
 
     These messages can be applied later by calling ``apply_missed_messages()``.
     """
@@ -500,6 +498,33 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         if self.synchronize_state:
             self._world.state.state_change_callbacks.append(self)
         self.update_previous_world_state()
+
+    def subscription_callback(self, message: std_msgs.msg.String):
+        """
+        Receive a serialized world update and process or defer it.
+
+        :param message: The incoming ROS string containing a serialized world update.
+        """
+        with self._world._world_lock:
+            message_data = json.loads(message.data)
+            message_meta_data = from_json(message_data["meta_data"])
+            if message_meta_data == self.meta_data:
+                return
+            if self._is_paused:
+                self.missed_messages.append(message.data)
+                return
+            deserialized_message = self._deserialize_message(message_data)
+            self._subscription_callback(deserialized_message)
+
+    def _deserialize_message(self, message_data: Dict[str, object]) -> WorldUpdate:
+        """
+        Deserialize a world update against the current world entities.
+
+        :param message_data: The parsed JSON representation of the world update.
+        :return: The deserialized world update.
+        """
+        tracker = WorldEntityWithIDKwargsTracker.from_world(self._world)
+        return from_json(message_data, **tracker.create_kwargs())
 
     def on_model_change(self, **kwargs):
         publish_changes = kwargs.get("publish_changes")
@@ -586,11 +611,13 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         }
 
     def _subscription_callback(self, message: WorldUpdate):
-        if self._is_paused:
-            self.missed_messages.append(message)
-        else:
-            self.apply_message(message)
-            self.acknowledge_message(message)
+        """
+        Apply and acknowledge a deserialized world update.
+
+        :param message: The world update to apply.
+        """
+        self.apply_message(message)
+        self.acknowledge_message(message)
 
     def apply_message(self, message: WorldUpdate):
         """
@@ -644,28 +671,27 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
 
     def apply_missed_messages(self):
         """
-        Apply buffered messages accumulated while the synchronizer was paused.
+        Deserialize and apply messages accumulated while the synchronizer was paused.
 
-        Each message is applied independently so that model-change notifications fire
-        between messages, which is required for state messages that follow model
-        messages (``compiled_all_fks`` must exist before ``notify_state_change`` is
-        called).
+        Each message is applied before the next message is deserialized so references to
+        entities introduced by preceding messages can be resolved.
 
         :raises ApplyMissedMessagesWhileWorldIsBeingModifiedError: If called while a
             ``modify_world`` context is active on this synchronizer's world.
         """
         if self._world.world_is_being_modified:
             raise ApplyMissedMessagesWhileWorldIsBeingModifiedError()
-        if not self.missed_messages:
-            return
-        pending_messages = self.missed_messages
-        self.missed_messages = []
-        # Hold the world lock across the whole batch so the buffered messages apply atomically: a
-        # concurrent modify_world on another thread serializes behind it instead of interleaving.
+        applied_messages = []
         with self._world._world_lock:
-            for message in pending_messages:
+            if not self.missed_messages:
+                return
+            pending_messages = self.missed_messages
+            self.missed_messages = []
+            for serialized_message in pending_messages:
+                message = self._deserialize_message(json.loads(serialized_message))
                 self.apply_message(message)
-        for message in pending_messages:
+                applied_messages.append(message)
+        for message in applied_messages:
             self.acknowledge_message(message)
 
     def resume(self):

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/world_synchronizer.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import cached_property
-from typing import ClassVar, Optional, Set, Type, List, Dict
+from typing import ClassVar, Optional, Set, Type, List, Dict, Callable, Any
 from uuid import UUID
 
 import numpy as np
@@ -122,9 +122,23 @@ class Synchronizer(WorldEntityWithClassBasedID):
     The type of the message that is sent and received.
     """
 
+    missed_messages: List[str] = field(default_factory=list, init=False, repr=False)
+    """
+    Serialized messages received while the synchronizer is paused.
+
+    These messages can be applied later by calling ``apply_missed_messages()``.
+    """
+
     wait_for_synchronization_timeout: float = field(default=30.0)
     """
     Timeout in seconds for waiting for synchronization.
+    """
+
+    _deserialize_method: ClassVar[Callable[[str], Any]] = None
+    """
+    Abstract method to deserialize message data into message objects.
+
+    Must be implemented by subclasses.
     """
 
     _current_publication_event_id: Optional[UUID] = None
@@ -209,22 +223,20 @@ class Synchronizer(WorldEntityWithClassBasedID):
 
     def subscription_callback(self, message: std_msgs.msg.String):
         """
-        Wrap the origin subscription callback by self-skipping and disabling the next
-        world callback. Holds the world lock while deserializing to ensure no changes
-        happen while building the tracker and running from_json.
+        Receive a serialized synchronization message and process or defer it.
 
-        :param message: The incoming ROS string message containing a serialized
-            synchronization message.
+        :param message: The incoming ROS string containing a serialized synchronization
+            message.
         """
         with self._world._world_lock:
-            tracker = WorldEntityWithIDKwargsTracker.from_world(self._world)
-            deserialized_message = from_json(
-                json.loads(message.data), **tracker.create_kwargs()
-            )
-
-            if deserialized_message.meta_data == self.meta_data:
+            message_data = json.loads(message.data)
+            message_meta_data = from_json(message_data["meta_data"])
+            if message_meta_data == self.meta_data:
                 return
-
+            if self._is_paused:
+                self.missed_messages.append(message.data)
+                return
+            deserialized_message = self._deserialize_message(message_data)
             self._subscription_callback(deserialized_message)
 
     def acknowledge_message(self, message: message_type):
@@ -434,6 +446,15 @@ class ModelReloadSynchronizer(Synchronizer):
         self._replace_world(new_world)
         self._world._notify_model_change(publish_changes=False)
 
+    def _deserialize_message(self, message_data: Dict[str, object]) -> LoadModel:
+        """
+        Deserialize a load model message.
+
+        :param message_data: The parsed JSON representation of the load model message.
+        :return: The deserialized LoadModel message.
+        """
+        return from_json(message_data)
+
     def _replace_world(self, new_world: World):
         """
         Replaces the current world with a new one, updating all relevant attributes.
@@ -484,13 +505,6 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
     changes.
     """
 
-    missed_messages: List[str] = field(default_factory=list, init=False, repr=False)
-    """
-    Serialized messages received while the synchronizer is paused.
-
-    These messages can be applied later by calling ``apply_missed_messages()``.
-    """
-
     def __post_init__(self):
         Synchronizer.__post_init__(self)
         if self.synchronize_model:
@@ -498,23 +512,6 @@ class WorldSynchronizer(Synchronizer, ModelChangeCallback, StateChangeCallback):
         if self.synchronize_state:
             self._world.state.state_change_callbacks.append(self)
         self.update_previous_world_state()
-
-    def subscription_callback(self, message: std_msgs.msg.String):
-        """
-        Receive a serialized world update and process or defer it.
-
-        :param message: The incoming ROS string containing a serialized world update.
-        """
-        with self._world._world_lock:
-            message_data = json.loads(message.data)
-            message_meta_data = from_json(message_data["meta_data"])
-            if message_meta_data == self.meta_data:
-                return
-            if self._is_paused:
-                self.missed_messages.append(message.data)
-                return
-            deserialized_message = self._deserialize_message(message_data)
-            self._subscription_callback(deserialized_message)
 
     def _deserialize_message(self, message_data: Dict[str, object]) -> WorldUpdate:
         """

--- a/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
@@ -517,9 +517,8 @@ def test_paused_messages_resolve_entities_from_preceding_messages(rclpy_node):
 
     synchronized_parent = receiver_world.get_world_entity_with_id_by_id(parent.id)
     synchronized_child = receiver_world.get_world_entity_with_id_by_id(child.id)
-    synchronized_connection = receiver_world.get_connection_between(
-        synchronized_parent, synchronized_child
-    )
+    assert len(receiver_world.connections) == 1
+    synchronized_connection = receiver_world.connections[0]
     assert synchronized_connection.parent is synchronized_parent
     assert synchronized_connection.child is synchronized_child
 

--- a/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_synchronizer.py
@@ -472,6 +472,60 @@ def test_callback_pausing(rclpy_node):
     assert len(w2.connections) == 1
 
 
+def test_paused_messages_resolve_entities_from_preceding_messages(rclpy_node):
+    source_world = World(name="cross_message_source")
+    receiver_world = World(name="cross_message_receiver")
+    receiver_synchronizer = WorldSynchronizer(node=rclpy_node, _world=receiver_world)
+    receiver_synchronizer.pause()
+    source_meta_data = MetaData(node_name="source", process_id=os.getpid())
+
+    parent = Body(name=PrefixedName("parent"))
+    with source_world.modify_world():
+        source_world.add_body(parent)
+    parent_update = WorldUpdate(
+        meta_data=source_meta_data,
+        modification_block=ModificationBlock(
+            meta_data=source_meta_data,
+            modifications=source_world.get_world_model_manager().model_modification_blocks[
+                -1
+            ],
+        ),
+    )
+
+    child = Body(name=PrefixedName("child"))
+    with source_world.modify_world():
+        source_world.add_body(child)
+        source_world.add_connection(FixedConnection(parent=parent, child=child))
+    child_update = WorldUpdate(
+        meta_data=source_meta_data,
+        modification_block=ModificationBlock(
+            meta_data=source_meta_data,
+            modifications=source_world.get_world_model_manager().model_modification_blocks[
+                -1
+            ],
+        ),
+    )
+
+    receiver_synchronizer.subscription_callback(
+        std_msgs.msg.String(data=json.dumps(to_json(parent_update)))
+    )
+    receiver_synchronizer.subscription_callback(
+        std_msgs.msg.String(data=json.dumps(to_json(child_update)))
+    )
+
+    receiver_synchronizer.apply_missed_messages()
+
+    synchronized_parent = receiver_world.get_world_entity_with_id_by_id(parent.id)
+    synchronized_child = receiver_world.get_world_entity_with_id_by_id(child.id)
+    synchronized_connection = receiver_world.get_connection_between(
+        synchronized_parent, synchronized_child
+    )
+    assert synchronized_connection.parent is synchronized_parent
+    assert synchronized_connection.child is synchronized_child
+
+    receiver_synchronizer.close()
+
+
 def test_ChangeDifHasHardwareInterface(rclpy_node):
     w1 = World(name="w1")
     w2 = World(name="w2")


### PR DESCRIPTION
The world synchronizer was missing messages when being paused. This led to some objects not being present in the world when being loaded in a demo script. Actually applying the buffered messages should solve this.