### PR TITLE
[DevTools] More scripted, and better instructions for starting a plan item.

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -135,7 +135,10 @@ the narrative that doesn't belong in structured data.
   every plan. It cross-checks every item against live GitHub PR/CI/review state, so a manifest
   can't silently go stale the way a hand-maintained roadmap doc could.
 - Start or unblock one item → `/plan-item-kickoff <plan-id> <item-id>`,
-  `/plan-item-resolve <plan-id> <item-id>`.
+  `/plan-item-resolve <plan-id> <item-id>`. Kickoff opens the item's branch and draft PR and
+  marks it `in_progress` as soon as its plan is approved — via
+  [`plan_item_bootstrap.py`](./plan_item_bootstrap.py), which you can also run by hand — so the
+  manifest never says `not_started` while the work is underway.
 
 **Auto-discovery.** If your branch is an item in some plan, that plan's `plan.yaml` and `roadmap.md`
 are pulled into `CLAUDE.local.md` too, via a generated branch-to-plan index that `save-plan.sh`

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -888,10 +888,10 @@ def apply_item_fields(
     manifest_text: str,
     plan_identifier: str,
     item_identifier: str,
-    fields_to_set: list[tuple[ManifestKey, str]],
+    values_by_key: dict[ManifestKey, str],
 ) -> str:
     """
-    Set each of *fields_to_set* on one item, patching an existing line or inserting a new
+    Set each of *values_by_key* on one item, patching an existing line or inserting a new
     one.
 
     Every other line is left byte-for-byte untouched, so comments, key order, string
@@ -900,16 +900,21 @@ def apply_item_fields(
     :param manifest_text: The manifest's raw text.
     :param plan_identifier: The plan being edited.
     :param item_identifier: The item to patch.
-    :param fields_to_set: Each field to write, with the value to write to it.
+    :param values_by_key: The value to write to each key, applied in insertion order. A
+        mapping rather than pairs, since one key cannot be set twice.
     :raises UnknownItemError: If the item has no block in the text.
     :return: The patched manifest text.
     """
     lines = manifest_text.split("\n")
     start, end = locate_item_block(lines, plan_identifier, item_identifier)
-    for field, value in fields_to_set:
-        rendered = field.render(value).rstrip("\n")
+    for manifest_key, value in values_by_key.items():
+        rendered = manifest_key.render(value).rstrip("\n")
         existing = next(
-            (index for index in range(start, end) if field.pattern.match(lines[index])),
+            (
+                index
+                for index in range(start, end)
+                if manifest_key.pattern.match(lines[index])
+            ),
             None,
         )
         if existing is not None:
@@ -951,28 +956,24 @@ def render_new_item(request: ItemRecordRequest) -> str:
     :raises IncompleteNewItemError: If a field a new entry cannot omit is missing.
     :return: The block's text, newline-terminated.
     """
+    required = {ManifestKey.TITLE: request.title, ManifestKey.TRACK: request.track}
     missing = tuple(
-        manifest_key
-        for manifest_key, value in (
-            (ManifestKey.TITLE, request.title),
-            (ManifestKey.TRACK, request.track),
-        )
-        if not value
+        manifest_key for manifest_key, value in required.items() if not value
     )
     if missing:
         raise IncompleteNewItemError(
             item_identifier=request.item_identifier, missing_keys=missing
         )
-    body = [
-        (ManifestKey.TITLE, request.title),
-        (ManifestKey.BRANCH, "null"),
-        (ManifestKey.TRACK, request.track),
-        (ManifestKey.DEPENDS_ON, "[]"),
-        (ManifestKey.STATUS, request.status.value),
-    ]
+    body = {
+        ManifestKey.TITLE: request.title,
+        ManifestKey.BRANCH: "null",
+        ManifestKey.TRACK: request.track,
+        ManifestKey.DEPENDS_ON: "[]",
+        ManifestKey.STATUS: request.status.value,
+    }
     return ManifestKey.IDENTIFIER.render(
         request.item_identifier, opening_the_item=True
-    ) + "".join(field.render(value) for field, value in body)
+    ) + "".join(manifest_key.render(value) for manifest_key, value in body.items())
 
 
 def append_item(manifest_text: str, block: str) -> str:
@@ -1120,7 +1121,7 @@ def record_item(request: ItemRecordRequest, project_root: Path) -> BootstrapRepo
             documents.manifest_text,
             request.plan_identifier,
             request.item_identifier,
-            [(ManifestKey.STATUS, request.status.value)],
+            {ManifestKey.STATUS: request.status.value},
         )
 
     roadmap_text = append_roadmap_section(
@@ -1464,12 +1465,12 @@ def open_work(
         documents.manifest_text,
         request.plan_identifier,
         request.item_identifier,
-        [
-            (ManifestKey.BRANCH, request.branch),
-            (ManifestKey.PULL_REQUEST_NUMBER, str(created.number)),
-            (ManifestKey.SESSION, request.session_url),
-            (ManifestKey.STATUS, ItemStatus.IN_PROGRESS.value),
-        ],
+        {
+            ManifestKey.BRANCH: request.branch,
+            ManifestKey.PULL_REQUEST_NUMBER: str(created.number),
+            ManifestKey.SESSION: request.session_url,
+            ManifestKey.STATUS: ItemStatus.IN_PROGRESS.value,
+        },
     )
     documents.save(manifest_text, documents.roadmap_text, project_root)
     return BootstrapReport(

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -1,0 +1,1124 @@
+#!/usr/bin/env python3
+"""
+Bootstrap a plan item before its implementation, rather than after it.
+
+Everything a session knows the moment an implementation plan is approved - the branch,
+the draft pull request, the item's manifest fields, its roadmap section - is derivable
+without a line of the implementation, yet all of it conventionally happens at the end.
+For that whole window ``plan.yaml`` says the item is ``not_started`` with no branch while
+a branch exists and is being worked, which every dashboard, kickoff and resolve run
+downstream reads as truth.
+
+Two operations, so each caller depends only on the surface it uses:
+
+``record``
+    Write or update the item's ``plan.yaml`` entry and append its ``roadmap.md``
+    section, set its status, and push both through ``save-plan.sh``.
+
+``open``
+    Create the branch, publish it, open the draft pull request, then write ``branch``,
+    ``session`` and ``pull_request_number`` back onto the item and flip it to
+    ``in_progress``.
+
+``open`` runs before ``record`` when both are wanted: the pull request number does not
+exist until the pull request does.
+
+Usage:
+    python3 plan_item_bootstrap.py record --plan <plan-id> --item <item-id> \\
+        --status <status> --roadmap-section <file> [--title <title>] [--track <track>]
+    python3 plan_item_bootstrap.py open --plan <plan-id> --item <item-id> \\
+        --branch <branch> --base <branch> --session <url> \\
+        --pull-request-title <title> --pull-request-body <file>
+
+Prints a one-line JSON report led by ``status`` and ``exit_code``, so a caller acting on
+the document never has to decode an integer back into a meaning.
+
+.. note::
+   Republishing the dashboard is deliberately not done here. Only a live session can
+   call the ``Artifact`` tool, so both operations hand back the ``/plan-dashboard``
+   command to run instead, exactly as ``save-plan.sh`` already does.
+
+.. note::
+   The manifest is edited by patching only the lines that change. A full YAML
+   load-mutate-dump round trip is rejected for the reason ``sync_manifest_status.py``
+   records: even a format-preserving library re-flows wrapped strings, turning a
+   one-field edit into an unreadable diff across the whole file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import IntEnum, StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+import yaml
+
+GITHUB_API_ROOT = "https://api.github.com"
+"""
+Where pull requests are created, overridable for a GitHub Enterprise host.
+"""
+
+CONFIGURATION_SCRIPT = ".claude/hooks/resolve-personal-notes-config.sh"
+"""
+The shell script that owns personal-notes remote/branch resolution, sourced rather than
+reimplemented so the two can never disagree.
+"""
+
+SAVE_PLAN_SCRIPT = ".claude/hooks/save-plan.sh"
+"""
+The script that pushes an edited manifest and roadmap to the personal-notes branch.
+"""
+
+ITEM_START_PATTERN = re.compile(r"^\s*- id:")
+"""
+Matches the first line of an item block in ``plan.yaml``.
+
+Same anchor ``sync_manifest_status.py`` uses to find item boundaries in raw text.
+"""
+
+TOP_LEVEL_KEY_PATTERN = re.compile(r"^\S")
+"""
+Matches a top-level ``plan.yaml`` key, which is where the last item block ends.
+"""
+
+FOLDED_FIELD_PATTERN = re.compile(r"^\s*(notes|blockers):")
+"""
+Matches an item field whose value may run over several following lines, so a new field
+is inserted before it rather than after.
+"""
+
+ITEM_FIELD_INDENT = "    "
+"""
+The indentation ``plan.yaml`` item fields carry, one level inside the list marker.
+"""
+
+
+class ItemStatus(StrEnum):
+    """
+    The statuses ``plan.yaml``'s ``status`` field accepts.
+
+    Mirrors ``build_dashboard.py``'s own enum, which lives in the plan-dashboard skill
+    directory and is not importable from here until ``development_tooling`` gives both a
+    shared home.
+    """
+
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    DEFERRED = "deferred"
+    DONE = "done"
+
+
+class ExitCode(IntEnum):
+    """
+    The process statuses this tool exits with.
+
+    Values are distinct rather than aligned with ``stack.py``'s own ``ExitCode``, which
+    is not reachable from ``main``; aligning the two belongs with whichever item brings
+    them into one package.
+    """
+
+    SUCCESS = 0
+    UNKNOWN_PLAN = 3
+    UNKNOWN_ITEM = 4
+    INCOMPLETE_NEW_ITEM = 5
+    BRANCH_ALREADY_PUBLISHED = 6
+    PULL_REQUEST_REFUSED = 8
+
+    @property
+    def name_for_a_caller(self) -> str:
+        """
+        The status's own name, for a report a person or a script has to act on.
+
+        Derived from the member rather than a table beside it, so a status can never
+        carry a name belonging to a different one.
+        """
+        return self.name.lower()
+
+
+# %% failures
+
+
+class BootstrapError(Exception):
+    """
+    Base for every refusal this tool reports, each carrying its own exit status.
+    """
+
+    exit_code = ExitCode.SUCCESS
+    """
+    The process status this refusal exits with.
+    """
+
+
+class UnknownPlanError(BootstrapError):
+    """
+    Raised when the named plan has no manifest on the personal-notes branch.
+    """
+
+    exit_code = ExitCode.UNKNOWN_PLAN
+
+
+class UnknownItemError(BootstrapError):
+    """
+    Raised when the named item is absent from an otherwise resolvable plan.
+    """
+
+    exit_code = ExitCode.UNKNOWN_ITEM
+
+
+class IncompleteNewItemError(BootstrapError):
+    """
+    Raised when an item that does not exist yet is recorded without the fields needed to
+    write its entry.
+    """
+
+    exit_code = ExitCode.INCOMPLETE_NEW_ITEM
+
+
+class BranchAlreadyPublishedError(BootstrapError):
+    """
+    Raised when the branch to open already exists on the remote, which means work is
+    underway and overwriting it would discard someone's commits.
+    """
+
+    exit_code = ExitCode.BRANCH_ALREADY_PUBLISHED
+
+
+class PullRequestRefusedError(BootstrapError):
+    """
+    Raised when the remote declines to create the pull request.
+    """
+
+    exit_code = ExitCode.PULL_REQUEST_REFUSED
+
+
+class NotesBranchUnavailableError(BootstrapError):
+    """
+    Raised when the personal-notes branch cannot be fetched, so there is no plan data to
+    read or write.
+    """
+
+    exit_code = ExitCode.UNKNOWN_PLAN
+
+
+# %% the plan on the personal-notes branch
+
+
+def run_git(*arguments: str, project_root: Path) -> str:
+    """
+    Run git in *project_root* and return its standard output.
+
+    :param arguments: The arguments to pass to git.
+    :param project_root: The repository to run within.
+    :raises subprocess.CalledProcessError: If git reports an error.
+    :return: Standard output, stripped of its trailing newline.
+    """
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.rstrip("\n")
+
+
+@dataclass(frozen=True)
+class PlanLocation:
+    """
+    Where one plan's manifest and roadmap live, as the shell configuration resolves it.
+    """
+
+    manifest_path: str
+    """
+    The manifest's path within the personal-notes branch.
+    """
+
+    roadmap_path: str
+    """
+    The roadmap's path within the personal-notes branch.
+    """
+
+    @classmethod
+    def resolve(cls, plan_identifier: str, project_root: Path) -> PlanLocation:
+        """
+        Fetch the personal-notes branch and resolve *plan_identifier*'s paths within it.
+
+        Sources the shell configuration and calls its own fetch function rather than
+        re-deriving the remote/branch precedence, so this and the hook scripts can never
+        disagree about which branch a plan is on.
+
+        :param plan_identifier: The plan's id.
+        :param project_root: The repository to resolve within.
+        :raises NotesBranchUnavailableError: If the notes branch cannot be fetched.
+        :return: The resolved location, with ``FETCH_HEAD`` left pointing at the branch.
+        """
+        probe = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f'source "{CONFIGURATION_SCRIPT}" && fetch_personal_notes_branch && '
+                'printf "%s\\n%s\\n" '
+                '"$(plan_manifest_path "$1")" "$(plan_roadmap_path "$1")"',
+                "plan_item_bootstrap",
+                plan_identifier,
+            ],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0:
+            raise NotesBranchUnavailableError(
+                "could not fetch the personal-notes branch: "
+                f"{probe.stderr.strip() or 'no personal-notes branch found'}"
+            )
+        manifest_path, roadmap_path = probe.stdout.strip().split("\n")
+        return cls(manifest_path=manifest_path, roadmap_path=roadmap_path)
+
+
+@dataclass(frozen=True)
+class PlanDocuments:
+    """
+    One plan's manifest and roadmap as they stand on the personal-notes branch.
+    """
+
+    plan_identifier: str
+    """
+    The plan's id.
+    """
+
+    manifest_text: str
+    """
+    The manifest's raw text, patched by line rather than re-serialized.
+    """
+
+    roadmap_text: str
+    """
+    The roadmap's raw markdown.
+    """
+
+    @classmethod
+    def load(cls, plan_identifier: str, project_root: Path) -> PlanDocuments:
+        """
+        Read a plan's manifest and roadmap off the freshly fetched notes branch.
+
+        The fetch happens here, immediately before the caller's edit, so an edit is
+        never applied to a copy loaded earlier in the session.
+
+        :param plan_identifier: The plan's id.
+        :param project_root: The repository to read within.
+        :raises UnknownPlanError: If the plan has no manifest on the branch.
+        :return: The loaded documents.
+        """
+        location = PlanLocation.resolve(plan_identifier, project_root)
+        try:
+            manifest_text = run_git(
+                "show",
+                f"FETCH_HEAD:{location.manifest_path}",
+                project_root=project_root,
+            )
+            roadmap_text = run_git(
+                "show", f"FETCH_HEAD:{location.roadmap_path}", project_root=project_root
+            )
+        except subprocess.CalledProcessError as error:
+            raise UnknownPlanError(
+                f"no plan {plan_identifier!r} on the personal-notes branch "
+                f"({location.manifest_path} is not there)"
+            ) from error
+        return cls(
+            plan_identifier=plan_identifier,
+            manifest_text=manifest_text + "\n",
+            roadmap_text=roadmap_text + "\n",
+        )
+
+    @property
+    def manifest(self) -> dict[str, Any]:
+        """
+        The parsed manifest, for reading fields rather than editing them.
+        """
+        return yaml.safe_load(self.manifest_text)
+
+    def repository_for(self, item_identifier: str) -> str:
+        """
+        The ``owner/repo`` an item's pull request belongs to.
+
+        :param item_identifier: The item's id.
+        :raises UnknownItemError: If no item carries that id.
+        :return: The item's own ``repository``, or the plan's ``default_repository``.
+        """
+        item = self.item(item_identifier)
+        return item.get("repository") or self.manifest["default_repository"]
+
+    def item(self, item_identifier: str) -> dict[str, Any]:
+        """
+        One item's parsed mapping.
+
+        :param item_identifier: The item's id, or its branch when it has no id.
+        :raises UnknownItemError: If no item matches.
+        :return: The item's mapping.
+        """
+        for candidate in self.manifest.get("items", []):
+            if (candidate.get("id") or candidate.get("branch")) == item_identifier:
+                return candidate
+        raise UnknownItemError(
+            f"no item {item_identifier!r} in plan {self.plan_identifier!r}"
+        )
+
+    def has_item(self, item_identifier: str) -> bool:
+        """
+        Whether the plan already tracks an item under *item_identifier*.
+
+        :param item_identifier: The item's id.
+        :return: True when an entry exists.
+        """
+        try:
+            self.item(item_identifier)
+        except UnknownItemError:
+            return False
+        return True
+
+    def save(self, manifest_text: str, roadmap_text: str, project_root: Path) -> None:
+        """
+        Push an edited manifest and roadmap through ``save-plan.sh``.
+
+        :param manifest_text: The full manifest to write.
+        :param roadmap_text: The full roadmap to write.
+        :param project_root: The repository to run the script from.
+        :raises subprocess.CalledProcessError: If the script reports an error.
+        """
+        with tempfile.TemporaryDirectory() as scratch_directory:
+            scratch = Path(scratch_directory)
+            manifest_file = scratch / "plan.yaml"
+            roadmap_file = scratch / "roadmap.md"
+            manifest_file.write_text(manifest_text)
+            roadmap_file.write_text(roadmap_text)
+            subprocess.run(
+                [
+                    "bash",
+                    SAVE_PLAN_SCRIPT,
+                    self.plan_identifier,
+                    "--manifest",
+                    str(manifest_file),
+                    "--roadmap",
+                    str(roadmap_file),
+                ],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+
+# %% patching one item's fields in the manifest text
+
+
+def item_block_bounds(manifest_lines: list[str]) -> list[tuple[int, int]]:
+    """
+    The half-open line range of every item block in the manifest.
+
+    :param manifest_lines: The manifest, split into lines.
+    :return: One ``(start, end)`` pair per item, in manifest order.
+    """
+    starts = [
+        index
+        for index, line in enumerate(manifest_lines)
+        if ITEM_START_PATTERN.match(line)
+    ]
+    if not starts:
+        return []
+    end_of_items = next(
+        (
+            index
+            for index in range(starts[-1] + 1, len(manifest_lines))
+            if TOP_LEVEL_KEY_PATTERN.match(manifest_lines[index])
+        ),
+        len(manifest_lines),
+    )
+    boundaries = starts[1:] + [end_of_items]
+    return list(zip(starts, boundaries))
+
+
+def locate_item_block(
+    manifest_lines: list[str], item_identifier: str
+) -> tuple[int, int]:
+    """
+    Find one item's block within the manifest text.
+
+    :param manifest_lines: The manifest, split into lines.
+    :param item_identifier: The item's id.
+    :raises UnknownItemError: If no block starts with that id.
+    :return: The block's half-open line range.
+    """
+    for start, end in item_block_bounds(manifest_lines):
+        if manifest_lines[start].strip().removeprefix("- id:").strip() == (
+            item_identifier
+        ):
+            return start, end
+    raise UnknownItemError(
+        f"no item block for {item_identifier!r} in the manifest text"
+    )
+
+
+def apply_item_fields(
+    manifest_text: str, item_identifier: str, fields: dict[str, str]
+) -> str:
+    """
+    Set each of *fields* on one item, patching an existing line or inserting a new one.
+
+    Every other line is left byte-for-byte untouched, so comments, key order, string
+    wrapping and quoting all survive.
+
+    :param manifest_text: The manifest's raw text.
+    :param item_identifier: The item to patch.
+    :param fields: Field names mapped to their rendered YAML values.
+    :raises UnknownItemError: If the item has no block in the text.
+    :return: The patched manifest text.
+    """
+    lines = manifest_text.split("\n")
+    start, end = locate_item_block(lines, item_identifier)
+    for field_name, value in fields.items():
+        field_pattern = re.compile(rf"^(\s*{re.escape(field_name)}:\s*).*$")
+        existing = next(
+            (index for index in range(start, end) if field_pattern.match(lines[index])),
+            None,
+        )
+        if existing is not None:
+            lines[existing] = f"{ITEM_FIELD_INDENT}{field_name}: {value}"
+            continue
+        insertion = next(
+            (
+                index
+                for index in range(start, end)
+                if FOLDED_FIELD_PATTERN.match(lines[index])
+            ),
+            last_populated_line(lines, start, end) + 1,
+        )
+        lines.insert(insertion, f"{ITEM_FIELD_INDENT}{field_name}: {value}")
+        end += 1
+    return "\n".join(lines)
+
+
+def last_populated_line(manifest_lines: list[str], start: int, end: int) -> int:
+    """
+    The last non-blank line of a block, so an appended field lands inside it.
+
+    :param manifest_lines: The manifest, split into lines.
+    :param start: The block's first line.
+    :param end: One past the block's last line.
+    :return: The index of the block's last non-blank line.
+    """
+    return max(
+        (index for index in range(start, end) if manifest_lines[index].strip()),
+        default=start,
+    )
+
+
+def render_new_item(request: ItemRecordRequest) -> str:
+    """
+    Render a brand-new item block, in the field order ``plan-schema.md`` documents.
+
+    :param request: The item to record.
+    :raises IncompleteNewItemError: If a field a new entry cannot omit is missing.
+    :return: The block's text, newline-terminated.
+    """
+    if not request.title or not request.track:
+        raise IncompleteNewItemError(
+            f"item {request.item_identifier!r} is not in the plan yet, so recording it "
+            "needs --title and --track"
+        )
+    return (
+        f"  - id: {request.item_identifier}\n"
+        f'{ITEM_FIELD_INDENT}title: "{request.title}"\n'
+        f"{ITEM_FIELD_INDENT}branch: null\n"
+        f"{ITEM_FIELD_INDENT}track: {request.track}\n"
+        f"{ITEM_FIELD_INDENT}depends_on: []\n"
+        f"{ITEM_FIELD_INDENT}status: {request.status.value}\n"
+    )
+
+
+def append_item(manifest_text: str, block: str) -> str:
+    """
+    Add a rendered item block after the manifest's last item.
+
+    :param manifest_text: The manifest's raw text.
+    :param block: The block to append, as :func:`render_new_item` renders it.
+    :return: The extended manifest text.
+    """
+    lines = manifest_text.split("\n")
+    bounds = item_block_bounds(lines)
+    insertion = bounds[-1][1] if bounds else len(lines)
+    tail = "\n".join(lines[insertion:])
+    head = "\n".join(lines[:insertion]).rstrip("\n")
+    return f"{head}\n\n{block}{tail}"
+
+
+# %% recording an item
+
+
+@dataclass(frozen=True)
+class ItemRecordRequest:
+    """
+    What recording one item needs: where it goes, what it is, and what to say about it.
+    """
+
+    plan_identifier: str
+    """
+    The plan the item belongs to.
+    """
+
+    item_identifier: str
+    """
+    The item's id, created if the plan does not track it yet.
+    """
+
+    status: ItemStatus
+    """
+    The status to set on the item.
+    """
+
+    roadmap_section_path: Path
+    """
+    A file whose markdown is appended to the plan's roadmap.
+    """
+
+    title: str | None = None
+    """
+    The item's title, required only when the entry does not exist yet.
+    """
+
+    track: str | None = None
+    """
+    The track the item belongs to, required only when the entry does not exist yet.
+    """
+
+
+@dataclass(frozen=True)
+class BootstrapReport:
+    """
+    What an operation did, in the shape a caller acts on.
+    """
+
+    exit_code: ExitCode
+    """
+    The status the process exits with.
+    """
+
+    plan_identifier: str
+    """
+    The plan that was written.
+    """
+
+    item_identifier: str
+    """
+    The item that was recorded or opened.
+    """
+
+    created_item: bool = False
+    """
+    Whether the item's manifest entry was written for the first time.
+    """
+
+    branch: str | None = None
+    """
+    The branch opened, when one was.
+    """
+
+    pull_request_number: int | None = None
+    """
+    The pull request opened, when one was.
+    """
+
+    pull_request_url: str | None = None
+    """
+    Where the opened pull request lives.
+    """
+
+    @property
+    def dashboard_command(self) -> str:
+        """
+        The republish a live session still has to run, since only it can call
+        ``Artifact``.
+        """
+        return f"/plan-dashboard {self.plan_identifier}"
+
+    def as_document(self) -> dict[str, Any]:
+        """
+        Render the report as the JSON a caller reads, led by what it means.
+        """
+        document: dict[str, Any] = {
+            "status": self.exit_code.name_for_a_caller,
+            "exit_code": int(self.exit_code),
+            "plan": self.plan_identifier,
+            "item": self.item_identifier,
+            "created_item": self.created_item,
+            "dashboard_command": self.dashboard_command,
+        }
+        if self.branch is not None:
+            document["branch"] = self.branch
+        if self.pull_request_number is not None:
+            document["pull_request_number"] = self.pull_request_number
+            document["pull_request_url"] = self.pull_request_url
+        return document
+
+
+def record_item(request: ItemRecordRequest, project_root: Path) -> BootstrapReport:
+    """
+    Write or update one item's manifest entry and roadmap section, then push both.
+
+    :param request: The item to record.
+    :param project_root: The repository to run within.
+    :raises UnknownPlanError: If the plan has no manifest on the notes branch.
+    :raises IncompleteNewItemError: If a new entry is missing a field it cannot omit.
+    :return: What was recorded.
+    """
+    documents = PlanDocuments.load(request.plan_identifier, project_root)
+    created_item = not documents.has_item(request.item_identifier)
+
+    if created_item:
+        manifest_text = append_item(documents.manifest_text, render_new_item(request))
+    else:
+        manifest_text = apply_item_fields(
+            documents.manifest_text,
+            request.item_identifier,
+            {"status": request.status.value},
+        )
+
+    roadmap_text = append_roadmap_section(
+        documents.roadmap_text, request.roadmap_section_path.read_text()
+    )
+    documents.save(manifest_text, roadmap_text, project_root)
+    return BootstrapReport(
+        exit_code=ExitCode.SUCCESS,
+        plan_identifier=request.plan_identifier,
+        item_identifier=request.item_identifier,
+        created_item=created_item,
+    )
+
+
+def append_roadmap_section(roadmap_text: str, section: str) -> str:
+    """
+    Add one section to the end of a roadmap, separated by a blank line.
+
+    :param roadmap_text: The roadmap as it stands.
+    :param section: The markdown to append.
+    :return: The extended roadmap.
+    """
+    return f"{roadmap_text.rstrip(chr(10))}\n\n{section.lstrip(chr(10))}"
+
+
+# %% opening the work
+
+
+@dataclass(frozen=True)
+class PullRequestRequest:
+    """
+    One pull request to create.
+    """
+
+    repository: str
+    """
+    The ``owner/repo`` to create it in.
+    """
+
+    title: str
+    """
+    The pull request's title.
+    """
+
+    body: str
+    """
+    The pull request's description.
+    """
+
+    head: str
+    """
+    The branch carrying the changes.
+    """
+
+    base: str
+    """
+    The branch to merge into.
+    """
+
+    draft: bool = True
+    """
+    Always a draft: this repository's convention is that a pull request stays a draft
+    until its author has reviewed it themselves, and at creation time nobody has.
+    """
+
+
+@dataclass(frozen=True)
+class CreatedPullRequest:
+    """
+    The pull request a remote actually created.
+    """
+
+    number: int
+    """
+    Its number.
+    """
+
+    html_url: str
+    """
+    Where to read it.
+    """
+
+
+class PullRequestOpener(Protocol):
+    """
+    The one call opening the work makes against a forge, kept behind a seam so the
+    surrounding git work is testable without network access.
+    """
+
+    def open_pull_request(self, request: PullRequestRequest) -> CreatedPullRequest:
+        """
+        Create *request* and report what came back.
+
+        :param request: The pull request to create.
+        :raises PullRequestRefusedError: If the remote declines it.
+        :return: The created pull request.
+        """
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestOpener:
+    """
+    Opens pull requests through GitHub's REST API.
+
+    Sends a bearer token when the environment supplies one and nothing otherwise. Inside
+    a Claude Code session the credential is inert - the agent proxy substitutes its own
+    identity - but the same code run from a terminal or a scheduled Action has no proxy,
+    and there the token is the credential. This is deliberately not a third copy of the
+    prefer-``gh``-else-token rule ``github-api.sh`` and ``pr_state`` carry between them;
+    it is the minimum that works from ``main`` today, for whichever item unifies them to
+    absorb.
+    """
+
+    api_root: str = GITHUB_API_ROOT
+    """
+    The API host, overridable for a GitHub Enterprise deployment.
+    """
+
+    def open_pull_request(self, request: PullRequestRequest) -> CreatedPullRequest:
+        """
+        Create *request* through ``POST /repos/{owner}/{repo}/pulls``.
+
+        :param request: The pull request to create.
+        :raises PullRequestRefusedError: If GitHub declines the creation.
+        :return: The created pull request.
+        """
+        payload = json.dumps(
+            {
+                "title": request.title,
+                "body": request.body,
+                "head": request.head,
+                "base": request.base,
+                "draft": request.draft,
+            }
+        ).encode()
+        http_request = urllib.request.Request(
+            f"{self.api_root}/repos/{request.repository}/pulls",
+            data=payload,
+            method="POST",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                **self.authorization_headers(),
+            },
+        )
+        try:
+            with urllib.request.urlopen(http_request) as response:
+                created = json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            raise PullRequestRefusedError(
+                f"GitHub refused to create the pull request ({error.code}): "
+                f"{error.read().decode(errors='replace').strip()}"
+            ) from error
+        return CreatedPullRequest(
+            number=created["number"], html_url=created["html_url"]
+        )
+
+    @staticmethod
+    def authorization_headers() -> dict[str, str]:
+        """
+        The ``Authorization`` header, when the environment carries a token to send.
+
+        :return: The header, or an empty mapping when there is no token.
+        """
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+@dataclass(frozen=True)
+class WorkOpenRequest:
+    """
+    What opening an item's work needs: the branch to create and the pull request to
+    open on it.
+    """
+
+    plan_identifier: str
+    """
+    The plan the item belongs to.
+    """
+
+    item_identifier: str
+    """
+    The item being opened, which must already be tracked.
+    """
+
+    branch: str
+    """
+    The branch to create and publish.
+    """
+
+    base_branch: str
+    """
+    The branch to create it from and target the pull request at.
+    """
+
+    session_url: str
+    """
+    The session doing the work, recorded on the item.
+
+    Required rather than derived: a session's environment cannot be asked which session
+    it is, and a script that guessed would record something wrong in silence.
+    """
+
+    pull_request_title: str
+    """
+    The pull request's title.
+    """
+
+    pull_request_body: str
+    """
+    The pull request's description.
+    """
+
+
+@dataclass
+class WorkOpener:
+    """
+    The git half of opening an item's work: branch from the base, mark the start, and
+    publish.
+    """
+
+    project_root: Path
+    """
+    The repository the branch is created in.
+    """
+
+    remote: str = "origin"
+    """
+    The remote the branch is published to.
+    """
+
+    def branch_is_published(self, branch: str) -> bool:
+        """
+        Whether *branch* already exists on the remote.
+
+        :param branch: The branch to look for.
+        :return: True when the remote already carries it.
+        """
+        listing = run_git(
+            "ls-remote", "--heads", self.remote, branch, project_root=self.project_root
+        )
+        return bool(listing.strip())
+
+    def publish(self, request: WorkOpenRequest) -> None:
+        """
+        Create the branch from its base and push it, so a pull request has a head.
+
+        The opening commit is empty by construction: the whole point of this tool is
+        that the branch exists before any implementation does, and a pull request needs
+        a commit its base does not have.
+
+        :param request: The work being opened.
+        """
+        run_git(
+            "checkout",
+            "-b",
+            request.branch,
+            request.base_branch,
+            project_root=self.project_root,
+        )
+        run_git(
+            "commit",
+            "--allow-empty",
+            "--quiet",
+            "-m",
+            f"Bootstrap {request.item_identifier}",
+            project_root=self.project_root,
+        )
+        run_git(
+            "push",
+            "-u",
+            self.remote,
+            request.branch,
+            project_root=self.project_root,
+        )
+
+
+def open_work(
+    request: WorkOpenRequest,
+    project_root: Path,
+    pull_request_opener: PullRequestOpener | None = None,
+    remote: str = "origin",
+) -> BootstrapReport:
+    """
+    Create the item's branch and draft pull request, then record both on the item.
+
+    Both refusals this can raise before publishing - an untracked item, an already
+    published branch - are checked first, so neither leaves anything behind. A pull
+    request the remote declines is the one case that does: the branch is already
+    published by then and stays, since a session cannot delete a remote branch. The
+    manifest is left untouched rather than pointing at a pull request that does not
+    exist, and re-running once the refusal is understood is refused by the
+    already-published guard rather than silently overwriting those commits.
+
+    :param request: The work to open.
+    :param project_root: The repository to run within.
+    :param pull_request_opener: What creates the pull request, defaulting to GitHub.
+    :param remote: The remote to publish the branch to.
+    :raises UnknownItemError: If the plan does not track the item yet.
+    :raises BranchAlreadyPublishedError: If the branch already exists on the remote.
+    :raises PullRequestRefusedError: If the pull request could not be created.
+    :return: What was opened.
+    """
+    opener = pull_request_opener or GitHubPullRequestOpener()
+    documents = PlanDocuments.load(request.plan_identifier, project_root)
+    repository = documents.repository_for(request.item_identifier)
+
+    work = WorkOpener(project_root=project_root, remote=remote)
+    if work.branch_is_published(request.branch):
+        raise BranchAlreadyPublishedError(
+            f"branch {request.branch!r} already exists on {remote!r} - it is already "
+            "being worked, and republishing it would discard those commits"
+        )
+
+    work.publish(request)
+    created = opener.open_pull_request(
+        PullRequestRequest(
+            repository=repository,
+            title=request.pull_request_title,
+            body=request.pull_request_body,
+            head=request.branch,
+            base=request.base_branch,
+        )
+    )
+
+    manifest_text = apply_item_fields(
+        documents.manifest_text,
+        request.item_identifier,
+        {
+            "branch": request.branch,
+            "pull_request_number": str(created.number),
+            "session": request.session_url,
+            "status": ItemStatus.IN_PROGRESS.value,
+        },
+    )
+    documents.save(manifest_text, documents.roadmap_text, project_root)
+    return BootstrapReport(
+        exit_code=ExitCode.SUCCESS,
+        plan_identifier=request.plan_identifier,
+        item_identifier=request.item_identifier,
+        branch=request.branch,
+        pull_request_number=created.number,
+        pull_request_url=created.html_url,
+    )
+
+
+# %% command line
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """
+    Build the argument parser for both subcommands.
+
+    :return: The parser.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subcommands = parser.add_subparsers(dest="subcommand", required=True)
+
+    record = subcommands.add_parser(
+        "record", help="Write an item's manifest entry and roadmap section"
+    )
+    record.add_argument("--plan", required=True)
+    record.add_argument("--item", required=True)
+    record.add_argument("--status", required=True, type=ItemStatus)
+    record.add_argument("--roadmap-section", required=True, type=Path)
+    record.add_argument("--title")
+    record.add_argument("--track")
+
+    open_command = subcommands.add_parser(
+        "open", help="Create the item's branch and draft pull request"
+    )
+    open_command.add_argument("--plan", required=True)
+    open_command.add_argument("--item", required=True)
+    open_command.add_argument("--branch", required=True)
+    open_command.add_argument("--base", required=True)
+    open_command.add_argument("--session", required=True)
+    open_command.add_argument("--pull-request-title", required=True)
+    open_command.add_argument("--pull-request-body", required=True, type=Path)
+    open_command.add_argument("--remote", default="origin")
+
+    return parser
+
+
+def main() -> int:
+    """
+    Parse arguments, run the requested operation, and print its report.
+
+    See the module docstring for the command line contract.
+    """
+    arguments = build_parser().parse_args()
+    project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR", Path.cwd()))
+
+    try:
+        if arguments.subcommand == "record":
+            report = record_item(
+                ItemRecordRequest(
+                    plan_identifier=arguments.plan,
+                    item_identifier=arguments.item,
+                    status=arguments.status,
+                    roadmap_section_path=arguments.roadmap_section,
+                    title=arguments.title,
+                    track=arguments.track,
+                ),
+                project_root=project_root,
+            )
+        else:
+            report = open_work(
+                WorkOpenRequest(
+                    plan_identifier=arguments.plan,
+                    item_identifier=arguments.item,
+                    branch=arguments.branch,
+                    base_branch=arguments.base,
+                    session_url=arguments.session,
+                    pull_request_title=arguments.pull_request_title,
+                    pull_request_body=arguments.pull_request_body.read_text(),
+                ),
+                project_root=project_root,
+                remote=arguments.remote,
+            )
+    except BootstrapError as error:
+        print(f"{error.exit_code.name_for_a_caller}: {error}", file=sys.stderr)
+        return int(error.exit_code)
+
+    print(json.dumps(report.as_document()))
+    return int(report.exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -45,8 +45,8 @@ the document never has to decode an integer back into a meaning.
    load-mutate-dump round trip is rejected for the reason ``sync_manifest_status.py``
    records: even a format-preserving library re-flows wrapped strings, turning a
    one-field edit into an unreadable diff across the whole file. Every key, filename and
-   status this module writes is named once in :class:`PlanField`, :class:`PlanDocument`
-   and :class:`ItemStatus`, and every line is rendered by the field that owns it, so no
+   status this module writes is named once in :class:`ManifestKey`, :class:`PlanDocument`
+   and :class:`ItemStatus`, and every line is rendered by the key that owns it, so no
    caller - tests included - writes a second copy of a manifest line by hand.
 """
 
@@ -63,7 +63,7 @@ import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from pathlib import Path
 from typing import Any, ClassVar, Protocol
 
@@ -155,156 +155,168 @@ class PlanDocument(StrEnum):
         return f"{PLANS_DIRECTORY}/{plan_identifier}/{self.value}"
 
 
-@dataclass(frozen=True)
-class FieldSpecification:
+class ValueStyle(StrEnum):
     """
-    How one ``plan.yaml`` key is written, so no caller has to decide per field.
+    How a key's value is written, in YAML's own vocabulary.
+
+    Mutually exclusive by construction, which the two booleans this replaced could not
+    say: a value is written one of these ways, never two.
+    """
+
+    PLAIN = "plain"
+    """
+    A bare scalar on the key's own line.
+    """
+
+    DOUBLE_QUOTED = "double_quoted"
+    """
+    A quoted scalar, for prose that would otherwise need escaping.
+    """
+
+    BLOCK = "block"
+    """
+    A value written across the lines beneath the key - a folded scalar or a sequence.
+
+    Anything inserted after such a key would be swallowed by its value, so a new key
+    goes before the first block-styled one in an item rather than at the end.
+    """
+
+
+@dataclass(frozen=True)
+class KeySpecification:
+    """
+    How one ``plan.yaml`` key is written, so no caller has to decide per key.
     """
 
     key: str
     """
     The key as it appears in the manifest.
+
+    Named ``key`` rather than ``name`` for two reasons: it is YAML's own term for the
+    left-hand side of a mapping, and :class:`ManifestKey` mixes this class into an
+    ``Enum``, whose ``name`` is reserved for the member's own name.
     """
 
-    quoted: bool = False
+    style: ValueStyle = ValueStyle.PLAIN
     """
-    Whether the value is written as a double-quoted string.
-    """
-
-    spans_following_lines: bool = False
-    """
-    Whether the value may continue over the lines beneath it.
-
-    A folded or list value swallows anything inserted after it, so a new field is
-    inserted before the first such field in a block rather than at its end.
+    How this key's value is written.
     """
 
 
-class PlanField(StrEnum):
+class ManifestKey(KeySpecification, Enum):
     """
     The ``plan.yaml`` keys this module reads or writes, each carrying how it is written.
 
-    A member's value is its key, so it indexes a parsed manifest directly, while its
-    :class:`FieldSpecification` says whether that key's value is quoted or spans several
-    lines. That is what lets :meth:`render` produce a correct line from the field alone -
-    a caller never chooses quoting, and every assertion about a manifest line derives
-    from the same place the line is written. The full schema is documented in
-    ``plan-schema.md``; this enum carries the subset bootstrapping an item touches.
+    A member *is* a :class:`KeySpecification`, so ``isinstance`` and ``issubclass`` hold
+    and a key's own style is reached directly: ``ManifestKey.TITLE.style``. That is what
+    lets :meth:`render` produce a correct line from the key alone - a caller never
+    chooses quoting, and every assertion about a manifest line derives from the same
+    place the line is written. The full schema is documented in ``plan-schema.md``; this
+    enum carries the subset bootstrapping an item touches.
+
+    .. note::
+       A member's value is the argument tuple its specification is built from, not a
+       built :class:`KeySpecification`. Passing an instance is accepted silently by the
+       enum machinery and lands the whole instance in :attr:`KeySpecification.key`, so a
+       test asserts every key is a string.
     """
 
-    def __new__(cls, specification: FieldSpecification) -> PlanField:
-        """
-        Build a member whose string value is its key and which carries its specification.
-
-        :param specification: How this key is written.
-        :return: The member.
-        """
-        member = str.__new__(cls, specification.key)
-        member._value_ = specification.key
-        member.specification = specification
-        return member
-
-    IDENTIFIER = FieldSpecification(key="id")
+    IDENTIFIER = ("id",)
     """
     The item's own id, and the line that opens its block.
     """
 
-    TITLE = FieldSpecification(key="title", quoted=True)
+    TITLE = ("title", ValueStyle.DOUBLE_QUOTED)
     """
     What the item does, quoted because it is prose.
     """
 
-    BRANCH = FieldSpecification(key="branch")
+    BRANCH = ("branch",)
     """
     The git branch the work happens on, once one exists.
     """
 
-    REPOSITORY = FieldSpecification(key="repository")
+    REPOSITORY = ("repository",)
     """
     The item's own repository, overriding the plan's default.
     """
 
-    DEFAULT_REPOSITORY = FieldSpecification(key="default_repository")
+    DEFAULT_REPOSITORY = ("default_repository",)
     """
     The repository every item uses unless it sets its own.
     """
 
-    PULL_REQUEST_NUMBER = FieldSpecification(key="pull_request_number")
+    PULL_REQUEST_NUMBER = ("pull_request_number",)
     """
     The real pull request number, once one exists.
     """
 
-    TRACK = FieldSpecification(key="track")
+    TRACK = ("track",)
     """
     The parallel line of work the item belongs to.
     """
 
-    DEPENDS_ON = FieldSpecification(key="depends_on")
+    DEPENDS_ON = ("depends_on",)
     """
     The items this one stacks on, by id.
     """
 
-    STATUS = FieldSpecification(key="status")
+    STATUS = ("status",)
     """
     The session's own planning assessment - see :class:`ItemStatus`.
     """
 
-    SESSION = FieldSpecification(key="session")
+    SESSION = ("session",)
     """
     The session doing the work.
     """
 
-    NOTES = FieldSpecification(key="notes", spans_following_lines=True)
+    NOTES = ("notes", ValueStyle.BLOCK)
     """
     Freeform detail, routinely folded over many lines.
     """
 
-    BLOCKERS = FieldSpecification(key="blockers", spans_following_lines=True)
+    BLOCKERS = ("blockers", ValueStyle.BLOCK)
     """
-    Why the item is stuck, as a list.
+    Why the item is stuck, written as a sequence.
     """
 
-    ITEMS = FieldSpecification(key="items")
+    ITEMS = ("items",)
     """
     The manifest's top-level list of items.
     """
 
-    @property
-    def spans_following_lines(self) -> bool:
-        """
-        Whether this field's value may continue over the lines beneath it.
-        """
-        return self.specification.spans_following_lines
-
     def render(self, value: str, opening_the_item: bool = False) -> str:
         """
-        The manifest line setting this field to *value*, newline included.
+        The manifest line setting this key to *value*, newline included.
 
-        Quoting comes from the field's own specification rather than from the caller.
+        Quoting comes from the key's own style rather than from the caller.
 
         :param value: The value to write.
         :param opening_the_item: Whether this is the item block's first line, which
-            carries the list marker instead of the field indent.
+            carries the list marker instead of the key indent.
         :return: The rendered line.
         """
         prefix = ITEM_MARKER if opening_the_item else ITEM_FIELD_INDENT
-        written = f'"{value}"' if self.specification.quoted else value
-        return f"{prefix}{self.value}: {written}\n"
+        written = f'"{value}"' if self.style is ValueStyle.DOUBLE_QUOTED else value
+        return f"{prefix}{self.key}: {written}\n"
 
     @property
     def pattern(self) -> re.Pattern[str]:
         """
-        Matches this field wherever it already appears in an item block.
+        Matches this key wherever it already appears in an item block.
         """
-        return re.compile(rf"^\s*{re.escape(self.value)}:\s*.*$")
+        return re.compile(rf"^\s*{re.escape(self.key)}:\s*.*$")
 
 
-FOLDED_PLAN_FIELDS = frozenset(
-    field for field in PlanField if field.spans_following_lines
+BLOCK_STYLED_KEYS = frozenset(
+    manifest_key
+    for manifest_key in ManifestKey
+    if manifest_key.style is ValueStyle.BLOCK
 )
 """
-The item fields whose values routinely run over several lines, derived from the fields
-themselves rather than listed a second time.
+The keys whose values run over the lines beneath them, derived from the keys themselves
+rather than listed a second time.
 """
 
 
@@ -344,7 +356,7 @@ class ItemStatus(StrEnum):
     """
 
 
-ITEM_START_PATTERN = re.compile(rf"^\s*- {re.escape(PlanField.IDENTIFIER.value)}:")
+ITEM_START_PATTERN = re.compile(rf"^\s*- {re.escape(ManifestKey.IDENTIFIER.key)}:")
 """
 Matches the first line of an item block, which is always its ``id``.
 
@@ -356,12 +368,12 @@ TOP_LEVEL_KEY_PATTERN = re.compile(r"^\S")
 Matches a top-level ``plan.yaml`` key, which is where the last item block ends.
 """
 
-FOLDED_FIELD_PATTERN = re.compile(
-    rf"^\s*({'|'.join(sorted(field.value for field in FOLDED_PLAN_FIELDS))}):"
+BLOCK_VALUE_PATTERN = re.compile(
+    rf"^\s*({'|'.join(sorted(manifest_key.key for manifest_key in BLOCK_STYLED_KEYS))}):"
 )
 """
-Matches an item field whose value may run over the following lines, derived from
-:data:`FOLDED_PLAN_FIELDS` rather than listing those field names a second time.
+Matches a key whose value may run over the following lines, derived from
+:data:`BLOCK_STYLED_KEYS` rather than listing those keys a second time.
 """
 
 
@@ -509,13 +521,13 @@ class IncompleteNewItemError(BootstrapError):
     The item that would have been created.
     """
 
-    missing_fields: tuple[PlanField, ...]
+    missing_keys: tuple[ManifestKey, ...]
     """
-    The fields a new entry cannot omit that were not supplied.
+    The keys a new entry cannot omit that were not supplied.
     """
 
     def error_message(self) -> str:
-        missing = ", ".join(field.value for field in self.missing_fields)
+        missing = ", ".join(manifest_key.key for manifest_key in self.missing_keys)
         return (
             f"item {self.item_identifier!r} is not in the plan yet, so recording it "
             f"needs {missing}"
@@ -523,7 +535,8 @@ class IncompleteNewItemError(BootstrapError):
 
     def suggest_correction(self) -> str:
         return "Pass " + " and ".join(
-            f"--{field.value.replace('_', '-')}" for field in self.missing_fields
+            f"--{manifest_key.key.replace('_', '-')}"
+            for manifest_key in self.missing_keys
         )
 
 
@@ -750,8 +763,8 @@ class PlanDocuments:
         """
         item = self.item(item_identifier)
         return (
-            item.get(PlanField.REPOSITORY)
-            or self.manifest[PlanField.DEFAULT_REPOSITORY]
+            item.get(ManifestKey.REPOSITORY.key)
+            or self.manifest[ManifestKey.DEFAULT_REPOSITORY.key]
         )
 
     def item(self, item_identifier: str) -> dict[str, Any]:
@@ -762,9 +775,9 @@ class PlanDocuments:
         :raises UnknownItemError: If no item matches.
         :return: The item's mapping.
         """
-        for candidate in self.manifest.get(PlanField.ITEMS, []):
-            identifier = candidate.get(PlanField.IDENTIFIER) or candidate.get(
-                PlanField.BRANCH
+        for candidate in self.manifest.get(ManifestKey.ITEMS.key, []):
+            identifier = candidate.get(ManifestKey.IDENTIFIER.key) or candidate.get(
+                ManifestKey.BRANCH
             )
             if identifier == item_identifier:
                 return candidate
@@ -859,7 +872,7 @@ def locate_item_block(
     :raises UnknownItemError: If no block starts with that id.
     :return: The block's half-open line range.
     """
-    opener = f"- {PlanField.IDENTIFIER.value}:"
+    opener = f"- {ManifestKey.IDENTIFIER.key}:"
     for start, end in item_block_bounds(manifest_lines):
         if (
             manifest_lines[start].strip().removeprefix(opener).strip()
@@ -875,7 +888,7 @@ def apply_item_fields(
     manifest_text: str,
     plan_identifier: str,
     item_identifier: str,
-    fields_to_set: list[tuple[PlanField, str]],
+    fields_to_set: list[tuple[ManifestKey, str]],
 ) -> str:
     """
     Set each of *fields_to_set* on one item, patching an existing line or inserting a new
@@ -906,7 +919,7 @@ def apply_item_fields(
             (
                 index
                 for index in range(start, end)
-                if FOLDED_FIELD_PATTERN.match(lines[index])
+                if BLOCK_VALUE_PATTERN.match(lines[index])
             ),
             last_populated_line(lines, start, end) + 1,
         )
@@ -939,25 +952,25 @@ def render_new_item(request: ItemRecordRequest) -> str:
     :return: The block's text, newline-terminated.
     """
     missing = tuple(
-        field
-        for field, value in (
-            (PlanField.TITLE, request.title),
-            (PlanField.TRACK, request.track),
+        manifest_key
+        for manifest_key, value in (
+            (ManifestKey.TITLE, request.title),
+            (ManifestKey.TRACK, request.track),
         )
         if not value
     )
     if missing:
         raise IncompleteNewItemError(
-            item_identifier=request.item_identifier, missing_fields=missing
+            item_identifier=request.item_identifier, missing_keys=missing
         )
     body = [
-        (PlanField.TITLE, request.title),
-        (PlanField.BRANCH, "null"),
-        (PlanField.TRACK, request.track),
-        (PlanField.DEPENDS_ON, "[]"),
-        (PlanField.STATUS, request.status.value),
+        (ManifestKey.TITLE, request.title),
+        (ManifestKey.BRANCH, "null"),
+        (ManifestKey.TRACK, request.track),
+        (ManifestKey.DEPENDS_ON, "[]"),
+        (ManifestKey.STATUS, request.status.value),
     ]
-    return PlanField.IDENTIFIER.render(
+    return ManifestKey.IDENTIFIER.render(
         request.item_identifier, opening_the_item=True
     ) + "".join(field.render(value) for field, value in body)
 
@@ -1080,9 +1093,9 @@ class BootstrapReport:
             "dashboard_command": self.dashboard_command,
         }
         if self.branch is not None:
-            document[PlanField.BRANCH.value] = self.branch
+            document[ManifestKey.BRANCH.key] = self.branch
         if self.pull_request_number is not None:
-            document[PlanField.PULL_REQUEST_NUMBER.value] = self.pull_request_number
+            document[ManifestKey.PULL_REQUEST_NUMBER.key] = self.pull_request_number
             document["pull_request_url"] = self.pull_request_url
         return document
 
@@ -1107,7 +1120,7 @@ def record_item(request: ItemRecordRequest, project_root: Path) -> BootstrapRepo
             documents.manifest_text,
             request.plan_identifier,
             request.item_identifier,
-            [(PlanField.STATUS, request.status.value)],
+            [(ManifestKey.STATUS, request.status.value)],
         )
 
     roadmap_text = append_roadmap_section(
@@ -1452,10 +1465,10 @@ def open_work(
         request.plan_identifier,
         request.item_identifier,
         [
-            (PlanField.BRANCH, request.branch),
-            (PlanField.PULL_REQUEST_NUMBER, str(created.number)),
-            (PlanField.SESSION, request.session_url),
-            (PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+            (ManifestKey.BRANCH, request.branch),
+            (ManifestKey.PULL_REQUEST_NUMBER, str(created.number)),
+            (ManifestKey.SESSION, request.session_url),
+            (ManifestKey.STATUS, ItemStatus.IN_PROGRESS.value),
         ],
     )
     documents.save(manifest_text, documents.roadmap_text, project_root)

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -381,18 +381,44 @@ class ExitCode(IntEnum):
     """
     The process statuses this tool exits with.
 
-    Values are distinct rather than aligned with ``stack.py``'s own ``ExitCode``, which
-    is not reachable from ``main``; aligning the two belongs with whichever item brings
-    them into one package.
+    A distinct status per refusal lets a caller act on *which* failure happened without
+    parsing stderr. ``argparse`` supplies 2 for a usage error.
     """
 
     SUCCESS = 0
+    """
+    The operation ran and printed its report.
+    """
+
     UNKNOWN_PLAN = 3
+    """
+    No plan of that id is on the personal-notes branch.
+    """
+
     UNKNOWN_ITEM = 4
+    """
+    The plan exists but tracks no item of that id, and too little was given to add one.
+    """
+
     INCOMPLETE_NEW_ITEM = 5
+    """
+    Adding the item was asked for without every key a new entry must carry.
+    """
+
     BRANCH_ALREADY_PUBLISHED = 6
+    """
+    The branch is already on the remote, so opening the work would adopt someone's.
+    """
+
     PULL_REQUEST_DETAILS_MISSING = 7
+    """
+    Neither an existing pull request number nor the title and body to create one.
+    """
+
     PULL_REQUEST_REFUSED = 8
+    """
+    GitHub rejected the creation; its own message says why.
+    """
 
     @property
     def name_for_a_caller(self) -> str:

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -29,7 +29,8 @@ Usage:
         --status <status> --roadmap-section <file> [--title <title>] [--track <track>]
     python3 plan_item_bootstrap.py open --plan <plan-id> --item <item-id> \\
         --branch <branch> --base <branch> --session <url> \\
-        --pull-request-title <title> --pull-request-body <file>
+        (--pull-request-number <number> | --pull-request-title <title> \\
+         --pull-request-body <file>)
 
 Prints a one-line JSON report led by ``status`` and ``exit_code``, so a caller acting on
 the document never has to decode an integer back into a meaning.
@@ -43,7 +44,10 @@ the document never has to decode an integer back into a meaning.
    The manifest is edited by patching only the lines that change. A full YAML
    load-mutate-dump round trip is rejected for the reason ``sync_manifest_status.py``
    records: even a format-preserving library re-flows wrapped strings, turning a
-   one-field edit into an unreadable diff across the whole file.
+   one-field edit into an unreadable diff across the whole file. Every key, filename and
+   status this module writes is named once in :class:`PlanField`, :class:`PlanDocument`
+   and :class:`ItemStatus`, and rendered through :class:`ItemFieldLine`, so no caller -
+   tests included - writes a second copy of a manifest line by hand.
 """
 
 from __future__ import annotations
@@ -57,10 +61,11 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, ClassVar, Protocol
 
 import yaml
 
@@ -69,20 +74,164 @@ GITHUB_API_ROOT = "https://api.github.com"
 Where pull requests are created, overridable for a GitHub Enterprise host.
 """
 
-CONFIGURATION_SCRIPT = ".claude/hooks/resolve-personal-notes-config.sh"
+HOOKS_DIRECTORY = ".claude/hooks"
 """
-The shell script that owns personal-notes remote/branch resolution, sourced rather than
-reimplemented so the two can never disagree.
-"""
-
-SAVE_PLAN_SCRIPT = ".claude/hooks/save-plan.sh"
-"""
-The script that pushes an edited manifest and roadmap to the personal-notes branch.
+Where this repository keeps the scripts that read and write personal-notes data.
 """
 
-ITEM_START_PATTERN = re.compile(r"^\s*- id:")
+
+# %% the vocabulary a plan manifest is written in
+
+
+class HookScript(StrEnum):
+    """
+    The hook scripts this module drives, named once so a caller - a test installing them
+    into a scratch layout, or this module invoking one - never spells a filename itself.
+    """
+
+    CONFIGURATION = "resolve-personal-notes-config.sh"
+    SAVE_PLAN = "save-plan.sh"
+    PLAN_ITEM_BOOTSTRAP = "plan_item_bootstrap.py"
+
+    @property
+    def path(self) -> str:
+        """
+        The script's path from the project root.
+        """
+        return f"{HOOKS_DIRECTORY}/{self.value}"
+
+
+class PlanDocument(StrEnum):
+    """
+    The two files a plan is kept in, beside each other on the personal-notes branch.
+
+    ``roadmap.md`` is a fixed sibling filename rather than a configurable one, so both
+    names belong together here.
+    """
+
+    MANIFEST = "plan.yaml"
+    ROADMAP = "roadmap.md"
+
+
+class PlanField(StrEnum):
+    """
+    The ``plan.yaml`` keys this module reads or writes.
+
+    Naming them once is what lets a manifest line be rendered rather than typed: see
+    :class:`ItemFieldLine`. The full schema is documented in ``plan-schema.md``; this
+    enum carries the subset bootstrapping an item touches.
+    """
+
+    IDENTIFIER = "id"
+    TITLE = "title"
+    BRANCH = "branch"
+    REPOSITORY = "repository"
+    DEFAULT_REPOSITORY = "default_repository"
+    PULL_REQUEST_NUMBER = "pull_request_number"
+    TRACK = "track"
+    DEPENDS_ON = "depends_on"
+    STATUS = "status"
+    SESSION = "session"
+    NOTES = "notes"
+    BLOCKERS = "blockers"
+    ITEMS = "items"
+
+    @property
+    def spans_following_lines(self) -> bool:
+        """
+        Whether this field's value may continue over the lines beneath it.
+
+        A folded or list value swallows anything inserted after it, so a new field is
+        inserted before the first such field in the block rather than at its end.
+        """
+        return self in FOLDED_PLAN_FIELDS
+
+
+FOLDED_PLAN_FIELDS = frozenset({PlanField.NOTES, PlanField.BLOCKERS})
 """
-Matches the first line of an item block in ``plan.yaml``.
+The item fields whose values routinely run over several lines.
+"""
+
+
+class ItemStatus(StrEnum):
+    """
+    The statuses ``plan.yaml``'s ``status`` field accepts.
+
+    Mirrors ``build_dashboard.py``'s own enum, which lives in the plan-dashboard skill
+    directory and needs jinja2 and markdown to import, so a hook cannot reach it. The one
+    definition both share arrives with the package migration that gives them a home.
+    """
+
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    DEFERRED = "deferred"
+    DONE = "done"
+
+
+ITEM_FIELD_INDENT = "    "
+"""
+The indentation ``plan.yaml`` item fields carry, one level inside the list marker.
+"""
+
+ITEM_MARKER = "  - "
+"""
+What opens an item block, the list marker its first field sits behind.
+"""
+
+
+@dataclass(frozen=True)
+class ItemFieldLine:
+    """
+    One ``<field>: <value>`` line of an item block, as it is written in the manifest.
+
+    Rendering a line rather than writing one is what keeps this module's output and every
+    assertion about it derived from the same place.
+    """
+
+    field: PlanField
+    """
+    The key this line sets.
+    """
+
+    value: str
+    """
+    The value, already in the form YAML should carry it - see :meth:`quoting`.
+    """
+
+    @classmethod
+    def quoting(cls, field: PlanField, value: str) -> ItemFieldLine:
+        """
+        Build a line whose value is written as a double-quoted string.
+
+        :param field: The key to set.
+        :param value: The value to quote.
+        :return: The line.
+        """
+        return cls(field, f'"{value}"')
+
+    def render(self, opening_the_item: bool = False) -> str:
+        """
+        The line as it appears in the manifest, newline included.
+
+        :param opening_the_item: Whether this is the item block's first line, which
+            carries the list marker instead of the field indent.
+        :return: The rendered line.
+        """
+        prefix = ITEM_MARKER if opening_the_item else ITEM_FIELD_INDENT
+        return f"{prefix}{self.field.value}: {self.value}\n"
+
+    @property
+    def pattern(self) -> re.Pattern[str]:
+        """
+        Matches this line's field wherever it already appears in an item block.
+        """
+        return re.compile(rf"^\s*{re.escape(self.field.value)}:\s*.*$")
+
+
+ITEM_START_PATTERN = re.compile(rf"^\s*- {re.escape(PlanField.IDENTIFIER.value)}:")
+"""
+Matches the first line of an item block, which is always its ``id``.
 
 Same anchor ``sync_manifest_status.py`` uses to find item boundaries in raw text.
 """
@@ -92,32 +241,13 @@ TOP_LEVEL_KEY_PATTERN = re.compile(r"^\S")
 Matches a top-level ``plan.yaml`` key, which is where the last item block ends.
 """
 
-FOLDED_FIELD_PATTERN = re.compile(r"^\s*(notes|blockers):")
+FOLDED_FIELD_PATTERN = re.compile(
+    rf"^\s*({'|'.join(sorted(field.value for field in FOLDED_PLAN_FIELDS))}):"
+)
 """
-Matches an item field whose value may run over several following lines, so a new field
-is inserted before it rather than after.
+Matches an item field whose value may run over the following lines, derived from
+:data:`FOLDED_PLAN_FIELDS` rather than listing those field names a second time.
 """
-
-ITEM_FIELD_INDENT = "    "
-"""
-The indentation ``plan.yaml`` item fields carry, one level inside the list marker.
-"""
-
-
-class ItemStatus(StrEnum):
-    """
-    The statuses ``plan.yaml``'s ``status`` field accepts.
-
-    Mirrors ``build_dashboard.py``'s own enum, which lives in the plan-dashboard skill
-    directory and is not importable from here until ``development_tooling`` gives both a
-    shared home.
-    """
-
-    NOT_STARTED = "not_started"
-    IN_PROGRESS = "in_progress"
-    BLOCKED = "blocked"
-    DEFERRED = "deferred"
-    DONE = "done"
 
 
 class ExitCode(IntEnum):
@@ -151,75 +281,238 @@ class ExitCode(IntEnum):
 # %% failures
 
 
-class BootstrapError(Exception):
+@dataclass
+class BootstrapError(Exception, ABC):
     """
     Base for every refusal this tool reports, each carrying its own exit status.
+
+    Subclasses hold the context that explains the refusal as typed fields and compose it
+    into the message at construction, so no call site formats one. Mirrors ``krrood``'s
+    ``DataclassException`` idiom in a stdlib-only base, which is the boundary decision 12
+    records for this tooling.
     """
 
-    exit_code = ExitCode.SUCCESS
+    exit_code: ClassVar[ExitCode] = ExitCode.SUCCESS
     """
     The process status this refusal exits with.
     """
 
+    def __post_init__(self) -> None:
+        """
+        Compose the message from the subclass's own description and advice.
+        """
+        correction = self.suggest_correction()
+        message = self.error_message()
+        super().__init__(f"{message}\n{correction}" if correction else message)
 
+    def __str__(self) -> str:
+        """
+        The composed message, rather than a repr of the dataclass fields.
+        """
+        return Exception.__str__(self)
+
+    @abstractmethod
+    def error_message(self) -> str:
+        """
+        :return: What went wrong.
+        """
+
+    @abstractmethod
+    def suggest_correction(self) -> str:
+        """
+        :return: What to do about it, or an empty string when there is nothing to add.
+        """
+
+
+@dataclass
 class UnknownPlanError(BootstrapError):
     """
     Raised when the named plan has no manifest on the personal-notes branch.
     """
 
-    exit_code = ExitCode.UNKNOWN_PLAN
+    exit_code: ClassVar[ExitCode] = ExitCode.UNKNOWN_PLAN
+
+    plan_identifier: str
+    """
+    The plan that could not be found.
+    """
+
+    manifest_path: str
+    """
+    Where its manifest was looked for.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"no plan {self.plan_identifier!r} on the personal-notes branch "
+            f"({self.manifest_path} is not there)"
+        )
+
+    def suggest_correction(self) -> str:
+        return "Run /plan-create to bootstrap it, or check the plan id for a typo."
 
 
+@dataclass
 class UnknownItemError(BootstrapError):
     """
     Raised when the named item is absent from an otherwise resolvable plan.
     """
 
-    exit_code = ExitCode.UNKNOWN_ITEM
+    exit_code: ClassVar[ExitCode] = ExitCode.UNKNOWN_ITEM
+
+    plan_identifier: str
+    """
+    The plan that was searched.
+    """
+
+    item_identifier: str
+    """
+    The item that is not in it.
+    """
+
+    def error_message(self) -> str:
+        return f"no item {self.item_identifier!r} in plan {self.plan_identifier!r}"
+
+    def suggest_correction(self) -> str:
+        return (
+            "Record the item first - /add-plan-item decides where new work belongs, and "
+            "this tool's record operation writes the entry."
+        )
 
 
+@dataclass
 class IncompleteNewItemError(BootstrapError):
     """
     Raised when an item that does not exist yet is recorded without the fields needed to
     write its entry.
     """
 
-    exit_code = ExitCode.INCOMPLETE_NEW_ITEM
+    exit_code: ClassVar[ExitCode] = ExitCode.INCOMPLETE_NEW_ITEM
+
+    item_identifier: str
+    """
+    The item that would have been created.
+    """
+
+    missing_fields: tuple[PlanField, ...]
+    """
+    The fields a new entry cannot omit that were not supplied.
+    """
+
+    def error_message(self) -> str:
+        missing = ", ".join(field.value for field in self.missing_fields)
+        return (
+            f"item {self.item_identifier!r} is not in the plan yet, so recording it "
+            f"needs {missing}"
+        )
+
+    def suggest_correction(self) -> str:
+        return "Pass " + " and ".join(
+            f"--{field.value.replace('_', '-')}" for field in self.missing_fields
+        )
 
 
+@dataclass
 class BranchAlreadyPublishedError(BootstrapError):
     """
     Raised when the branch to open already exists on the remote, which means work is
     underway and overwriting it would discard someone's commits.
     """
 
-    exit_code = ExitCode.BRANCH_ALREADY_PUBLISHED
+    exit_code: ClassVar[ExitCode] = ExitCode.BRANCH_ALREADY_PUBLISHED
+
+    branch: str
+    """
+    The branch that is already published.
+    """
+
+    remote: str
+    """
+    The remote carrying it.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"branch {self.branch!r} already exists on {self.remote!r} - it is already "
+            "being worked, and republishing it would discard those commits"
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Pass --pull-request-number if its pull request already exists, or choose a "
+            "branch name that is not taken."
+        )
 
 
+@dataclass
 class PullRequestDetailsMissingError(BootstrapError):
     """
-    Raised when opening the work must create a pull request but was given neither a
-    title nor a body to create it from.
+    Raised when opening the work must create a pull request but was given nothing to
+    create it from.
     """
 
-    exit_code = ExitCode.PULL_REQUEST_DETAILS_MISSING
+    exit_code: ClassVar[ExitCode] = ExitCode.PULL_REQUEST_DETAILS_MISSING
+
+    item_identifier: str
+    """
+    The item whose work was being opened.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"opening {self.item_identifier!r} has to create a pull request, but was "
+            "given neither a title nor a body to create one from"
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Pass --pull-request-number for one you already created - which keeps your "
+            "identity on it - or --pull-request-title and --pull-request-body."
+        )
 
 
+@dataclass
 class PullRequestRefusedError(BootstrapError):
     """
     Raised when the remote declines to create the pull request.
     """
 
-    exit_code = ExitCode.PULL_REQUEST_REFUSED
+    exit_code: ClassVar[ExitCode] = ExitCode.PULL_REQUEST_REFUSED
+
+    detail: str
+    """
+    What the remote said.
+    """
+
+    def error_message(self) -> str:
+        return f"the remote refused to create the pull request: {self.detail}"
+
+    def suggest_correction(self) -> str:
+        return (
+            "The branch is published, so create the pull request yourself and re-run "
+            "with --pull-request-number."
+        )
 
 
+@dataclass
 class NotesBranchUnavailableError(BootstrapError):
     """
     Raised when the personal-notes branch cannot be fetched, so there is no plan data to
     read or write.
     """
 
-    exit_code = ExitCode.UNKNOWN_PLAN
+    exit_code: ClassVar[ExitCode] = ExitCode.UNKNOWN_PLAN
+
+    detail: str
+    """
+    Why the fetch failed.
+    """
+
+    def error_message(self) -> str:
+        return f"could not fetch the personal-notes branch: {self.detail}"
+
+    def suggest_correction(self) -> str:
+        return f"Run {HOOKS_DIRECTORY}/create-personal-notes-branch.sh first."
 
 
 # %% the plan on the personal-notes branch
@@ -247,17 +540,12 @@ def run_git(*arguments: str, project_root: Path) -> str:
 @dataclass(frozen=True)
 class PlanLocation:
     """
-    Where one plan's manifest and roadmap live, as the shell configuration resolves it.
+    Where one plan's documents live, as the shell configuration resolves it.
     """
 
-    manifest_path: str
+    paths: dict[PlanDocument, str]
     """
-    The manifest's path within the personal-notes branch.
-    """
-
-    roadmap_path: str
-    """
-    The roadmap's path within the personal-notes branch.
+    Each document's path within the personal-notes branch.
     """
 
     @classmethod
@@ -265,9 +553,10 @@ class PlanLocation:
         """
         Fetch the personal-notes branch and resolve *plan_identifier*'s paths within it.
 
-        Sources the shell configuration and calls its own fetch function rather than
-        re-deriving the remote/branch precedence, so this and the hook scripts can never
-        disagree about which branch a plan is on.
+        Sources the shell configuration and calls its own resolution functions rather
+        than re-deriving where a plan lives, so this and the hook scripts can never
+        disagree - which is also why a test asserting on those paths asks this rather
+        than spelling them out.
 
         :param plan_identifier: The plan's id.
         :param project_root: The repository to resolve within.
@@ -278,7 +567,8 @@ class PlanLocation:
             [
                 "bash",
                 "-c",
-                f'source "{CONFIGURATION_SCRIPT}" && fetch_personal_notes_branch && '
+                f'source "{HookScript.CONFIGURATION.path}" && '
+                "fetch_personal_notes_branch && "
                 'printf "%s\\n%s\\n" '
                 '"$(plan_manifest_path "$1")" "$(plan_roadmap_path "$1")"',
                 "plan_item_bootstrap",
@@ -290,11 +580,24 @@ class PlanLocation:
         )
         if probe.returncode != 0:
             raise NotesBranchUnavailableError(
-                "could not fetch the personal-notes branch: "
-                f"{probe.stderr.strip() or 'no personal-notes branch found'}"
+                detail=probe.stderr.strip() or "no personal-notes branch found"
             )
         manifest_path, roadmap_path = probe.stdout.strip().split("\n")
-        return cls(manifest_path=manifest_path, roadmap_path=roadmap_path)
+        return cls(
+            paths={
+                PlanDocument.MANIFEST: manifest_path,
+                PlanDocument.ROADMAP: roadmap_path,
+            }
+        )
+
+    def path_of(self, document: PlanDocument) -> str:
+        """
+        One document's path within the personal-notes branch.
+
+        :param document: The document wanted.
+        :return: Its path.
+        """
+        return self.paths[document]
 
 
 @dataclass(frozen=True)
@@ -332,24 +635,22 @@ class PlanDocuments:
         :return: The loaded documents.
         """
         location = PlanLocation.resolve(plan_identifier, project_root)
-        try:
-            manifest_text = run_git(
-                "show",
-                f"FETCH_HEAD:{location.manifest_path}",
-                project_root=project_root,
-            )
-            roadmap_text = run_git(
-                "show", f"FETCH_HEAD:{location.roadmap_path}", project_root=project_root
-            )
-        except subprocess.CalledProcessError as error:
-            raise UnknownPlanError(
-                f"no plan {plan_identifier!r} on the personal-notes branch "
-                f"({location.manifest_path} is not there)"
-            ) from error
+        contents = {}
+        for document in PlanDocument:
+            path = location.path_of(document)
+            try:
+                contents[document] = (
+                    run_git("show", f"FETCH_HEAD:{path}", project_root=project_root)
+                    + "\n"
+                )
+            except subprocess.CalledProcessError as error:
+                raise UnknownPlanError(
+                    plan_identifier=plan_identifier, manifest_path=path
+                ) from error
         return cls(
             plan_identifier=plan_identifier,
-            manifest_text=manifest_text + "\n",
-            roadmap_text=roadmap_text + "\n",
+            manifest_text=contents[PlanDocument.MANIFEST],
+            roadmap_text=contents[PlanDocument.ROADMAP],
         )
 
     @property
@@ -365,10 +666,13 @@ class PlanDocuments:
 
         :param item_identifier: The item's id.
         :raises UnknownItemError: If no item carries that id.
-        :return: The item's own ``repository``, or the plan's ``default_repository``.
+        :return: The item's own repository, or the plan's default one.
         """
         item = self.item(item_identifier)
-        return item.get("repository") or self.manifest["default_repository"]
+        return (
+            item.get(PlanField.REPOSITORY)
+            or self.manifest[PlanField.DEFAULT_REPOSITORY]
+        )
 
     def item(self, item_identifier: str) -> dict[str, Any]:
         """
@@ -378,11 +682,14 @@ class PlanDocuments:
         :raises UnknownItemError: If no item matches.
         :return: The item's mapping.
         """
-        for candidate in self.manifest.get("items", []):
-            if (candidate.get("id") or candidate.get("branch")) == item_identifier:
+        for candidate in self.manifest.get(PlanField.ITEMS, []):
+            identifier = candidate.get(PlanField.IDENTIFIER) or candidate.get(
+                PlanField.BRANCH
+            )
+            if identifier == item_identifier:
                 return candidate
         raise UnknownItemError(
-            f"no item {item_identifier!r} in plan {self.plan_identifier!r}"
+            plan_identifier=self.plan_identifier, item_identifier=item_identifier
         )
 
     def has_item(self, item_identifier: str) -> bool:
@@ -409,19 +716,21 @@ class PlanDocuments:
         """
         with tempfile.TemporaryDirectory() as scratch_directory:
             scratch = Path(scratch_directory)
-            manifest_file = scratch / "plan.yaml"
-            roadmap_file = scratch / "roadmap.md"
-            manifest_file.write_text(manifest_text)
-            roadmap_file.write_text(roadmap_text)
+            written = {
+                PlanDocument.MANIFEST: manifest_text,
+                PlanDocument.ROADMAP: roadmap_text,
+            }
+            for document, content in written.items():
+                (scratch / document.value).write_text(content)
             subprocess.run(
                 [
                     "bash",
-                    SAVE_PLAN_SCRIPT,
+                    HookScript.SAVE_PLAN.path,
                     self.plan_identifier,
                     "--manifest",
-                    str(manifest_file),
+                    str(scratch / PlanDocument.MANIFEST.value),
                     "--roadmap",
-                    str(roadmap_file),
+                    str(scratch / PlanDocument.ROADMAP.value),
                 ],
                 cwd=project_root,
                 capture_output=True,
@@ -455,56 +764,67 @@ def item_block_bounds(manifest_lines: list[str]) -> list[tuple[int, int]]:
         ),
         len(manifest_lines),
     )
-    boundaries = starts[1:] + [end_of_items]
-    return list(zip(starts, boundaries))
+    return list(zip(starts, starts[1:] + [end_of_items]))
 
 
 def locate_item_block(
-    manifest_lines: list[str], item_identifier: str
+    manifest_lines: list[str], plan_identifier: str, item_identifier: str
 ) -> tuple[int, int]:
     """
     Find one item's block within the manifest text.
 
     :param manifest_lines: The manifest, split into lines.
+    :param plan_identifier: The plan being edited, for the error message.
     :param item_identifier: The item's id.
     :raises UnknownItemError: If no block starts with that id.
     :return: The block's half-open line range.
     """
+    opener = f"- {PlanField.IDENTIFIER.value}:"
     for start, end in item_block_bounds(manifest_lines):
-        if manifest_lines[start].strip().removeprefix("- id:").strip() == (
-            item_identifier
+        if (
+            manifest_lines[start].strip().removeprefix(opener).strip()
+            == item_identifier
         ):
             return start, end
     raise UnknownItemError(
-        f"no item block for {item_identifier!r} in the manifest text"
+        plan_identifier=plan_identifier, item_identifier=item_identifier
     )
 
 
 def apply_item_fields(
-    manifest_text: str, item_identifier: str, fields: dict[str, str]
+    manifest_text: str,
+    plan_identifier: str,
+    item_identifier: str,
+    lines_to_set: list[ItemFieldLine],
 ) -> str:
     """
-    Set each of *fields* on one item, patching an existing line or inserting a new one.
+    Set each of *lines_to_set* on one item, patching an existing line or inserting a new
+    one.
 
     Every other line is left byte-for-byte untouched, so comments, key order, string
     wrapping and quoting all survive.
 
     :param manifest_text: The manifest's raw text.
+    :param plan_identifier: The plan being edited.
     :param item_identifier: The item to patch.
-    :param fields: Field names mapped to their rendered YAML values.
+    :param lines_to_set: The field lines to write.
     :raises UnknownItemError: If the item has no block in the text.
     :return: The patched manifest text.
     """
     lines = manifest_text.split("\n")
-    start, end = locate_item_block(lines, item_identifier)
-    for field_name, value in fields.items():
-        field_pattern = re.compile(rf"^(\s*{re.escape(field_name)}:\s*).*$")
+    start, end = locate_item_block(lines, plan_identifier, item_identifier)
+    for field_line in lines_to_set:
+        rendered = field_line.render().rstrip("\n")
         existing = next(
-            (index for index in range(start, end) if field_pattern.match(lines[index])),
+            (
+                index
+                for index in range(start, end)
+                if field_line.pattern.match(lines[index])
+            ),
             None,
         )
         if existing is not None:
-            lines[existing] = f"{ITEM_FIELD_INDENT}{field_name}: {value}"
+            lines[existing] = rendered
             continue
         insertion = next(
             (
@@ -514,7 +834,7 @@ def apply_item_fields(
             ),
             last_populated_line(lines, start, end) + 1,
         )
-        lines.insert(insertion, f"{ITEM_FIELD_INDENT}{field_name}: {value}")
+        lines.insert(insertion, rendered)
         end += 1
     return "\n".join(lines)
 
@@ -542,18 +862,28 @@ def render_new_item(request: ItemRecordRequest) -> str:
     :raises IncompleteNewItemError: If a field a new entry cannot omit is missing.
     :return: The block's text, newline-terminated.
     """
-    if not request.title or not request.track:
-        raise IncompleteNewItemError(
-            f"item {request.item_identifier!r} is not in the plan yet, so recording it "
-            "needs --title and --track"
+    missing = tuple(
+        field
+        for field, value in (
+            (PlanField.TITLE, request.title),
+            (PlanField.TRACK, request.track),
         )
-    return (
-        f"  - id: {request.item_identifier}\n"
-        f'{ITEM_FIELD_INDENT}title: "{request.title}"\n'
-        f"{ITEM_FIELD_INDENT}branch: null\n"
-        f"{ITEM_FIELD_INDENT}track: {request.track}\n"
-        f"{ITEM_FIELD_INDENT}depends_on: []\n"
-        f"{ITEM_FIELD_INDENT}status: {request.status.value}\n"
+        if not value
+    )
+    if missing:
+        raise IncompleteNewItemError(
+            item_identifier=request.item_identifier, missing_fields=missing
+        )
+    opening = ItemFieldLine(PlanField.IDENTIFIER, request.item_identifier)
+    body = [
+        ItemFieldLine.quoting(PlanField.TITLE, request.title),
+        ItemFieldLine(PlanField.BRANCH, "null"),
+        ItemFieldLine(PlanField.TRACK, request.track),
+        ItemFieldLine(PlanField.DEPENDS_ON, "[]"),
+        ItemFieldLine(PlanField.STATUS, request.status.value),
+    ]
+    return opening.render(opening_the_item=True) + "".join(
+        line.render() for line in body
     )
 
 
@@ -675,9 +1005,9 @@ class BootstrapReport:
             "dashboard_command": self.dashboard_command,
         }
         if self.branch is not None:
-            document["branch"] = self.branch
+            document[PlanField.BRANCH.value] = self.branch
         if self.pull_request_number is not None:
-            document["pull_request_number"] = self.pull_request_number
+            document[PlanField.PULL_REQUEST_NUMBER.value] = self.pull_request_number
             document["pull_request_url"] = self.pull_request_url
         return document
 
@@ -700,8 +1030,9 @@ def record_item(request: ItemRecordRequest, project_root: Path) -> BootstrapRepo
     else:
         manifest_text = apply_item_fields(
             documents.manifest_text,
+            request.plan_identifier,
             request.item_identifier,
-            {"status": request.status.value},
+            [ItemFieldLine(PlanField.STATUS, request.status.value)],
         )
 
     roadmap_text = append_roadmap_section(
@@ -852,7 +1183,7 @@ class GitHubPullRequestOpener:
                 created = json.loads(response.read())
         except urllib.error.HTTPError as error:
             raise PullRequestRefusedError(
-                f"GitHub refused to create the pull request ({error.code}): "
+                detail=f"{error.code} "
                 f"{error.read().decode(errors='replace').strip()}"
             ) from error
         return CreatedPullRequest(
@@ -873,8 +1204,8 @@ class GitHubPullRequestOpener:
 @dataclass(frozen=True)
 class WorkOpenRequest:
     """
-    What opening an item's work needs: the branch to create and the pull request to
-    open on it.
+    What opening an item's work needs: the branch to create and the pull request to open
+    on it.
     """
 
     plan_identifier: str
@@ -920,9 +1251,9 @@ class WorkOpenRequest:
     A pull request the caller has already created, recorded instead of creating one.
 
     A pull request this module creates is attributed to the app the request is proxied
-    through rather than to the person running it, so a caller that can create one under
-    its own identity should, and hand the number here. Left unset, the module creates it
-    - which is what an unattended run with no session has to do.
+    through rather than to the person whose work it is, so a caller that can create one
+    under its own identity should, and hand the number here. Left unset, the module
+    creates it - which is what an unattended run with no session has to do.
     """
 
 
@@ -981,11 +1312,7 @@ class WorkOpener:
             project_root=self.project_root,
         )
         run_git(
-            "push",
-            "-u",
-            self.remote,
-            request.branch,
-            project_root=self.project_root,
+            "push", "-u", self.remote, request.branch, project_root=self.project_root
         )
 
 
@@ -1011,6 +1338,8 @@ def open_work(
     :param pull_request_opener: What creates the pull request, defaulting to GitHub.
     :param remote: The remote to publish the branch to.
     :raises UnknownItemError: If the plan does not track the item yet.
+    :raises PullRequestDetailsMissingError: If it must create a pull request but was
+        given nothing to create one from.
     :raises BranchAlreadyPublishedError: If the branch already exists on the remote.
     :raises PullRequestRefusedError: If the pull request could not be created.
     :return: What was opened.
@@ -1019,10 +1348,7 @@ def open_work(
     if request.pull_request_number is None and not (
         request.pull_request_title and request.pull_request_body
     ):
-        raise PullRequestDetailsMissingError(
-            "opening the work has to create the pull request, so it needs a title and "
-            "a body - or a --pull-request-number for one already created"
-        )
+        raise PullRequestDetailsMissingError(item_identifier=request.item_identifier)
     documents = PlanDocuments.load(request.plan_identifier, project_root)
     repository = documents.repository_for(request.item_identifier)
 
@@ -1030,10 +1356,7 @@ def open_work(
     if not work.branch_is_published(request.branch):
         work.publish(request)
     elif request.pull_request_number is None:
-        raise BranchAlreadyPublishedError(
-            f"branch {request.branch!r} already exists on {remote!r} - it is already "
-            "being worked, and republishing it would discard those commits"
-        )
+        raise BranchAlreadyPublishedError(branch=request.branch, remote=remote)
 
     created = (
         CreatedPullRequest(number=request.pull_request_number, html_url=None)
@@ -1051,13 +1374,14 @@ def open_work(
 
     manifest_text = apply_item_fields(
         documents.manifest_text,
+        request.plan_identifier,
         request.item_identifier,
-        {
-            "branch": request.branch,
-            "pull_request_number": str(created.number),
-            "session": request.session_url,
-            "status": ItemStatus.IN_PROGRESS.value,
-        },
+        [
+            ItemFieldLine(PlanField.BRANCH, request.branch),
+            ItemFieldLine(PlanField.PULL_REQUEST_NUMBER, str(created.number)),
+            ItemFieldLine(PlanField.SESSION, request.session_url),
+            ItemFieldLine(PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+        ],
     )
     documents.save(manifest_text, documents.roadmap_text, project_root)
     return BootstrapReport(

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -18,7 +18,8 @@ Two operations, so each caller depends only on the surface it uses:
 ``open``
     Create the branch, publish it, open the draft pull request, then write ``branch``,
     ``session`` and ``pull_request_number`` back onto the item and flip it to
-    ``in_progress``.
+    ``in_progress``. A caller that has already created the pull request passes
+    ``--pull-request-number`` and only the recording happens.
 
 ``open`` runs before ``record`` when both are wanted: the pull request number does not
 exist until the pull request does.
@@ -133,6 +134,7 @@ class ExitCode(IntEnum):
     UNKNOWN_ITEM = 4
     INCOMPLETE_NEW_ITEM = 5
     BRANCH_ALREADY_PUBLISHED = 6
+    PULL_REQUEST_DETAILS_MISSING = 7
     PULL_REQUEST_REFUSED = 8
 
     @property
@@ -192,6 +194,15 @@ class BranchAlreadyPublishedError(BootstrapError):
     """
 
     exit_code = ExitCode.BRANCH_ALREADY_PUBLISHED
+
+
+class PullRequestDetailsMissingError(BootstrapError):
+    """
+    Raised when opening the work must create a pull request but was given neither a
+    title nor a body to create it from.
+    """
+
+    exit_code = ExitCode.PULL_REQUEST_DETAILS_MISSING
 
 
 class PullRequestRefusedError(BootstrapError):
@@ -768,9 +779,9 @@ class CreatedPullRequest:
     Its number.
     """
 
-    html_url: str
+    html_url: str | None
     """
-    Where to read it.
+    Where to read it, unset when the caller supplied the number and already has it.
     """
 
 
@@ -894,14 +905,24 @@ class WorkOpenRequest:
     it is, and a script that guessed would record something wrong in silence.
     """
 
-    pull_request_title: str
+    pull_request_title: str | None = None
     """
-    The pull request's title.
+    The pull request's title, needed only when this module creates it.
     """
 
-    pull_request_body: str
+    pull_request_body: str | None = None
     """
-    The pull request's description.
+    The pull request's description, needed only when this module creates it.
+    """
+
+    pull_request_number: int | None = None
+    """
+    A pull request the caller has already created, recorded instead of creating one.
+
+    A pull request this module creates is attributed to the app the request is proxied
+    through rather than to the person running it, so a caller that can create one under
+    its own identity should, and hand the number here. Left unset, the module creates it
+    - which is what an unattended run with no session has to do.
     """
 
 
@@ -995,24 +1016,36 @@ def open_work(
     :return: What was opened.
     """
     opener = pull_request_opener or GitHubPullRequestOpener()
+    if request.pull_request_number is None and not (
+        request.pull_request_title and request.pull_request_body
+    ):
+        raise PullRequestDetailsMissingError(
+            "opening the work has to create the pull request, so it needs a title and "
+            "a body - or a --pull-request-number for one already created"
+        )
     documents = PlanDocuments.load(request.plan_identifier, project_root)
     repository = documents.repository_for(request.item_identifier)
 
     work = WorkOpener(project_root=project_root, remote=remote)
-    if work.branch_is_published(request.branch):
+    if not work.branch_is_published(request.branch):
+        work.publish(request)
+    elif request.pull_request_number is None:
         raise BranchAlreadyPublishedError(
             f"branch {request.branch!r} already exists on {remote!r} - it is already "
             "being worked, and republishing it would discard those commits"
         )
 
-    work.publish(request)
-    created = opener.open_pull_request(
-        PullRequestRequest(
-            repository=repository,
-            title=request.pull_request_title,
-            body=request.pull_request_body,
-            head=request.branch,
-            base=request.base_branch,
+    created = (
+        CreatedPullRequest(number=request.pull_request_number, html_url=None)
+        if request.pull_request_number is not None
+        else opener.open_pull_request(
+            PullRequestRequest(
+                repository=repository,
+                title=request.pull_request_title,
+                body=request.pull_request_body,
+                head=request.branch,
+                base=request.base_branch,
+            )
         )
     )
 
@@ -1069,8 +1102,19 @@ def build_parser() -> argparse.ArgumentParser:
     open_command.add_argument("--branch", required=True)
     open_command.add_argument("--base", required=True)
     open_command.add_argument("--session", required=True)
-    open_command.add_argument("--pull-request-title", required=True)
-    open_command.add_argument("--pull-request-body", required=True, type=Path)
+    open_command.add_argument(
+        "--pull-request-title", help="Required unless --pull-request-number is given"
+    )
+    open_command.add_argument(
+        "--pull-request-body",
+        type=Path,
+        help="Required unless --pull-request-number is given",
+    )
+    open_command.add_argument(
+        "--pull-request-number",
+        type=int,
+        help="Record a pull request the caller already created, instead of creating one",
+    )
     open_command.add_argument("--remote", default="origin")
 
     return parser
@@ -1107,7 +1151,12 @@ def main() -> int:
                     base_branch=arguments.base,
                     session_url=arguments.session,
                     pull_request_title=arguments.pull_request_title,
-                    pull_request_body=arguments.pull_request_body.read_text(),
+                    pull_request_body=(
+                        arguments.pull_request_body.read_text()
+                        if arguments.pull_request_body
+                        else None
+                    ),
+                    pull_request_number=arguments.pull_request_number,
                 ),
                 project_root=project_root,
                 remote=arguments.remote,

--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -46,8 +46,8 @@ the document never has to decode an integer back into a meaning.
    records: even a format-preserving library re-flows wrapped strings, turning a
    one-field edit into an unreadable diff across the whole file. Every key, filename and
    status this module writes is named once in :class:`PlanField`, :class:`PlanDocument`
-   and :class:`ItemStatus`, and rendered through :class:`ItemFieldLine`, so no caller -
-   tests included - writes a second copy of a manifest line by hand.
+   and :class:`ItemStatus`, and every line is rendered by the field that owns it, so no
+   caller - tests included - writes a second copy of a manifest line by hand.
 """
 
 from __future__ import annotations
@@ -79,95 +79,13 @@ HOOKS_DIRECTORY = ".claude/hooks"
 Where this repository keeps the scripts that read and write personal-notes data.
 """
 
-
-# %% the vocabulary a plan manifest is written in
-
-
-class HookScript(StrEnum):
-    """
-    The hook scripts this module drives, named once so a caller - a test installing them
-    into a scratch layout, or this module invoking one - never spells a filename itself.
-    """
-
-    CONFIGURATION = "resolve-personal-notes-config.sh"
-    SAVE_PLAN = "save-plan.sh"
-    PLAN_ITEM_BOOTSTRAP = "plan_item_bootstrap.py"
-
-    @property
-    def path(self) -> str:
-        """
-        The script's path from the project root.
-        """
-        return f"{HOOKS_DIRECTORY}/{self.value}"
-
-
-class PlanDocument(StrEnum):
-    """
-    The two files a plan is kept in, beside each other on the personal-notes branch.
-
-    ``roadmap.md`` is a fixed sibling filename rather than a configurable one, so both
-    names belong together here.
-    """
-
-    MANIFEST = "plan.yaml"
-    ROADMAP = "roadmap.md"
-
-
-class PlanField(StrEnum):
-    """
-    The ``plan.yaml`` keys this module reads or writes.
-
-    Naming them once is what lets a manifest line be rendered rather than typed: see
-    :class:`ItemFieldLine`. The full schema is documented in ``plan-schema.md``; this
-    enum carries the subset bootstrapping an item touches.
-    """
-
-    IDENTIFIER = "id"
-    TITLE = "title"
-    BRANCH = "branch"
-    REPOSITORY = "repository"
-    DEFAULT_REPOSITORY = "default_repository"
-    PULL_REQUEST_NUMBER = "pull_request_number"
-    TRACK = "track"
-    DEPENDS_ON = "depends_on"
-    STATUS = "status"
-    SESSION = "session"
-    NOTES = "notes"
-    BLOCKERS = "blockers"
-    ITEMS = "items"
-
-    @property
-    def spans_following_lines(self) -> bool:
-        """
-        Whether this field's value may continue over the lines beneath it.
-
-        A folded or list value swallows anything inserted after it, so a new field is
-        inserted before the first such field in the block rather than at its end.
-        """
-        return self in FOLDED_PLAN_FIELDS
-
-
-FOLDED_PLAN_FIELDS = frozenset({PlanField.NOTES, PlanField.BLOCKERS})
+PLANS_DIRECTORY = ".claude/personal/plans"
 """
-The item fields whose values routinely run over several lines.
+Where plans live on the personal-notes branch.
+
+Mirrors ``PLANS_DIR`` in ``resolve-personal-notes-config.sh``, which is the shell half of
+the same tooling; a test holds the two equal so the mirror cannot drift.
 """
-
-
-class ItemStatus(StrEnum):
-    """
-    The statuses ``plan.yaml``'s ``status`` field accepts.
-
-    Mirrors ``build_dashboard.py``'s own enum, which lives in the plan-dashboard skill
-    directory and needs jinja2 and markdown to import, so a hook cannot reach it. The one
-    definition both share arrives with the package migration that gives them a home.
-    """
-
-    NOT_STARTED = "not_started"
-    IN_PROGRESS = "in_progress"
-    BLOCKED = "blocked"
-    DEFERRED = "deferred"
-    DONE = "done"
-
 
 ITEM_FIELD_INDENT = "    "
 """
@@ -180,53 +98,250 @@ What opens an item block, the list marker its first field sits behind.
 """
 
 
+# %% the vocabulary a plan manifest is written in
+
+
+class HookScript(StrEnum):
+    """
+    The hook scripts this module drives, named once so a caller - a test installing them
+    into a scratch layout, or this module invoking one - never spells a filename itself.
+    """
+
+    CONFIGURATION = "resolve-personal-notes-config.sh"
+    """
+    Resolves the personal-notes remote and branch, and fetches it.
+    """
+
+    SAVE_PLAN = "save-plan.sh"
+    """
+    Pushes an edited manifest and roadmap to the personal-notes branch.
+    """
+
+    PLAN_ITEM_BOOTSTRAP = "plan_item_bootstrap.py"
+    """
+    This module, which a caller invokes by path.
+    """
+
+    @property
+    def path(self) -> str:
+        """
+        The script's path from the project root.
+        """
+        return f"{HOOKS_DIRECTORY}/{self.value}"
+
+
+class PlanDocument(StrEnum):
+    """
+    The two files a plan is kept in, beside each other on the personal-notes branch.
+    """
+
+    MANIFEST = "plan.yaml"
+    """
+    The structured manifest, whose schema ``plan-schema.md`` documents.
+    """
+
+    ROADMAP = "roadmap.md"
+    """
+    The narrative companion, a fixed sibling filename rather than a configurable one.
+    """
+
+    def path_within_notes_branch(self, plan_identifier: str) -> str:
+        """
+        Where this document lives for one plan.
+
+        :param plan_identifier: The plan's id.
+        :return: The path, relative to the personal-notes branch's root.
+        """
+        return f"{PLANS_DIRECTORY}/{plan_identifier}/{self.value}"
+
+
 @dataclass(frozen=True)
-class ItemFieldLine:
+class FieldSpecification:
     """
-    One ``<field>: <value>`` line of an item block, as it is written in the manifest.
-
-    Rendering a line rather than writing one is what keeps this module's output and every
-    assertion about it derived from the same place.
+    How one ``plan.yaml`` key is written, so no caller has to decide per field.
     """
 
-    field: PlanField
+    key: str
     """
-    The key this line sets.
-    """
-
-    value: str
-    """
-    The value, already in the form YAML should carry it - see :meth:`quoting`.
+    The key as it appears in the manifest.
     """
 
-    @classmethod
-    def quoting(cls, field: PlanField, value: str) -> ItemFieldLine:
+    quoted: bool = False
+    """
+    Whether the value is written as a double-quoted string.
+    """
+
+    spans_following_lines: bool = False
+    """
+    Whether the value may continue over the lines beneath it.
+
+    A folded or list value swallows anything inserted after it, so a new field is
+    inserted before the first such field in a block rather than at its end.
+    """
+
+
+class PlanField(StrEnum):
+    """
+    The ``plan.yaml`` keys this module reads or writes, each carrying how it is written.
+
+    A member's value is its key, so it indexes a parsed manifest directly, while its
+    :class:`FieldSpecification` says whether that key's value is quoted or spans several
+    lines. That is what lets :meth:`render` produce a correct line from the field alone -
+    a caller never chooses quoting, and every assertion about a manifest line derives
+    from the same place the line is written. The full schema is documented in
+    ``plan-schema.md``; this enum carries the subset bootstrapping an item touches.
+    """
+
+    def __new__(cls, specification: FieldSpecification) -> PlanField:
         """
-        Build a line whose value is written as a double-quoted string.
+        Build a member whose string value is its key and which carries its specification.
 
-        :param field: The key to set.
-        :param value: The value to quote.
-        :return: The line.
+        :param specification: How this key is written.
+        :return: The member.
         """
-        return cls(field, f'"{value}"')
+        member = str.__new__(cls, specification.key)
+        member._value_ = specification.key
+        member.specification = specification
+        return member
 
-    def render(self, opening_the_item: bool = False) -> str:
+    IDENTIFIER = FieldSpecification(key="id")
+    """
+    The item's own id, and the line that opens its block.
+    """
+
+    TITLE = FieldSpecification(key="title", quoted=True)
+    """
+    What the item does, quoted because it is prose.
+    """
+
+    BRANCH = FieldSpecification(key="branch")
+    """
+    The git branch the work happens on, once one exists.
+    """
+
+    REPOSITORY = FieldSpecification(key="repository")
+    """
+    The item's own repository, overriding the plan's default.
+    """
+
+    DEFAULT_REPOSITORY = FieldSpecification(key="default_repository")
+    """
+    The repository every item uses unless it sets its own.
+    """
+
+    PULL_REQUEST_NUMBER = FieldSpecification(key="pull_request_number")
+    """
+    The real pull request number, once one exists.
+    """
+
+    TRACK = FieldSpecification(key="track")
+    """
+    The parallel line of work the item belongs to.
+    """
+
+    DEPENDS_ON = FieldSpecification(key="depends_on")
+    """
+    The items this one stacks on, by id.
+    """
+
+    STATUS = FieldSpecification(key="status")
+    """
+    The session's own planning assessment - see :class:`ItemStatus`.
+    """
+
+    SESSION = FieldSpecification(key="session")
+    """
+    The session doing the work.
+    """
+
+    NOTES = FieldSpecification(key="notes", spans_following_lines=True)
+    """
+    Freeform detail, routinely folded over many lines.
+    """
+
+    BLOCKERS = FieldSpecification(key="blockers", spans_following_lines=True)
+    """
+    Why the item is stuck, as a list.
+    """
+
+    ITEMS = FieldSpecification(key="items")
+    """
+    The manifest's top-level list of items.
+    """
+
+    @property
+    def spans_following_lines(self) -> bool:
         """
-        The line as it appears in the manifest, newline included.
+        Whether this field's value may continue over the lines beneath it.
+        """
+        return self.specification.spans_following_lines
 
+    def render(self, value: str, opening_the_item: bool = False) -> str:
+        """
+        The manifest line setting this field to *value*, newline included.
+
+        Quoting comes from the field's own specification rather than from the caller.
+
+        :param value: The value to write.
         :param opening_the_item: Whether this is the item block's first line, which
             carries the list marker instead of the field indent.
         :return: The rendered line.
         """
         prefix = ITEM_MARKER if opening_the_item else ITEM_FIELD_INDENT
-        return f"{prefix}{self.field.value}: {self.value}\n"
+        written = f'"{value}"' if self.specification.quoted else value
+        return f"{prefix}{self.value}: {written}\n"
 
     @property
     def pattern(self) -> re.Pattern[str]:
         """
-        Matches this line's field wherever it already appears in an item block.
+        Matches this field wherever it already appears in an item block.
         """
-        return re.compile(rf"^\s*{re.escape(self.field.value)}:\s*.*$")
+        return re.compile(rf"^\s*{re.escape(self.value)}:\s*.*$")
+
+
+FOLDED_PLAN_FIELDS = frozenset(
+    field for field in PlanField if field.spans_following_lines
+)
+"""
+The item fields whose values routinely run over several lines, derived from the fields
+themselves rather than listed a second time.
+"""
+
+
+class ItemStatus(StrEnum):
+    """
+    The statuses ``plan.yaml``'s ``status`` field accepts.
+
+    Mirrors ``build_dashboard.py``'s own enum, which lives in the plan-dashboard skill
+    directory and needs jinja2 and markdown to import, so a hook cannot reach it. A test
+    holds the two equal; the one definition both share arrives with the package
+    migration that gives them a home.
+    """
+
+    NOT_STARTED = "not_started"
+    """
+    Nothing has begun.
+    """
+
+    IN_PROGRESS = "in_progress"
+    """
+    The work is underway - what bootstrapping an item sets.
+    """
+
+    BLOCKED = "blocked"
+    """
+    Something outside the item has to move first.
+    """
+
+    DEFERRED = "deferred"
+    """
+    Deliberately parked rather than stuck.
+    """
+
+    DONE = "done"
+    """
+    Landed.
+    """
 
 
 ITEM_START_PATTERN = re.compile(rf"^\s*- {re.escape(PlanField.IDENTIFIER.value)}:")
@@ -537,67 +652,32 @@ def run_git(*arguments: str, project_root: Path) -> str:
     return result.stdout.rstrip("\n")
 
 
-@dataclass(frozen=True)
-class PlanLocation:
+def fetch_notes_branch(project_root: Path) -> None:
     """
-    Where one plan's documents live, as the shell configuration resolves it.
+    Fetch the personal-notes branch, leaving ``FETCH_HEAD`` pointing at it.
+
+    Sources the shell configuration and calls its own fetch function rather than
+    re-deriving the remote and branch precedence, so this and the hook scripts can never
+    disagree about which branch a plan is on. Where a plan sits *within* that branch is
+    :meth:`PlanDocument.path_within_notes_branch`'s to say.
+
+    :param project_root: The repository to fetch within.
+    :raises NotesBranchUnavailableError: If the notes branch cannot be fetched.
     """
-
-    paths: dict[PlanDocument, str]
-    """
-    Each document's path within the personal-notes branch.
-    """
-
-    @classmethod
-    def resolve(cls, plan_identifier: str, project_root: Path) -> PlanLocation:
-        """
-        Fetch the personal-notes branch and resolve *plan_identifier*'s paths within it.
-
-        Sources the shell configuration and calls its own resolution functions rather
-        than re-deriving where a plan lives, so this and the hook scripts can never
-        disagree - which is also why a test asserting on those paths asks this rather
-        than spelling them out.
-
-        :param plan_identifier: The plan's id.
-        :param project_root: The repository to resolve within.
-        :raises NotesBranchUnavailableError: If the notes branch cannot be fetched.
-        :return: The resolved location, with ``FETCH_HEAD`` left pointing at the branch.
-        """
-        probe = subprocess.run(
-            [
-                "bash",
-                "-c",
-                f'source "{HookScript.CONFIGURATION.path}" && '
-                "fetch_personal_notes_branch && "
-                'printf "%s\\n%s\\n" '
-                '"$(plan_manifest_path "$1")" "$(plan_roadmap_path "$1")"',
-                "plan_item_bootstrap",
-                plan_identifier,
-            ],
-            cwd=project_root,
-            capture_output=True,
-            text=True,
+    probe = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{HookScript.CONFIGURATION.path}" && fetch_personal_notes_branch',
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        raise NotesBranchUnavailableError(
+            detail=probe.stderr.strip() or "no personal-notes branch found"
         )
-        if probe.returncode != 0:
-            raise NotesBranchUnavailableError(
-                detail=probe.stderr.strip() or "no personal-notes branch found"
-            )
-        manifest_path, roadmap_path = probe.stdout.strip().split("\n")
-        return cls(
-            paths={
-                PlanDocument.MANIFEST: manifest_path,
-                PlanDocument.ROADMAP: roadmap_path,
-            }
-        )
-
-    def path_of(self, document: PlanDocument) -> str:
-        """
-        One document's path within the personal-notes branch.
-
-        :param document: The document wanted.
-        :return: Its path.
-        """
-        return self.paths[document]
 
 
 @dataclass(frozen=True)
@@ -634,10 +714,10 @@ class PlanDocuments:
         :raises UnknownPlanError: If the plan has no manifest on the branch.
         :return: The loaded documents.
         """
-        location = PlanLocation.resolve(plan_identifier, project_root)
+        fetch_notes_branch(project_root)
         contents = {}
         for document in PlanDocument:
-            path = location.path_of(document)
+            path = document.path_within_notes_branch(plan_identifier)
             try:
                 contents[document] = (
                     run_git("show", f"FETCH_HEAD:{path}", project_root=project_root)
@@ -795,10 +875,10 @@ def apply_item_fields(
     manifest_text: str,
     plan_identifier: str,
     item_identifier: str,
-    lines_to_set: list[ItemFieldLine],
+    fields_to_set: list[tuple[PlanField, str]],
 ) -> str:
     """
-    Set each of *lines_to_set* on one item, patching an existing line or inserting a new
+    Set each of *fields_to_set* on one item, patching an existing line or inserting a new
     one.
 
     Every other line is left byte-for-byte untouched, so comments, key order, string
@@ -807,20 +887,16 @@ def apply_item_fields(
     :param manifest_text: The manifest's raw text.
     :param plan_identifier: The plan being edited.
     :param item_identifier: The item to patch.
-    :param lines_to_set: The field lines to write.
+    :param fields_to_set: Each field to write, with the value to write to it.
     :raises UnknownItemError: If the item has no block in the text.
     :return: The patched manifest text.
     """
     lines = manifest_text.split("\n")
     start, end = locate_item_block(lines, plan_identifier, item_identifier)
-    for field_line in lines_to_set:
-        rendered = field_line.render().rstrip("\n")
+    for field, value in fields_to_set:
+        rendered = field.render(value).rstrip("\n")
         existing = next(
-            (
-                index
-                for index in range(start, end)
-                if field_line.pattern.match(lines[index])
-            ),
+            (index for index in range(start, end) if field.pattern.match(lines[index])),
             None,
         )
         if existing is not None:
@@ -874,17 +950,16 @@ def render_new_item(request: ItemRecordRequest) -> str:
         raise IncompleteNewItemError(
             item_identifier=request.item_identifier, missing_fields=missing
         )
-    opening = ItemFieldLine(PlanField.IDENTIFIER, request.item_identifier)
     body = [
-        ItemFieldLine.quoting(PlanField.TITLE, request.title),
-        ItemFieldLine(PlanField.BRANCH, "null"),
-        ItemFieldLine(PlanField.TRACK, request.track),
-        ItemFieldLine(PlanField.DEPENDS_ON, "[]"),
-        ItemFieldLine(PlanField.STATUS, request.status.value),
+        (PlanField.TITLE, request.title),
+        (PlanField.BRANCH, "null"),
+        (PlanField.TRACK, request.track),
+        (PlanField.DEPENDS_ON, "[]"),
+        (PlanField.STATUS, request.status.value),
     ]
-    return opening.render(opening_the_item=True) + "".join(
-        line.render() for line in body
-    )
+    return PlanField.IDENTIFIER.render(
+        request.item_identifier, opening_the_item=True
+    ) + "".join(field.render(value) for field, value in body)
 
 
 def append_item(manifest_text: str, block: str) -> str:
@@ -1032,7 +1107,7 @@ def record_item(request: ItemRecordRequest, project_root: Path) -> BootstrapRepo
             documents.manifest_text,
             request.plan_identifier,
             request.item_identifier,
-            [ItemFieldLine(PlanField.STATUS, request.status.value)],
+            [(PlanField.STATUS, request.status.value)],
         )
 
     roadmap_text = append_roadmap_section(
@@ -1377,10 +1452,10 @@ def open_work(
         request.plan_identifier,
         request.item_identifier,
         [
-            ItemFieldLine(PlanField.BRANCH, request.branch),
-            ItemFieldLine(PlanField.PULL_REQUEST_NUMBER, str(created.number)),
-            ItemFieldLine(PlanField.SESSION, request.session_url),
-            ItemFieldLine(PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+            (PlanField.BRANCH, request.branch),
+            (PlanField.PULL_REQUEST_NUMBER, str(created.number)),
+            (PlanField.SESSION, request.session_url),
+            (PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
         ],
     )
     documents.save(manifest_text, documents.roadmap_text, project_root)

--- a/.claude/hooks/resolve-personal-notes-config.sh
+++ b/.claude/hooks/resolve-personal-notes-config.sh
@@ -293,6 +293,12 @@ STARTER_NOTES_FILE="${SETUP_PERSONAL_NOTES_DIRECTORY}/starter-notes.md"
 # duplication risk, just for a hook script instead of a plan-dashboard one.
 SAVE_PLAN_SCRIPT=".claude/hooks/save-plan.sh"
 
+# PLAN_ITEM_BOOTSTRAP_SCRIPT: same reasoning again, for the script that opens
+# an item's branch and draft pull request and records its manifest entry -
+# invoked from plan-item-kickoff/SKILL.md and add-plan-item/SKILL.md, so it is
+# a path this codebase controls rather than one a human types once.
+PLAN_ITEM_BOOTSTRAP_SCRIPT=".claude/hooks/plan_item_bootstrap.py"
+
 # GITHUB_LIST_PULL_REQUESTS_TOOL / GITHUB_PULL_REQUEST_READ_TOOL: the two
 # MCP tools every pr_data.json-gathering procedure in this system calls
 # (see pr-data-fetching.md), named once here so every doc references the

--- a/.claude/hooks/tests/fixtures/bootstrap-plan.yaml
+++ b/.claude/hooks/tests/fixtures/bootstrap-plan.yaml
@@ -1,0 +1,36 @@
+schema_version: 1
+id: test-plan
+title: "A plan under test"
+description: >
+  One paragraph.
+default_repository: an-owner/a-repository
+tracking_issue: 7
+
+waves:
+  - id: immediate
+    name: "Immediate"
+
+tracks:
+  - id: a-track
+    name: "A track"
+    wave: immediate
+
+items:
+  - id: an-existing-item
+    branch: null
+    title: "An item that has not been started"
+    track: a-track
+    depends_on: []
+    status: not_started
+    notes: >
+      A folded note whose wrapping must survive untouched, because a full YAML
+      round trip re-flows it.
+
+  - id: a-second-item
+    branch: some/other-branch
+    title: "An item that is already underway"
+    pull_request_number: 12
+    track: a-track
+    depends_on: []
+    status: in_progress
+    session: https://example.invalid/session_second

--- a/.claude/hooks/tests/fixtures/bootstrap-roadmap.md
+++ b/.claude/hooks/tests/fixtures/bootstrap-roadmap.md
@@ -1,0 +1,3 @@
+# test-plan — roadmap
+
+Narrative companion to plan.yaml.

--- a/.claude/hooks/tests/scratch_repository.py
+++ b/.claude/hooks/tests/scratch_repository.py
@@ -65,6 +65,13 @@ class ScratchRepository:
     The bare repository the notes branch is pushed to and fetched from.
     """
 
+    work_remote_path: Path | None = None
+    """
+    The bare repository standing in for the project's own remote, created only by
+    :meth:`add_work_remote` so a test that never publishes a work branch has no
+    ``origin`` it did not ask for.
+    """
+
     @classmethod
     def create(cls, parent_directory: Path) -> ScratchRepository:
         """
@@ -201,6 +208,19 @@ class ScratchRepository:
         self.run_git("commit", "--quiet", "-m", f"Set {relative_path}", cwd=checkout)
         self.run_git("push", "--quiet", "origin", NOTES_BRANCH, cwd=checkout)
         shutil.rmtree(checkout)
+
+    def add_work_remote(self) -> Path:
+        """
+        Create a bare repository standing in for the project's own remote and register
+        it as ``origin``, for a hook that publishes a work branch rather than notes.
+
+        :return: The work remote's path.
+        """
+        self.work_remote_path = initialize_bare_repository(
+            self.project_root.parent / "work-remote.git"
+        )
+        self.run_git("remote", "add", "origin", str(self.work_remote_path))
+        return self.work_remote_path
 
     def resolve_notes_remote_to(self, remote: Path | None = None) -> None:
         """

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -6,10 +6,9 @@ Run against the local scratch repository fixture rather than a real remote, and 
 a recording pull request opener rather than GitHub, so nothing here needs network access
 or credentials.
 
-Every manifest line asserted on is rendered by the production :class:`ItemFieldLine`
-rather than written out again here, and every path is resolved by the production
-:class:`PlanLocation`, so a test cannot pin a second, independently-drifting copy of the
-manifest's own vocabulary.
+Every manifest line asserted on is rendered by the :class:`PlanField` that owns it, and
+every path by the :class:`PlanDocument` that lives at it, so a test cannot pin a second,
+independently-drifting copy of the manifest's own vocabulary.
 """
 
 from __future__ import annotations
@@ -22,18 +21,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
+import yaml
 
 import plan_item_bootstrap
 from plan_item_bootstrap import (
+    PLANS_DIRECTORY,
     CreatedPullRequest,
     ExitCode,
     HookScript,
-    ItemFieldLine,
     ItemRecordRequest,
     ItemStatus,
     PlanDocument,
     PlanField,
-    PlanLocation,
     PullRequestRequest,
     UnknownItemError,
     UnknownPlanError,
@@ -49,8 +48,7 @@ PLAN_IDENTIFIER = "test-plan"
 
 PLAN_MANIFEST = (FIXTURES_DIRECTORY / "bootstrap-plan.yaml").read_text()
 """
-The manifest every test starts from, kept as a real ``.yaml`` file rather than a string
-in this module so it is edited and validated as YAML.
+The manifest every test starts from.
 """
 
 PLAN_ROADMAP = (FIXTURES_DIRECTORY / "bootstrap-roadmap.md").read_text()
@@ -59,20 +57,35 @@ The roadmap every test starts from.
 """
 
 EXISTING_ITEM = "an-existing-item"
+"""
+The fixture item the plan already tracks, with no branch of its own yet.
+"""
+
 NEW_ITEM = "a-brand-new-item"
+"""
+An item the fixture plan does not track, for the entry-creating path.
+"""
+
 NEW_BRANCH = "claude/a-new-branch"
+"""
+The branch opening the work publishes.
+"""
+
 SESSION_URL = "https://example.invalid/session_first"
+"""
+The session recorded on an item whose work was opened.
+"""
 
 
 def manifest_line(field: PlanField, value: str) -> str:
     """
-    One manifest line as the production renderer writes it.
+    One manifest line as the field that owns it writes it.
 
     :param field: The key the line sets.
     :param value: The value it carries.
     :return: The rendered line.
     """
-    return ItemFieldLine(field, value).render()
+    return field.render(value)
 
 
 # %% fixtures
@@ -144,10 +157,10 @@ def bootstrap_repository(scratch_repository: ScratchRepository) -> ScratchReposi
     scratch_repository.commit_everything("initial commit")
     scratch_repository.publish_notes_branch(
         {
-            f".claude/personal/plans/{PLAN_IDENTIFIER}/{PlanDocument.MANIFEST}": (
+            PlanDocument.MANIFEST.path_within_notes_branch(PLAN_IDENTIFIER): (
                 PLAN_MANIFEST
             ),
-            f".claude/personal/plans/{PLAN_IDENTIFIER}/{PlanDocument.ROADMAP}": (
+            PlanDocument.ROADMAP.path_within_notes_branch(PLAN_IDENTIFIER): (
                 PLAN_ROADMAP
             ),
         }
@@ -162,8 +175,8 @@ def published_plan(repository: ScratchRepository) -> dict[PlanDocument, str]:
     Read the plan's documents as they actually are on the notes branch, rather than what
     a run reported.
 
-    Resolves where they live through the production resolver, so this never states a
-    plan's layout independently of the configuration that owns it.
+    Asks each document where it lives, so this never states a plan's layout
+    independently of the code that owns it.
 
     :param repository: The scratch repository whose notes remote to read.
     :return: Each document's content.
@@ -171,9 +184,10 @@ def published_plan(repository: ScratchRepository) -> dict[PlanDocument, str]:
     checkout = repository.project_root.parent / "published-plan-checkout"
     shutil.rmtree(checkout, ignore_errors=True)
     repository.clone_notes_branch(checkout)
-    location = PlanLocation.resolve(PLAN_IDENTIFIER, repository.project_root)
     return {
-        document: (checkout / location.path_of(document)).read_text()
+        document: (
+            checkout / document.path_within_notes_branch(PLAN_IDENTIFIER)
+        ).read_text()
         for document in PlanDocument
     }
 
@@ -300,8 +314,8 @@ def test_recording_a_new_item_appends_it_to_the_manifest(
     manifest = published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
     assert manifest.startswith(PLAN_MANIFEST)
     assert manifest.endswith(
-        ItemFieldLine(PlanField.IDENTIFIER, NEW_ITEM).render(opening_the_item=True)
-        + ItemFieldLine.quoting(PlanField.TITLE, "A brand new item").render()
+        PlanField.IDENTIFIER.render(NEW_ITEM, opening_the_item=True)
+        + manifest_line(PlanField.TITLE, "A brand new item")
         + manifest_line(PlanField.BRANCH, "null")
         + manifest_line(PlanField.TRACK, "a-track")
         + manifest_line(PlanField.DEPENDS_ON, "[]")
@@ -537,6 +551,55 @@ def test_a_rendered_field_line_matches_how_a_real_manifest_writes_it():
         manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value) in PLAN_MANIFEST
     )
     assert manifest_line(PlanField.TRACK, "a-track") in PLAN_MANIFEST
+
+
+def test_a_field_quotes_its_own_value_when_its_specification_says_to():
+    """
+    Quoting is the field's to decide, so no caller has to know that a title is prose and
+    a track is a bare identifier.
+    """
+    assert PlanField.TITLE.render("A brand new item").endswith(': "A brand new item"\n')
+    assert PlanField.TRACK.render("a-track").endswith(": a-track\n")
+    assert PlanField.TITLE.specification.quoted
+    assert not PlanField.TRACK.specification.quoted
+
+
+def test_a_field_indexes_a_parsed_manifest_by_its_own_key():
+    """
+    A member's string value stays its key, so carrying a specification never costs the
+    caller a ``.value`` when reading parsed YAML.
+    """
+    item = yaml.safe_load(PLAN_MANIFEST)[PlanField.ITEMS][0]
+    assert item[PlanField.IDENTIFIER] == EXISTING_ITEM
+    assert item[PlanField.STATUS] == ItemStatus.NOT_STARTED
+
+
+def test_the_plans_directory_matches_the_shell_configuration_that_owns_it(
+    bootstrap_repository: ScratchRepository,
+):
+    """
+    ``PLANS_DIRECTORY`` mirrors ``PLANS_DIR`` in the shell configuration; this is what
+    stops the mirror drifting, since the two are edited in different files.
+    """
+    resolved = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{HookScript.CONFIGURATION.path}" && '
+            'printf "%s\\n%s\\n" "${PLANS_DIR}" "$(plan_manifest_path "$1")"',
+            "test",
+            PLAN_IDENTIFIER,
+        ],
+        cwd=bootstrap_repository.project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    plans_directory, manifest_path = resolved.stdout.strip().split("\n")
+    assert plans_directory == PLANS_DIRECTORY
+    assert manifest_path == PlanDocument.MANIFEST.path_within_notes_branch(
+        PLAN_IDENTIFIER
+    )
 
 
 def test_only_the_fields_that_run_over_lines_are_treated_as_folded():

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -5,11 +5,18 @@ work.
 Run against the local scratch repository fixture rather than a real remote, and against
 a recording pull request opener rather than GitHub, so nothing here needs network access
 or credentials.
+
+Every manifest line asserted on is rendered by the production :class:`ItemFieldLine`
+rather than written out again here, and every path is resolved by the production
+:class:`PlanLocation`, so a test cannot pin a second, independently-drifting copy of the
+manifest's own vocabulary.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -20,8 +27,13 @@ import plan_item_bootstrap
 from plan_item_bootstrap import (
     CreatedPullRequest,
     ExitCode,
+    HookScript,
+    ItemFieldLine,
     ItemRecordRequest,
     ItemStatus,
+    PlanDocument,
+    PlanField,
+    PlanLocation,
     PullRequestRequest,
     UnknownItemError,
     UnknownPlanError,
@@ -31,50 +43,36 @@ from plan_item_bootstrap import (
 )
 from scratch_repository import WORK_BRANCH, ScratchRepository
 
+FIXTURES_DIRECTORY = Path(__file__).parent / "fixtures"
+
 PLAN_IDENTIFIER = "test-plan"
 
-PLAN_MANIFEST = """schema_version: 1
-id: test-plan
-title: "A plan under test"
-description: >
-  One paragraph.
-default_repository: an-owner/a-repository
-tracking_issue: 7
-
-waves:
-  - id: immediate
-    name: "Immediate"
-
-tracks:
-  - id: a-track
-    name: "A track"
-    wave: immediate
-
-items:
-  - id: an-existing-item
-    branch: null
-    title: "An item that has not been started"
-    track: a-track
-    depends_on: []
-    status: not_started
-    notes: >
-      A folded note whose wrapping must survive untouched, because a full YAML
-      round trip re-flows it.
-
-  - id: a-second-item
-    branch: some/other-branch
-    title: "An item that is already underway"
-    pull_request_number: 12
-    track: a-track
-    depends_on: []
-    status: in_progress
-    session: https://example.invalid/session_second
+PLAN_MANIFEST = (FIXTURES_DIRECTORY / "bootstrap-plan.yaml").read_text()
+"""
+The manifest every test starts from, kept as a real ``.yaml`` file rather than a string
+in this module so it is edited and validated as YAML.
 """
 
-PLAN_ROADMAP = """# test-plan — roadmap
-
-Narrative companion to plan.yaml.
+PLAN_ROADMAP = (FIXTURES_DIRECTORY / "bootstrap-roadmap.md").read_text()
 """
+The roadmap every test starts from.
+"""
+
+EXISTING_ITEM = "an-existing-item"
+NEW_ITEM = "a-brand-new-item"
+NEW_BRANCH = "claude/a-new-branch"
+SESSION_URL = "https://example.invalid/session_first"
+
+
+def manifest_line(field: PlanField, value: str) -> str:
+    """
+    One manifest line as the production renderer writes it.
+
+    :param field: The key the line sets.
+    :param value: The value it carries.
+    :return: The rendered line.
+    """
+    return ItemFieldLine(field, value).render()
 
 
 # %% fixtures
@@ -124,9 +122,7 @@ class RefusingPullRequestOpener:
         :param request: The pull request that will not be created.
         :raises PullRequestRefusedError: Always.
         """
-        raise plan_item_bootstrap.PullRequestRefusedError(
-            "the remote refused to create the pull request"
-        )
+        raise plan_item_bootstrap.PullRequestRefusedError(detail="422 refused")
 
 
 @pytest.fixture
@@ -139,17 +135,21 @@ def bootstrap_repository(scratch_repository: ScratchRepository) -> ScratchReposi
     :return: The same repository, ready to bootstrap an item in.
     """
     scratch_repository.install_hook_scripts(
-        "resolve-personal-notes-config.sh",
-        "save-plan.sh",
+        HookScript.CONFIGURATION.value,
+        HookScript.SAVE_PLAN.value,
         "plan_manifest_tools.py",
-        "plan_item_bootstrap.py",
+        HookScript.PLAN_ITEM_BOOTSTRAP.value,
     )
     scratch_repository.write("README.md", "scratch repo\n")
     scratch_repository.commit_everything("initial commit")
     scratch_repository.publish_notes_branch(
         {
-            f".claude/personal/plans/{PLAN_IDENTIFIER}/plan.yaml": PLAN_MANIFEST,
-            f".claude/personal/plans/{PLAN_IDENTIFIER}/roadmap.md": PLAN_ROADMAP,
+            f".claude/personal/plans/{PLAN_IDENTIFIER}/{PlanDocument.MANIFEST}": (
+                PLAN_MANIFEST
+            ),
+            f".claude/personal/plans/{PLAN_IDENTIFIER}/{PlanDocument.ROADMAP}": (
+                PLAN_ROADMAP
+            ),
         }
     )
     scratch_repository.resolve_notes_remote_to()
@@ -157,158 +157,58 @@ def bootstrap_repository(scratch_repository: ScratchRepository) -> ScratchReposi
     return scratch_repository
 
 
-def published_plan(repository: ScratchRepository) -> tuple[str, str]:
+def published_plan(repository: ScratchRepository) -> dict[PlanDocument, str]:
     """
-    Read the manifest and roadmap actually on the notes branch, rather than what a run
-    reported.
+    Read the plan's documents as they actually are on the notes branch, rather than what
+    a run reported.
+
+    Resolves where they live through the production resolver, so this never states a
+    plan's layout independently of the configuration that owns it.
 
     :param repository: The scratch repository whose notes remote to read.
-    :return: The manifest text and the roadmap text.
+    :return: Each document's content.
     """
     checkout = repository.project_root.parent / "published-plan-checkout"
-    if checkout.exists():
-        subprocess.run(["rm", "-rf", str(checkout)], check=True)
+    shutil.rmtree(checkout, ignore_errors=True)
     repository.clone_notes_branch(checkout)
-    plan_directory = checkout / ".claude" / "personal" / "plans" / PLAN_IDENTIFIER
-    return (
-        (plan_directory / "plan.yaml").read_text(),
-        (plan_directory / "roadmap.md").read_text(),
-    )
+    location = PlanLocation.resolve(PLAN_IDENTIFIER, repository.project_root)
+    return {
+        document: (checkout / location.path_of(document)).read_text()
+        for document in PlanDocument
+    }
 
 
 def roadmap_section(repository: ScratchRepository, content: str) -> Path:
     """
     Write a roadmap section to a scratch file, the way a caller hands one over.
 
+    The file is named after its content so that a test overriding the default section
+    cannot have its file overwritten by the default one being built alongside it.
+
     :param repository: The scratch repository to write within.
     :param content: The section's markdown.
     :return: The path written to.
     """
-    return repository.write("section.md", content)
+    digest = hashlib.sha256(content.encode()).hexdigest()[:12]
+    return repository.write(f"sections/{digest}.md", content)
 
 
-# %% recording an item
+def record_request(repository: ScratchRepository, **overrides: object):
+    """
+    Build a record request, overriding only what a test cares about.
 
-
-def test_recording_an_existing_item_sets_its_status(
-    bootstrap_repository: ScratchRepository,
-):
-    result = record_item(
-        ItemRecordRequest(
-            plan_identifier=PLAN_IDENTIFIER,
-            item_identifier="an-existing-item",
-            status=ItemStatus.IN_PROGRESS,
-            roadmap_section_path=roadmap_section(
-                bootstrap_repository, "## A new section\n"
-            ),
-        ),
-        project_root=bootstrap_repository.project_root,
+    :param repository: The scratch repository the roadmap section is written in.
+    :param overrides: Fields to replace on the default request.
+    :return: The request.
+    """
+    defaults = dict(
+        plan_identifier=PLAN_IDENTIFIER,
+        item_identifier=EXISTING_ITEM,
+        status=ItemStatus.IN_PROGRESS,
+        roadmap_section_path=roadmap_section(repository, "## A new section\n"),
     )
-
-    assert result.exit_code is ExitCode.SUCCESS
-    manifest, _ = published_plan(bootstrap_repository)
-    assert "    status: in_progress\n" in manifest
-
-
-def test_recording_leaves_every_other_manifest_line_byte_identical(
-    bootstrap_repository: ScratchRepository,
-):
-    record_item(
-        ItemRecordRequest(
-            plan_identifier=PLAN_IDENTIFIER,
-            item_identifier="an-existing-item",
-            status=ItemStatus.IN_PROGRESS,
-            roadmap_section_path=roadmap_section(bootstrap_repository, "## Section\n"),
-        ),
-        project_root=bootstrap_repository.project_root,
-    )
-
-    manifest, _ = published_plan(bootstrap_repository)
-    expected = PLAN_MANIFEST.replace(
-        "    status: not_started\n", "    status: in_progress\n", 1
-    )
-    assert manifest == expected
-
-
-def test_recording_appends_the_roadmap_section_without_rewriting_the_roadmap(
-    bootstrap_repository: ScratchRepository,
-):
-    record_item(
-        ItemRecordRequest(
-            plan_identifier=PLAN_IDENTIFIER,
-            item_identifier="an-existing-item",
-            status=ItemStatus.IN_PROGRESS,
-            roadmap_section_path=roadmap_section(
-                bootstrap_repository, "## An appended section\n\nIts body.\n"
-            ),
-        ),
-        project_root=bootstrap_repository.project_root,
-    )
-
-    _, roadmap = published_plan(bootstrap_repository)
-    assert roadmap.startswith(PLAN_ROADMAP)
-    assert roadmap.endswith("## An appended section\n\nIts body.\n")
-
-
-def test_recording_a_new_item_appends_it_to_the_manifest(
-    bootstrap_repository: ScratchRepository,
-):
-    record_item(
-        ItemRecordRequest(
-            plan_identifier=PLAN_IDENTIFIER,
-            item_identifier="a-brand-new-item",
-            title="A brand new item",
-            track="a-track",
-            status=ItemStatus.NOT_STARTED,
-            roadmap_section_path=roadmap_section(bootstrap_repository, "## New\n"),
-        ),
-        project_root=bootstrap_repository.project_root,
-    )
-
-    manifest, _ = published_plan(bootstrap_repository)
-    assert manifest.startswith(PLAN_MANIFEST)
-    assert manifest.endswith(
-        "  - id: a-brand-new-item\n"
-        '    title: "A brand new item"\n'
-        "    branch: null\n"
-        "    track: a-track\n"
-        "    depends_on: []\n"
-        "    status: not_started\n"
-    )
-
-
-def test_recording_a_new_item_without_a_title_is_refused(
-    bootstrap_repository: ScratchRepository,
-):
-    with pytest.raises(plan_item_bootstrap.IncompleteNewItemError):
-        record_item(
-            ItemRecordRequest(
-                plan_identifier=PLAN_IDENTIFIER,
-                item_identifier="a-brand-new-item",
-                track="a-track",
-                status=ItemStatus.NOT_STARTED,
-                roadmap_section_path=roadmap_section(bootstrap_repository, "## New\n"),
-            ),
-            project_root=bootstrap_repository.project_root,
-        )
-
-
-def test_recording_against_an_unknown_plan_is_refused(
-    bootstrap_repository: ScratchRepository,
-):
-    with pytest.raises(UnknownPlanError):
-        record_item(
-            ItemRecordRequest(
-                plan_identifier="no-such-plan",
-                item_identifier="an-existing-item",
-                status=ItemStatus.IN_PROGRESS,
-                roadmap_section_path=roadmap_section(bootstrap_repository, "## S\n"),
-            ),
-            project_root=bootstrap_repository.project_root,
-        )
-
-
-# %% opening the work
+    defaults.update(overrides)
+    return ItemRecordRequest(**defaults)
 
 
 def open_request(**overrides: object) -> WorkOpenRequest:
@@ -320,15 +220,125 @@ def open_request(**overrides: object) -> WorkOpenRequest:
     """
     defaults = dict(
         plan_identifier=PLAN_IDENTIFIER,
-        item_identifier="an-existing-item",
-        branch="claude/a-new-branch",
+        item_identifier=EXISTING_ITEM,
+        branch=NEW_BRANCH,
         base_branch=WORK_BRANCH,
-        session_url="https://example.invalid/session_first",
+        session_url=SESSION_URL,
         pull_request_title="An item that has not been started",
         pull_request_body="What it does.",
     )
     defaults.update(overrides)
     return WorkOpenRequest(**defaults)
+
+
+# %% recording an item
+
+
+def test_recording_an_existing_item_sets_its_status(
+    bootstrap_repository: ScratchRepository,
+):
+    result = record_item(
+        record_request(bootstrap_repository),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    assert result.exit_code is ExitCode.SUCCESS
+    published = published_plan(bootstrap_repository)
+    assert (
+        manifest_line(PlanField.STATUS, ItemStatus.IN_PROGRESS.value)
+        in published[PlanDocument.MANIFEST]
+    )
+
+
+def test_recording_leaves_every_other_manifest_line_byte_identical(
+    bootstrap_repository: ScratchRepository,
+):
+    record_item(
+        record_request(bootstrap_repository),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    expected = PLAN_MANIFEST.replace(
+        manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value),
+        manifest_line(PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+        1,
+    )
+    assert published_plan(bootstrap_repository)[PlanDocument.MANIFEST] == expected
+
+
+def test_recording_appends_the_roadmap_section_without_rewriting_the_roadmap(
+    bootstrap_repository: ScratchRepository,
+):
+    section = "## An appended section\n\nIts body.\n"
+    record_item(
+        record_request(
+            bootstrap_repository,
+            roadmap_section_path=roadmap_section(bootstrap_repository, section),
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    roadmap = published_plan(bootstrap_repository)[PlanDocument.ROADMAP]
+    assert roadmap.startswith(PLAN_ROADMAP)
+    assert roadmap.endswith(section)
+
+
+def test_recording_a_new_item_appends_it_to_the_manifest(
+    bootstrap_repository: ScratchRepository,
+):
+    record_item(
+        record_request(
+            bootstrap_repository,
+            item_identifier=NEW_ITEM,
+            title="A brand new item",
+            track="a-track",
+            status=ItemStatus.NOT_STARTED,
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    manifest = published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
+    assert manifest.startswith(PLAN_MANIFEST)
+    assert manifest.endswith(
+        ItemFieldLine(PlanField.IDENTIFIER, NEW_ITEM).render(opening_the_item=True)
+        + ItemFieldLine.quoting(PlanField.TITLE, "A brand new item").render()
+        + manifest_line(PlanField.BRANCH, "null")
+        + manifest_line(PlanField.TRACK, "a-track")
+        + manifest_line(PlanField.DEPENDS_ON, "[]")
+        + manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value)
+    )
+
+
+def test_recording_a_new_item_without_a_title_names_the_field_it_needs(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(plan_item_bootstrap.IncompleteNewItemError) as refusal:
+        record_item(
+            record_request(
+                bootstrap_repository,
+                item_identifier=NEW_ITEM,
+                track="a-track",
+                status=ItemStatus.NOT_STARTED,
+            ),
+            project_root=bootstrap_repository.project_root,
+        )
+
+    assert refusal.value.missing_fields == (PlanField.TITLE,)
+
+
+def test_recording_against_an_unknown_plan_is_refused(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(UnknownPlanError) as refusal:
+        record_item(
+            record_request(bootstrap_repository, plan_identifier="no-such-plan"),
+            project_root=bootstrap_repository.project_root,
+        )
+
+    assert refusal.value.plan_identifier == "no-such-plan"
+
+
+# %% opening the work
 
 
 def test_opening_writes_the_branch_pull_request_and_session_onto_the_item(
@@ -344,11 +354,14 @@ def test_opening_writes_the_branch_pull_request_and_session_onto_the_item(
 
     assert result.exit_code is ExitCode.SUCCESS
     assert result.pull_request_number == 143
-    manifest, _ = published_plan(bootstrap_repository)
-    assert "    branch: claude/a-new-branch\n" in manifest
-    assert "    pull_request_number: 143\n" in manifest
-    assert "    session: https://example.invalid/session_first\n" in manifest
-    assert "    status: in_progress\n" in manifest
+    manifest = published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
+    for field_written, value in (
+        (PlanField.BRANCH, NEW_BRANCH),
+        (PlanField.PULL_REQUEST_NUMBER, "143"),
+        (PlanField.SESSION, SESSION_URL),
+        (PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+    ):
+        assert manifest_line(field_written, value) in manifest
 
 
 def test_opening_asks_for_a_draft_pull_request_against_the_plans_repository(
@@ -366,7 +379,7 @@ def test_opening_asks_for_a_draft_pull_request_against_the_plans_repository(
     request = opener.requests[0]
     assert request.draft is True
     assert request.repository == "an-owner/a-repository"
-    assert request.head == "claude/a-new-branch"
+    assert request.head == NEW_BRANCH
     assert request.base == WORK_BRANCH
 
 
@@ -383,9 +396,9 @@ def test_opening_publishes_the_branch_to_the_repositorys_own_remote(
         "ls-remote",
         "--heads",
         str(bootstrap_repository.work_remote_path),
-        "claude/a-new-branch",
+        NEW_BRANCH,
     )
-    assert "claude/a-new-branch" in published.stdout
+    assert NEW_BRANCH in published.stdout
 
 
 def test_opening_an_already_published_branch_is_refused(
@@ -398,12 +411,13 @@ def test_opening_an_already_published_branch_is_refused(
         pull_request_opener=opener,
     )
 
-    with pytest.raises(plan_item_bootstrap.BranchAlreadyPublishedError):
+    with pytest.raises(plan_item_bootstrap.BranchAlreadyPublishedError) as refusal:
         open_work(
             open_request(),
             project_root=bootstrap_repository.project_root,
             pull_request_opener=opener,
         )
+    assert refusal.value.branch == NEW_BRANCH
     assert len(opener.requests) == 1
 
 
@@ -423,7 +437,7 @@ def test_opening_an_unknown_item_is_refused_before_anything_is_created(
     published = bootstrap_repository.run_git(
         "ls-remote", "--heads", str(bootstrap_repository.work_remote_path)
     )
-    assert "claude/a-new-branch" not in published.stdout
+    assert NEW_BRANCH not in published.stdout
 
 
 def test_a_refused_pull_request_leaves_the_manifest_untouched(
@@ -436,8 +450,7 @@ def test_a_refused_pull_request_leaves_the_manifest_untouched(
             pull_request_opener=RefusingPullRequestOpener(),
         )
 
-    manifest, _ = published_plan(bootstrap_repository)
-    assert manifest == PLAN_MANIFEST
+    assert published_plan(bootstrap_repository)[PlanDocument.MANIFEST] == PLAN_MANIFEST
 
 
 def test_a_refused_pull_request_leaves_the_branch_it_already_published(
@@ -454,9 +467,9 @@ def test_a_refused_pull_request_leaves_the_branch_it_already_published(
         "ls-remote",
         "--heads",
         str(bootstrap_repository.work_remote_path),
-        "claude/a-new-branch",
+        NEW_BRANCH,
     )
-    assert "claude/a-new-branch" in published.stdout
+    assert NEW_BRANCH in published.stdout
 
 
 def test_a_supplied_pull_request_number_is_recorded_without_creating_one(
@@ -472,8 +485,10 @@ def test_a_supplied_pull_request_number_is_recorded_without_creating_one(
 
     assert opener.requests == []
     assert result.pull_request_number == 57
-    manifest, _ = published_plan(bootstrap_repository)
-    assert "    pull_request_number: 57\n" in manifest
+    assert (
+        manifest_line(PlanField.PULL_REQUEST_NUMBER, "57")
+        in published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
+    )
 
 
 def test_creating_a_pull_request_without_a_title_or_body_is_refused_before_publishing(
@@ -489,7 +504,7 @@ def test_creating_a_pull_request_without_a_title_or_body_is_refused_before_publi
     published = bootstrap_repository.run_git(
         "ls-remote", "--heads", str(bootstrap_repository.work_remote_path)
     )
-    assert "claude/a-new-branch" not in published.stdout
+    assert NEW_BRANCH not in published.stdout
 
 
 def test_a_supplied_pull_request_number_adopts_the_branch_its_caller_published(
@@ -510,6 +525,25 @@ def test_a_supplied_pull_request_number_adopts_the_branch_its_caller_published(
     assert result.pull_request_number == 57
 
 
+# %% the vocabulary the manifest is written in
+
+
+def test_a_rendered_field_line_matches_how_a_real_manifest_writes_it():
+    """
+    The renderer's indentation and spacing have to match a manifest written by hand,
+    since every other test compares the two.
+    """
+    assert (
+        manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value) in PLAN_MANIFEST
+    )
+    assert manifest_line(PlanField.TRACK, "a-track") in PLAN_MANIFEST
+
+
+def test_only_the_fields_that_run_over_lines_are_treated_as_folded():
+    folded = {field for field in PlanField if field.spans_following_lines}
+    assert folded == {PlanField.NOTES, PlanField.BLOCKERS}
+
+
 # %% exit statuses
 
 
@@ -523,13 +557,23 @@ def test_each_refusal_carries_its_own_exit_code():
         UnknownPlanError: ExitCode.UNKNOWN_PLAN,
         UnknownItemError: ExitCode.UNKNOWN_ITEM,
         plan_item_bootstrap.IncompleteNewItemError: ExitCode.INCOMPLETE_NEW_ITEM,
-        plan_item_bootstrap.BranchAlreadyPublishedError: ExitCode.BRANCH_ALREADY_PUBLISHED,
+        plan_item_bootstrap.BranchAlreadyPublishedError: (
+            ExitCode.BRANCH_ALREADY_PUBLISHED
+        ),
         plan_item_bootstrap.PullRequestDetailsMissingError: (
             ExitCode.PULL_REQUEST_DETAILS_MISSING
         ),
         plan_item_bootstrap.PullRequestRefusedError: ExitCode.PULL_REQUEST_REFUSED,
     }
     assert {error: error.exit_code for error in codes} == codes
+
+
+def test_a_refusal_composes_its_message_from_its_own_fields():
+    refusal = UnknownItemError(
+        plan_identifier=PLAN_IDENTIFIER, item_identifier="no-such-item"
+    )
+    assert refusal.error_message() in str(refusal)
+    assert refusal.suggest_correction() in str(refusal)
 
 
 # %% the command line
@@ -548,9 +592,7 @@ def run_bootstrap(
     return subprocess.run(
         [
             "python3",
-            str(
-                repository.project_root / ".claude" / "hooks" / "plan_item_bootstrap.py"
-            ),
+            str(repository.project_root / HookScript.PLAN_ITEM_BOOTSTRAP.path),
             *arguments,
         ],
         cwd=repository.project_root,
@@ -559,28 +601,38 @@ def run_bootstrap(
     )
 
 
+def record_arguments(section: Path, plan: str = PLAN_IDENTIFIER) -> list[str]:
+    """
+    The command line for recording the existing item.
+
+    :param section: The roadmap section to append.
+    :param plan: The plan to record against.
+    :return: The arguments.
+    """
+    return [
+        "record",
+        "--plan",
+        plan,
+        "--item",
+        EXISTING_ITEM,
+        "--status",
+        ItemStatus.IN_PROGRESS.value,
+        "--roadmap-section",
+        str(section),
+    ]
+
+
 def test_the_record_subcommand_reports_status_and_exit_code_first(
     bootstrap_repository: ScratchRepository,
 ):
     section = roadmap_section(bootstrap_repository, "## From the command line\n")
 
-    result = run_bootstrap(
-        bootstrap_repository,
-        "record",
-        "--plan",
-        PLAN_IDENTIFIER,
-        "--item",
-        "an-existing-item",
-        "--status",
-        "in_progress",
-        "--roadmap-section",
-        str(section),
-    )
+    result = run_bootstrap(bootstrap_repository, *record_arguments(section))
 
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
     assert list(report)[:2] == ["status", "exit_code"]
-    assert report["status"] == "success"
+    assert report["status"] == ExitCode.SUCCESS.name_for_a_caller
     assert report["exit_code"] == 0
 
 
@@ -590,20 +642,11 @@ def test_the_command_line_names_the_status_it_failed_with(
     section = roadmap_section(bootstrap_repository, "## Section\n")
 
     result = run_bootstrap(
-        bootstrap_repository,
-        "record",
-        "--plan",
-        "no-such-plan",
-        "--item",
-        "an-existing-item",
-        "--status",
-        "in_progress",
-        "--roadmap-section",
-        str(section),
+        bootstrap_repository, *record_arguments(section, plan="no-such-plan")
     )
 
     assert result.returncode == ExitCode.UNKNOWN_PLAN
-    assert "unknown_plan" in result.stderr
+    assert ExitCode.UNKNOWN_PLAN.name_for_a_caller in result.stderr
 
 
 def test_the_dashboard_republish_is_handed_back_rather_than_attempted(
@@ -611,18 +654,7 @@ def test_the_dashboard_republish_is_handed_back_rather_than_attempted(
 ):
     section = roadmap_section(bootstrap_repository, "## Section\n")
 
-    result = run_bootstrap(
-        bootstrap_repository,
-        "record",
-        "--plan",
-        PLAN_IDENTIFIER,
-        "--item",
-        "an-existing-item",
-        "--status",
-        "in_progress",
-        "--roadmap-section",
-        str(section),
-    )
+    result = run_bootstrap(bootstrap_repository, *record_arguments(section))
 
     report = json.loads(result.stdout)
     assert report["dashboard_command"] == f"/plan-dashboard {PLAN_IDENTIFIER}"

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -6,9 +6,9 @@ Run against the local scratch repository fixture rather than a real remote, and 
 a recording pull request opener rather than GitHub, so nothing here needs network access
 or credentials.
 
-Every manifest line asserted on is rendered by the :class:`PlanField` that owns it, and
-every path by the :class:`PlanDocument` that lives at it, so a test cannot pin a second,
-independently-drifting copy of the manifest's own vocabulary.
+Every manifest line asserted on is rendered by the :class:`ManifestKey` that owns it,
+and every path by the :class:`PlanDocument` that lives at it, so a test cannot pin a
+second, independently-drifting copy of the manifest's own vocabulary.
 """
 
 from __future__ import annotations
@@ -25,17 +25,20 @@ import yaml
 
 import plan_item_bootstrap
 from plan_item_bootstrap import (
+    BLOCK_STYLED_KEYS,
     PLANS_DIRECTORY,
     CreatedPullRequest,
     ExitCode,
     HookScript,
     ItemRecordRequest,
     ItemStatus,
+    KeySpecification,
+    ManifestKey,
     PlanDocument,
-    PlanField,
     PullRequestRequest,
     UnknownItemError,
     UnknownPlanError,
+    ValueStyle,
     WorkOpenRequest,
     open_work,
     record_item,
@@ -77,15 +80,15 @@ The session recorded on an item whose work was opened.
 """
 
 
-def manifest_line(field: PlanField, value: str) -> str:
+def manifest_line(manifest_key: ManifestKey, value: str) -> str:
     """
-    One manifest line as the field that owns it writes it.
+    One manifest line as the key that owns it writes it.
 
-    :param field: The key the line sets.
+    :param manifest_key: The key the line sets.
     :param value: The value it carries.
     :return: The rendered line.
     """
-    return field.render(value)
+    return manifest_key.render(value)
 
 
 # %% fixtures
@@ -259,7 +262,7 @@ def test_recording_an_existing_item_sets_its_status(
     assert result.exit_code is ExitCode.SUCCESS
     published = published_plan(bootstrap_repository)
     assert (
-        manifest_line(PlanField.STATUS, ItemStatus.IN_PROGRESS.value)
+        manifest_line(ManifestKey.STATUS, ItemStatus.IN_PROGRESS.value)
         in published[PlanDocument.MANIFEST]
     )
 
@@ -273,8 +276,8 @@ def test_recording_leaves_every_other_manifest_line_byte_identical(
     )
 
     expected = PLAN_MANIFEST.replace(
-        manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value),
-        manifest_line(PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+        manifest_line(ManifestKey.STATUS, ItemStatus.NOT_STARTED.value),
+        manifest_line(ManifestKey.STATUS, ItemStatus.IN_PROGRESS.value),
         1,
     )
     assert published_plan(bootstrap_repository)[PlanDocument.MANIFEST] == expected
@@ -314,16 +317,16 @@ def test_recording_a_new_item_appends_it_to_the_manifest(
     manifest = published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
     assert manifest.startswith(PLAN_MANIFEST)
     assert manifest.endswith(
-        PlanField.IDENTIFIER.render(NEW_ITEM, opening_the_item=True)
-        + manifest_line(PlanField.TITLE, "A brand new item")
-        + manifest_line(PlanField.BRANCH, "null")
-        + manifest_line(PlanField.TRACK, "a-track")
-        + manifest_line(PlanField.DEPENDS_ON, "[]")
-        + manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value)
+        ManifestKey.IDENTIFIER.render(NEW_ITEM, opening_the_item=True)
+        + manifest_line(ManifestKey.TITLE, "A brand new item")
+        + manifest_line(ManifestKey.BRANCH, "null")
+        + manifest_line(ManifestKey.TRACK, "a-track")
+        + manifest_line(ManifestKey.DEPENDS_ON, "[]")
+        + manifest_line(ManifestKey.STATUS, ItemStatus.NOT_STARTED.value)
     )
 
 
-def test_recording_a_new_item_without_a_title_names_the_field_it_needs(
+def test_recording_a_new_item_without_a_title_names_the_key_it_needs(
     bootstrap_repository: ScratchRepository,
 ):
     with pytest.raises(plan_item_bootstrap.IncompleteNewItemError) as refusal:
@@ -337,7 +340,7 @@ def test_recording_a_new_item_without_a_title_names_the_field_it_needs(
             project_root=bootstrap_repository.project_root,
         )
 
-    assert refusal.value.missing_fields == (PlanField.TITLE,)
+    assert refusal.value.missing_keys == (ManifestKey.TITLE,)
 
 
 def test_recording_against_an_unknown_plan_is_refused(
@@ -369,13 +372,13 @@ def test_opening_writes_the_branch_pull_request_and_session_onto_the_item(
     assert result.exit_code is ExitCode.SUCCESS
     assert result.pull_request_number == 143
     manifest = published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
-    for field_written, value in (
-        (PlanField.BRANCH, NEW_BRANCH),
-        (PlanField.PULL_REQUEST_NUMBER, "143"),
-        (PlanField.SESSION, SESSION_URL),
-        (PlanField.STATUS, ItemStatus.IN_PROGRESS.value),
+    for written_key, value in (
+        (ManifestKey.BRANCH, NEW_BRANCH),
+        (ManifestKey.PULL_REQUEST_NUMBER, "143"),
+        (ManifestKey.SESSION, SESSION_URL),
+        (ManifestKey.STATUS, ItemStatus.IN_PROGRESS.value),
     ):
-        assert manifest_line(field_written, value) in manifest
+        assert manifest_line(written_key, value) in manifest
 
 
 def test_opening_asks_for_a_draft_pull_request_against_the_plans_repository(
@@ -500,7 +503,7 @@ def test_a_supplied_pull_request_number_is_recorded_without_creating_one(
     assert opener.requests == []
     assert result.pull_request_number == 57
     assert (
-        manifest_line(PlanField.PULL_REQUEST_NUMBER, "57")
+        manifest_line(ManifestKey.PULL_REQUEST_NUMBER, "57")
         in published_plan(bootstrap_repository)[PlanDocument.MANIFEST]
     )
 
@@ -548,30 +551,56 @@ def test_a_rendered_field_line_matches_how_a_real_manifest_writes_it():
     since every other test compares the two.
     """
     assert (
-        manifest_line(PlanField.STATUS, ItemStatus.NOT_STARTED.value) in PLAN_MANIFEST
+        manifest_line(ManifestKey.STATUS, ItemStatus.NOT_STARTED.value) in PLAN_MANIFEST
     )
-    assert manifest_line(PlanField.TRACK, "a-track") in PLAN_MANIFEST
+    assert manifest_line(ManifestKey.TRACK, "a-track") in PLAN_MANIFEST
 
 
-def test_a_field_quotes_its_own_value_when_its_specification_says_to():
+def test_a_key_quotes_its_own_value_when_its_style_says_to():
     """
-    Quoting is the field's to decide, so no caller has to know that a title is prose and
-    a track is a bare identifier.
+    Quoting is the key's to decide, so no caller has to know that a title is prose and a
+    track is a bare identifier.
     """
-    assert PlanField.TITLE.render("A brand new item").endswith(': "A brand new item"\n')
-    assert PlanField.TRACK.render("a-track").endswith(": a-track\n")
-    assert PlanField.TITLE.specification.quoted
-    assert not PlanField.TRACK.specification.quoted
+    assert ManifestKey.TITLE.render("A brand new item").endswith(
+        ': "A brand new item"\n'
+    )
+    assert ManifestKey.TRACK.render("a-track").endswith(": a-track\n")
+    assert ManifestKey.TITLE.style is ValueStyle.DOUBLE_QUOTED
+    assert ManifestKey.TRACK.style is ValueStyle.PLAIN
 
 
-def test_a_field_indexes_a_parsed_manifest_by_its_own_key():
+def test_every_key_is_a_specification_in_its_own_right():
     """
-    A member's string value stays its key, so carrying a specification never costs the
-    caller a ``.value`` when reading parsed YAML.
+    Mixing the specification into the enum is what lets a key carry its style without a
+    lookup beside it, so the relationship is asserted rather than assumed.
     """
-    item = yaml.safe_load(PLAN_MANIFEST)[PlanField.ITEMS][0]
-    assert item[PlanField.IDENTIFIER] == EXISTING_ITEM
-    assert item[PlanField.STATUS] == ItemStatus.NOT_STARTED
+    assert issubclass(ManifestKey, KeySpecification)
+    assert all(
+        isinstance(manifest_key, KeySpecification) for manifest_key in ManifestKey
+    )
+
+
+def test_every_key_was_declared_as_specification_arguments():
+    """
+    A member declared as a built ``KeySpecification`` rather than as its argument tuple
+    is accepted silently by the enum machinery and lands the whole instance in ``key``.
+
+    This is what catches that.
+    """
+    assert all(isinstance(manifest_key.key, str) for manifest_key in ManifestKey)
+    assert all(
+        isinstance(manifest_key.style, ValueStyle) for manifest_key in ManifestKey
+    )
+
+
+def test_a_key_indexes_a_parsed_manifest_by_the_string_it_names():
+    """
+    A key reads parsed YAML through its own ``key``, which is the manifest's own
+    spelling of it.
+    """
+    item = yaml.safe_load(PLAN_MANIFEST)[ManifestKey.ITEMS.key][0]
+    assert item[ManifestKey.IDENTIFIER.key] == EXISTING_ITEM
+    assert item[ManifestKey.STATUS.key] == ItemStatus.NOT_STARTED
 
 
 def test_the_plans_directory_matches_the_shell_configuration_that_owns_it(
@@ -602,9 +631,8 @@ def test_the_plans_directory_matches_the_shell_configuration_that_owns_it(
     )
 
 
-def test_only_the_fields_that_run_over_lines_are_treated_as_folded():
-    folded = {field for field in PlanField if field.spans_following_lines}
-    assert folded == {PlanField.NOTES, PlanField.BLOCKERS}
+def test_only_the_keys_whose_values_run_over_lines_are_block_styled():
+    assert BLOCK_STYLED_KEYS == {ManifestKey.NOTES, ManifestKey.BLOCKERS}
 
 
 # %% exit statuses

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -459,6 +459,57 @@ def test_a_refused_pull_request_leaves_the_branch_it_already_published(
     assert "claude/a-new-branch" in published.stdout
 
 
+def test_a_supplied_pull_request_number_is_recorded_without_creating_one(
+    bootstrap_repository: ScratchRepository,
+):
+    opener = RecordingPullRequestOpener()
+
+    result = open_work(
+        open_request(pull_request_number=57),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=opener,
+    )
+
+    assert opener.requests == []
+    assert result.pull_request_number == 57
+    manifest, _ = published_plan(bootstrap_repository)
+    assert "    pull_request_number: 57\n" in manifest
+
+
+def test_creating_a_pull_request_without_a_title_or_body_is_refused_before_publishing(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(plan_item_bootstrap.PullRequestDetailsMissingError):
+        open_work(
+            open_request(pull_request_title=None, pull_request_body=None),
+            project_root=bootstrap_repository.project_root,
+            pull_request_opener=RecordingPullRequestOpener(),
+        )
+
+    published = bootstrap_repository.run_git(
+        "ls-remote", "--heads", str(bootstrap_repository.work_remote_path)
+    )
+    assert "claude/a-new-branch" not in published.stdout
+
+
+def test_a_supplied_pull_request_number_adopts_the_branch_its_caller_published(
+    bootstrap_repository: ScratchRepository,
+):
+    open_work(
+        open_request(),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=RecordingPullRequestOpener(number=99),
+    )
+
+    result = open_work(
+        open_request(pull_request_number=57),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=RecordingPullRequestOpener(),
+    )
+
+    assert result.pull_request_number == 57
+
+
 # %% exit statuses
 
 
@@ -473,6 +524,9 @@ def test_each_refusal_carries_its_own_exit_code():
         UnknownItemError: ExitCode.UNKNOWN_ITEM,
         plan_item_bootstrap.IncompleteNewItemError: ExitCode.INCOMPLETE_NEW_ITEM,
         plan_item_bootstrap.BranchAlreadyPublishedError: ExitCode.BRANCH_ALREADY_PUBLISHED,
+        plan_item_bootstrap.PullRequestDetailsMissingError: (
+            ExitCode.PULL_REQUEST_DETAILS_MISSING
+        ),
         plan_item_bootstrap.PullRequestRefusedError: ExitCode.PULL_REQUEST_REFUSED,
     }
     assert {error: error.exit_code for error in codes} == codes

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -1,0 +1,574 @@
+"""
+Tests for plan_item_bootstrap.py's two operations, recording an item and opening its
+work.
+
+Run against the local scratch repository fixture rather than a real remote, and against
+a recording pull request opener rather than GitHub, so nothing here needs network access
+or credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+import plan_item_bootstrap
+from plan_item_bootstrap import (
+    CreatedPullRequest,
+    ExitCode,
+    ItemRecordRequest,
+    ItemStatus,
+    PullRequestRequest,
+    UnknownItemError,
+    UnknownPlanError,
+    WorkOpenRequest,
+    open_work,
+    record_item,
+)
+from scratch_repository import WORK_BRANCH, ScratchRepository
+
+PLAN_IDENTIFIER = "test-plan"
+
+PLAN_MANIFEST = """schema_version: 1
+id: test-plan
+title: "A plan under test"
+description: >
+  One paragraph.
+default_repository: an-owner/a-repository
+tracking_issue: 7
+
+waves:
+  - id: immediate
+    name: "Immediate"
+
+tracks:
+  - id: a-track
+    name: "A track"
+    wave: immediate
+
+items:
+  - id: an-existing-item
+    branch: null
+    title: "An item that has not been started"
+    track: a-track
+    depends_on: []
+    status: not_started
+    notes: >
+      A folded note whose wrapping must survive untouched, because a full YAML
+      round trip re-flows it.
+
+  - id: a-second-item
+    branch: some/other-branch
+    title: "An item that is already underway"
+    pull_request_number: 12
+    track: a-track
+    depends_on: []
+    status: in_progress
+    session: https://example.invalid/session_second
+"""
+
+PLAN_ROADMAP = """# test-plan — roadmap
+
+Narrative companion to plan.yaml.
+"""
+
+
+# %% fixtures
+
+
+@dataclass
+class RecordingPullRequestOpener:
+    """
+    Stands in for the GitHub pull request endpoint, recording what it was asked to
+    create instead of calling it.
+    """
+
+    number: int = 99
+    """
+    The pull request number handed back to the caller.
+    """
+
+    requests: list[PullRequestRequest] = field(default_factory=list)
+    """
+    Every request this opener was given, in call order.
+    """
+
+    def open_pull_request(self, request: PullRequestRequest) -> CreatedPullRequest:
+        """
+        Record *request* and hand back a pull request as GitHub would.
+
+        :param request: The pull request to create.
+        :return: The created pull request.
+        """
+        self.requests.append(request)
+        return CreatedPullRequest(
+            number=self.number,
+            html_url=f"https://example.invalid/pull/{self.number}",
+        )
+
+
+@dataclass
+class RefusingPullRequestOpener:
+    """
+    Stands in for a GitHub endpoint that refuses the creation.
+    """
+
+    def open_pull_request(self, request: PullRequestRequest) -> CreatedPullRequest:
+        """
+        Refuse the creation the way the real opener does on a non-success response.
+
+        :param request: The pull request that will not be created.
+        :raises PullRequestRefusedError: Always.
+        """
+        raise plan_item_bootstrap.PullRequestRefusedError(
+            "the remote refused to create the pull request"
+        )
+
+
+@pytest.fixture
+def bootstrap_repository(scratch_repository: ScratchRepository) -> ScratchRepository:
+    """
+    A scratch repository carrying the hook scripts this module drives, with a plan
+    already published on its notes branch.
+
+    :param scratch_repository: The initialized scratch repository and notes remote.
+    :return: The same repository, ready to bootstrap an item in.
+    """
+    scratch_repository.install_hook_scripts(
+        "resolve-personal-notes-config.sh",
+        "save-plan.sh",
+        "plan_manifest_tools.py",
+        "plan_item_bootstrap.py",
+    )
+    scratch_repository.write("README.md", "scratch repo\n")
+    scratch_repository.commit_everything("initial commit")
+    scratch_repository.publish_notes_branch(
+        {
+            f".claude/personal/plans/{PLAN_IDENTIFIER}/plan.yaml": PLAN_MANIFEST,
+            f".claude/personal/plans/{PLAN_IDENTIFIER}/roadmap.md": PLAN_ROADMAP,
+        }
+    )
+    scratch_repository.resolve_notes_remote_to()
+    scratch_repository.add_work_remote()
+    return scratch_repository
+
+
+def published_plan(repository: ScratchRepository) -> tuple[str, str]:
+    """
+    Read the manifest and roadmap actually on the notes branch, rather than what a run
+    reported.
+
+    :param repository: The scratch repository whose notes remote to read.
+    :return: The manifest text and the roadmap text.
+    """
+    checkout = repository.project_root.parent / "published-plan-checkout"
+    if checkout.exists():
+        subprocess.run(["rm", "-rf", str(checkout)], check=True)
+    repository.clone_notes_branch(checkout)
+    plan_directory = checkout / ".claude" / "personal" / "plans" / PLAN_IDENTIFIER
+    return (
+        (plan_directory / "plan.yaml").read_text(),
+        (plan_directory / "roadmap.md").read_text(),
+    )
+
+
+def roadmap_section(repository: ScratchRepository, content: str) -> Path:
+    """
+    Write a roadmap section to a scratch file, the way a caller hands one over.
+
+    :param repository: The scratch repository to write within.
+    :param content: The section's markdown.
+    :return: The path written to.
+    """
+    return repository.write("section.md", content)
+
+
+# %% recording an item
+
+
+def test_recording_an_existing_item_sets_its_status(
+    bootstrap_repository: ScratchRepository,
+):
+    result = record_item(
+        ItemRecordRequest(
+            plan_identifier=PLAN_IDENTIFIER,
+            item_identifier="an-existing-item",
+            status=ItemStatus.IN_PROGRESS,
+            roadmap_section_path=roadmap_section(
+                bootstrap_repository, "## A new section\n"
+            ),
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    assert result.exit_code is ExitCode.SUCCESS
+    manifest, _ = published_plan(bootstrap_repository)
+    assert "    status: in_progress\n" in manifest
+
+
+def test_recording_leaves_every_other_manifest_line_byte_identical(
+    bootstrap_repository: ScratchRepository,
+):
+    record_item(
+        ItemRecordRequest(
+            plan_identifier=PLAN_IDENTIFIER,
+            item_identifier="an-existing-item",
+            status=ItemStatus.IN_PROGRESS,
+            roadmap_section_path=roadmap_section(bootstrap_repository, "## Section\n"),
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    manifest, _ = published_plan(bootstrap_repository)
+    expected = PLAN_MANIFEST.replace(
+        "    status: not_started\n", "    status: in_progress\n", 1
+    )
+    assert manifest == expected
+
+
+def test_recording_appends_the_roadmap_section_without_rewriting_the_roadmap(
+    bootstrap_repository: ScratchRepository,
+):
+    record_item(
+        ItemRecordRequest(
+            plan_identifier=PLAN_IDENTIFIER,
+            item_identifier="an-existing-item",
+            status=ItemStatus.IN_PROGRESS,
+            roadmap_section_path=roadmap_section(
+                bootstrap_repository, "## An appended section\n\nIts body.\n"
+            ),
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    _, roadmap = published_plan(bootstrap_repository)
+    assert roadmap.startswith(PLAN_ROADMAP)
+    assert roadmap.endswith("## An appended section\n\nIts body.\n")
+
+
+def test_recording_a_new_item_appends_it_to_the_manifest(
+    bootstrap_repository: ScratchRepository,
+):
+    record_item(
+        ItemRecordRequest(
+            plan_identifier=PLAN_IDENTIFIER,
+            item_identifier="a-brand-new-item",
+            title="A brand new item",
+            track="a-track",
+            status=ItemStatus.NOT_STARTED,
+            roadmap_section_path=roadmap_section(bootstrap_repository, "## New\n"),
+        ),
+        project_root=bootstrap_repository.project_root,
+    )
+
+    manifest, _ = published_plan(bootstrap_repository)
+    assert manifest.startswith(PLAN_MANIFEST)
+    assert manifest.endswith(
+        "  - id: a-brand-new-item\n"
+        '    title: "A brand new item"\n'
+        "    branch: null\n"
+        "    track: a-track\n"
+        "    depends_on: []\n"
+        "    status: not_started\n"
+    )
+
+
+def test_recording_a_new_item_without_a_title_is_refused(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(plan_item_bootstrap.IncompleteNewItemError):
+        record_item(
+            ItemRecordRequest(
+                plan_identifier=PLAN_IDENTIFIER,
+                item_identifier="a-brand-new-item",
+                track="a-track",
+                status=ItemStatus.NOT_STARTED,
+                roadmap_section_path=roadmap_section(bootstrap_repository, "## New\n"),
+            ),
+            project_root=bootstrap_repository.project_root,
+        )
+
+
+def test_recording_against_an_unknown_plan_is_refused(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(UnknownPlanError):
+        record_item(
+            ItemRecordRequest(
+                plan_identifier="no-such-plan",
+                item_identifier="an-existing-item",
+                status=ItemStatus.IN_PROGRESS,
+                roadmap_section_path=roadmap_section(bootstrap_repository, "## S\n"),
+            ),
+            project_root=bootstrap_repository.project_root,
+        )
+
+
+# %% opening the work
+
+
+def open_request(**overrides: object) -> WorkOpenRequest:
+    """
+    Build a work-open request, overriding only what a test cares about.
+
+    :param overrides: Fields to replace on the default request.
+    :return: The request.
+    """
+    defaults = dict(
+        plan_identifier=PLAN_IDENTIFIER,
+        item_identifier="an-existing-item",
+        branch="claude/a-new-branch",
+        base_branch=WORK_BRANCH,
+        session_url="https://example.invalid/session_first",
+        pull_request_title="An item that has not been started",
+        pull_request_body="What it does.",
+    )
+    defaults.update(overrides)
+    return WorkOpenRequest(**defaults)
+
+
+def test_opening_writes_the_branch_pull_request_and_session_onto_the_item(
+    bootstrap_repository: ScratchRepository,
+):
+    opener = RecordingPullRequestOpener(number=143)
+
+    result = open_work(
+        open_request(),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=opener,
+    )
+
+    assert result.exit_code is ExitCode.SUCCESS
+    assert result.pull_request_number == 143
+    manifest, _ = published_plan(bootstrap_repository)
+    assert "    branch: claude/a-new-branch\n" in manifest
+    assert "    pull_request_number: 143\n" in manifest
+    assert "    session: https://example.invalid/session_first\n" in manifest
+    assert "    status: in_progress\n" in manifest
+
+
+def test_opening_asks_for_a_draft_pull_request_against_the_plans_repository(
+    bootstrap_repository: ScratchRepository,
+):
+    opener = RecordingPullRequestOpener()
+
+    open_work(
+        open_request(),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=opener,
+    )
+
+    assert len(opener.requests) == 1
+    request = opener.requests[0]
+    assert request.draft is True
+    assert request.repository == "an-owner/a-repository"
+    assert request.head == "claude/a-new-branch"
+    assert request.base == WORK_BRANCH
+
+
+def test_opening_publishes_the_branch_to_the_repositorys_own_remote(
+    bootstrap_repository: ScratchRepository,
+):
+    open_work(
+        open_request(),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=RecordingPullRequestOpener(),
+    )
+
+    published = bootstrap_repository.run_git(
+        "ls-remote",
+        "--heads",
+        str(bootstrap_repository.work_remote_path),
+        "claude/a-new-branch",
+    )
+    assert "claude/a-new-branch" in published.stdout
+
+
+def test_opening_an_already_published_branch_is_refused(
+    bootstrap_repository: ScratchRepository,
+):
+    opener = RecordingPullRequestOpener()
+    open_work(
+        open_request(),
+        project_root=bootstrap_repository.project_root,
+        pull_request_opener=opener,
+    )
+
+    with pytest.raises(plan_item_bootstrap.BranchAlreadyPublishedError):
+        open_work(
+            open_request(),
+            project_root=bootstrap_repository.project_root,
+            pull_request_opener=opener,
+        )
+    assert len(opener.requests) == 1
+
+
+def test_opening_an_unknown_item_is_refused_before_anything_is_created(
+    bootstrap_repository: ScratchRepository,
+):
+    opener = RecordingPullRequestOpener()
+
+    with pytest.raises(UnknownItemError):
+        open_work(
+            open_request(item_identifier="no-such-item"),
+            project_root=bootstrap_repository.project_root,
+            pull_request_opener=opener,
+        )
+
+    assert opener.requests == []
+    published = bootstrap_repository.run_git(
+        "ls-remote", "--heads", str(bootstrap_repository.work_remote_path)
+    )
+    assert "claude/a-new-branch" not in published.stdout
+
+
+def test_a_refused_pull_request_leaves_the_manifest_untouched(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(plan_item_bootstrap.PullRequestRefusedError):
+        open_work(
+            open_request(),
+            project_root=bootstrap_repository.project_root,
+            pull_request_opener=RefusingPullRequestOpener(),
+        )
+
+    manifest, _ = published_plan(bootstrap_repository)
+    assert manifest == PLAN_MANIFEST
+
+
+def test_a_refused_pull_request_leaves_the_branch_it_already_published(
+    bootstrap_repository: ScratchRepository,
+):
+    with pytest.raises(plan_item_bootstrap.PullRequestRefusedError):
+        open_work(
+            open_request(),
+            project_root=bootstrap_repository.project_root,
+            pull_request_opener=RefusingPullRequestOpener(),
+        )
+
+    published = bootstrap_repository.run_git(
+        "ls-remote",
+        "--heads",
+        str(bootstrap_repository.work_remote_path),
+        "claude/a-new-branch",
+    )
+    assert "claude/a-new-branch" in published.stdout
+
+
+# %% exit statuses
+
+
+def test_every_exit_code_names_itself_from_its_own_member():
+    for exit_code in ExitCode:
+        assert exit_code.name_for_a_caller == exit_code.name.lower()
+
+
+def test_each_refusal_carries_its_own_exit_code():
+    codes = {
+        UnknownPlanError: ExitCode.UNKNOWN_PLAN,
+        UnknownItemError: ExitCode.UNKNOWN_ITEM,
+        plan_item_bootstrap.IncompleteNewItemError: ExitCode.INCOMPLETE_NEW_ITEM,
+        plan_item_bootstrap.BranchAlreadyPublishedError: ExitCode.BRANCH_ALREADY_PUBLISHED,
+        plan_item_bootstrap.PullRequestRefusedError: ExitCode.PULL_REQUEST_REFUSED,
+    }
+    assert {error: error.exit_code for error in codes} == codes
+
+
+# %% the command line
+
+
+def run_bootstrap(
+    repository: ScratchRepository, *arguments: str
+) -> subprocess.CompletedProcess[str]:
+    """
+    Run the scratch layout's plan_item_bootstrap.py with *arguments*.
+
+    :param repository: A fixture-built scratch repository.
+    :param arguments: CLI arguments to pass.
+    :return: The finished subprocess.
+    """
+    return subprocess.run(
+        [
+            "python3",
+            str(
+                repository.project_root / ".claude" / "hooks" / "plan_item_bootstrap.py"
+            ),
+            *arguments,
+        ],
+        cwd=repository.project_root,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_record_subcommand_reports_status_and_exit_code_first(
+    bootstrap_repository: ScratchRepository,
+):
+    section = roadmap_section(bootstrap_repository, "## From the command line\n")
+
+    result = run_bootstrap(
+        bootstrap_repository,
+        "record",
+        "--plan",
+        PLAN_IDENTIFIER,
+        "--item",
+        "an-existing-item",
+        "--status",
+        "in_progress",
+        "--roadmap-section",
+        str(section),
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert list(report)[:2] == ["status", "exit_code"]
+    assert report["status"] == "success"
+    assert report["exit_code"] == 0
+
+
+def test_the_command_line_names_the_status_it_failed_with(
+    bootstrap_repository: ScratchRepository,
+):
+    section = roadmap_section(bootstrap_repository, "## Section\n")
+
+    result = run_bootstrap(
+        bootstrap_repository,
+        "record",
+        "--plan",
+        "no-such-plan",
+        "--item",
+        "an-existing-item",
+        "--status",
+        "in_progress",
+        "--roadmap-section",
+        str(section),
+    )
+
+    assert result.returncode == ExitCode.UNKNOWN_PLAN
+    assert "unknown_plan" in result.stderr
+
+
+def test_the_dashboard_republish_is_handed_back_rather_than_attempted(
+    bootstrap_repository: ScratchRepository,
+):
+    section = roadmap_section(bootstrap_repository, "## Section\n")
+
+    result = run_bootstrap(
+        bootstrap_repository,
+        "record",
+        "--plan",
+        PLAN_IDENTIFIER,
+        "--item",
+        "an-existing-item",
+        "--status",
+        "in_progress",
+        "--roadmap-section",
+        str(section),
+    )
+
+    report = json.loads(result.stdout)
+    assert report["dashboard_command"] == f"/plan-dashboard {PLAN_IDENTIFIER}"

--- a/.claude/skills/plan-item-kickoff/SKILL.md
+++ b/.claude/skills/plan-item-kickoff/SKILL.md
@@ -148,24 +148,40 @@ dashboard, kickoff and resolve run downstream reads as truth.
 
 So run this first, before the first edit:
 
+Create the branch and its draft pull request yourself, then hand the number
+over:
+
 ```bash
+git checkout -b <branch> <base-branch>
+git commit --allow-empty -m "Bootstrap <item-id>"
+git push -u origin <branch>
+# then create the draft pull request with your GitHub tool, and:
 source .claude/hooks/resolve-personal-notes-config.sh
 python3 "${PLAN_ITEM_BOOTSTRAP_SCRIPT}" open \
     --plan <plan-id> --item <item-id> \
     --branch <branch> --base <base-branch> \
     --session <this session's url> \
-    --pull-request-title <title> --pull-request-body <file>
+    --pull-request-number <number>
 python3 "${PLAN_ITEM_BOOTSTRAP_SCRIPT}" record \
     --plan <plan-id> --item <item-id> \
     --status in_progress --roadmap-section <file>
 ```
 
-`open` before `record`: the pull request number does not exist until the
-pull request does. `open` creates and publishes the branch, opens the draft
-pull request, and writes the branch, session and pull request number back
-onto the item as `in_progress`; `record` appends the approved plan to
+`open` before `record`: the pull request number does not exist until the pull
+request does. `open` writes the branch, session and pull request number onto
+the item and flips it to `in_progress`; `record` appends the approved plan to
 `roadmap.md`. Both print a one-line JSON report led by `status` and
 `exit_code`.
+
+**Why a session creates the pull request rather than the script.** The script
+can create one — with `--pull-request-title`/`--pull-request-body` instead of
+`--pull-request-number`, verified live — but a pull request it creates is
+attributed to the app its requests are proxied through rather than to the
+person whose work it is, the same authorship problem `AGENTS.md` rules out for
+commits. Creating it yourself keeps your identity on it. The creating path is
+there for an unattended run whose credential is a real one; if you use it,
+`open` publishes the branch too, so the three git commands above are yours to
+skip.
 
 The branch name and the base branch are this skill's judgment, not the
 script's: the base comes from step 2's dependency readiness, and the branch

--- a/.claude/skills/plan-item-kickoff/SKILL.md
+++ b/.claude/skills/plan-item-kickoff/SKILL.md
@@ -185,9 +185,20 @@ skip.
 
 The branch name and the base branch are this skill's judgment, not the
 script's: the base comes from step 2's dependency readiness, and the branch
-from whatever this session is designated to develop on. The roadmap section
-is the approved plan written up — what was decided and why, not a restatement
-of the diff.
+from whatever this session is designated to develop on.
+
+**Write the approved plan down in both places it belongs**, rather than
+leaving it only in the conversation that produced it:
+
+- **`roadmap.md`**, via `record`'s `--roadmap-section` — the durable record of
+  what was decided and *why*, including any assumption or open question the
+  plan carries. Not a restatement of the diff.
+- **The PR-progress note** — the plan, what is done, and what is next, kept
+  current as the work goes. Write it between `CLAUDE.local.md`'s
+  `BEGIN-PR-PROGRESS`/`END-PR-PROGRESS` markers and run
+  `.claude/hooks/save-pr-progress.sh` to push it. Do this as soon as the
+  branch exists, not at the end: a note written afterwards is a summary, and
+  the point of it is that another session can pick the work up mid-flight.
 
 Then republish the dashboard yourself:
 

--- a/.claude/skills/plan-item-kickoff/SKILL.md
+++ b/.claude/skills/plan-item-kickoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-item-kickoff
-description: Gather everything available about one tracked plan item (its plan.yaml entry, roadmap.md history/design context, its dependency chain's live GitHub state, and patterns from already-landed sibling items in the same track) and propose a concrete implementation plan via plan mode, without writing any code. Invoke as "/plan-item-kickoff <plan-id> <item-id>". Use when starting work on a specific item from a plan-dashboard's "Start now" link, or when the user asks to "start", "kick off", or "plan out" a specific tracked item.
+description: Gather everything available about one tracked plan item (its plan.yaml entry, roadmap.md history/design context, its dependency chain's live GitHub state, and patterns from already-landed sibling items in the same track), propose a concrete implementation plan via plan mode without writing any code, and once it is approved open the item's branch and draft pull request and record its manifest state before implementation starts. Invoke as "/plan-item-kickoff <plan-id> <item-id>". Use when starting work on a specific item from a plan-dashboard's "Start now" link, or when the user asks to "start", "kick off", or "plan out" a specific tracked item.
 allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, Skill, EnterPlanMode, ExitPlanMode, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__get_file_contents, mcp__Claude_Code_Remote__subscribe_pr_activity
 ---
 
@@ -9,10 +9,14 @@ allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, Skill, EnterPlanMode, Ex
 Generic, plan-agnostic — nothing here may hardcode a specific plan id, item,
 or branch. Gathers everything a session doing this item's work would
 actually want before starting, then hands the user a concrete
-implementation plan via plan mode. **This skill never writes code, creates a
-branch, or pushes anything** — it is a research-and-planning skill, not an
-implementation one. Whether to implement the approved plan in this session
-or a fresh one is the user's call, made after they see it.
+implementation plan via plan mode. **This skill never writes code, and
+creates nothing at all until the user has approved a plan** — steps 1-5 are
+research and planning only. Once a plan *is* approved, step 6 opens the
+item's branch and draft pull request and records its manifest state, before
+any implementation begins. Whether to implement the approved plan in this
+session or a fresh one is the user's call, made after they see it; step 6
+runs either way, so the item stops reading as `not_started` the moment it
+isn't.
 
 ## 0. Check the setup is in place, and offer it if not
 
@@ -129,5 +133,54 @@ it. Flag explicitly, never silently paper over:
 - Anything the gathered context left genuinely unresolved after the check
   above — say so rather than filling the gap with an assumption.
 
-Do not touch git, create a branch, or write any code in this skill — its
-only output is the plan itself.
+Do not touch git, create a branch, or write any code in this step — its only
+output is the plan itself. Everything below happens after the user approves
+it, never before.
+
+## 6. Bootstrap the item — before implementing, not after
+
+The moment a plan is approved, the branch, the draft pull request, the
+item's `branch`/`session`/`pull_request_number` fields and its roadmap
+section are all derivable, and none of them depends on a line of the
+implementation. Doing them at the end instead means the manifest says
+`not_started` with no branch for the entire length of the work, which every
+dashboard, kickoff and resolve run downstream reads as truth.
+
+So run this first, before the first edit:
+
+```bash
+source .claude/hooks/resolve-personal-notes-config.sh
+python3 "${PLAN_ITEM_BOOTSTRAP_SCRIPT}" open \
+    --plan <plan-id> --item <item-id> \
+    --branch <branch> --base <base-branch> \
+    --session <this session's url> \
+    --pull-request-title <title> --pull-request-body <file>
+python3 "${PLAN_ITEM_BOOTSTRAP_SCRIPT}" record \
+    --plan <plan-id> --item <item-id> \
+    --status in_progress --roadmap-section <file>
+```
+
+`open` before `record`: the pull request number does not exist until the
+pull request does. `open` creates and publishes the branch, opens the draft
+pull request, and writes the branch, session and pull request number back
+onto the item as `in_progress`; `record` appends the approved plan to
+`roadmap.md`. Both print a one-line JSON report led by `status` and
+`exit_code`.
+
+The branch name and the base branch are this skill's judgment, not the
+script's: the base comes from step 2's dependency readiness, and the branch
+from whatever this session is designated to develop on. The roadmap section
+is the approved plan written up — what was decided and why, not a restatement
+of the diff.
+
+Then republish the dashboard yourself:
+
+```
+/plan-dashboard <plan-id>
+```
+
+Both operations end here rather than doing it, because only a live session
+can call the `Artifact` tool — the script's report hands the command back
+rather than pretending it ran. Do not skip it: a published dashboard that is
+older than the manifest behind it is the exact staleness this step exists to
+close.


### PR DESCRIPTION
- Adds `.claude/hooks/plan_item_bootstrap.py` so branch creation, draft PR, and `plan.yaml`/roadmap state all happen the moment a plan is approved, instead of trailing behind the implementation.
- Two focused operations: `record` (write plan.yaml/roadmap, run save-plan.sh) and `open` (create branch + draft PR, write back `branch`/`session`/`pull_request_number`) — callers only take the surface they need.
- `/plan-item-kickoff` now creates the branch/draft PR in a new step 6 right after approval; `/add-plan-item` still never writes code, per its existing contract.
- PR creation stays with the session's own GitHub tool (not the script) so authorship lands on the user, not a bot identity.
- Manifest edits patch only the changed lines (no full YAML round-trip) to avoid unrelated diff noise.
- 21 new tests, each verified to fail for its own reason before the fix.

Fork PR: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/143