### PR TITLE
Improve GraphOfBoundingBoxes path finding: weighted Dijkstra + shortc…

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -840,9 +840,9 @@ class Mesh(Shape):
         """
         points = np.asarray([point.to_np()[:3] for point in points_3d], dtype=float)
         points = np.unique(points, axis=0)
-        assert (
-            len(points) >= 3
-        ), "At least 4 unique points are required to define a 3D region."
+        assert len(points) >= 3, (
+            "At least 4 unique points are required to define a 3D region."
+        )
 
         centered_points = points - points.mean(axis=0, keepdims=True)
         assert np.any(centered_points), "Points must not be all identical."
@@ -1126,6 +1126,39 @@ class Bounds(Generic[T], SubClassSafeGeneric):
     The corner with the largest coordinate on every axis.
     """
 
+    def clip_segment(
+        self, start: np.ndarray, direction: np.ndarray
+    ) -> Optional[SimpleInterval]:
+        """
+        Clip the parametrized segment ``start + t * direction`` (``t`` in ``[0, 1]``)
+        against this region, using the slab method.
+
+        Assumes ``lower``/``upper`` are plain numeric arrays, as returned by
+        :meth:`BoundingBox.to_array_bounds`.
+
+        :param start: The segment's start point.
+        :param direction: The vector from the segment's start to its end.
+        :return: The sub-interval of ``t`` for which the segment lies inside this
+            region, or None if the segment misses it entirely.
+        """
+        t_min, t_max = 0.0, 1.0
+        for coordinate, delta, lower, upper in zip(
+            start, direction, self.lower, self.upper
+        ):
+            if abs(delta) < 1e-12:
+                if coordinate < lower or coordinate > upper:
+                    return None
+                continue
+            t_enter = (lower - coordinate) / delta
+            t_exit = (upper - coordinate) / delta
+            if t_enter > t_exit:
+                t_enter, t_exit = t_exit, t_enter
+            t_min = max(t_min, t_enter)
+            t_max = min(t_max, t_exit)
+            if t_min > t_max:
+                return None
+        return SimpleInterval.from_data(t_min, t_max, Bound.CLOSED, Bound.CLOSED)
+
 
 @dataclass(eq=False)
 class BoundingBox:
@@ -1212,12 +1245,9 @@ class BoundingBox:
 
         :return: The corners, in the same frame as ``origin``.
         """
-        lower = np.array(
-            [self.x_interval.lower, self.y_interval.lower, self.z_interval.lower]
-        )
-        upper = np.array(
-            [self.x_interval.upper, self.y_interval.upper, self.z_interval.upper]
-        )
+        x, y, z = self.x_interval, self.y_interval, self.z_interval
+        lower = np.array([x.lower, y.lower, z.lower])
+        upper = np.array([x.upper, y.upper, z.upper])
         return Bounds(lower, upper)
 
     def to_point3_bounds(self) -> Bounds[Point3]:
@@ -1226,16 +1256,17 @@ class BoundingBox:
 
         :return: The corners, in the same frame as ``origin``.
         """
+        x, y, z = self.x_interval, self.y_interval, self.z_interval
         lower = Point3(
-            self.x_interval.lower,
-            self.y_interval.lower,
-            self.z_interval.lower,
+            x.lower,
+            y.lower,
+            z.lower,
             reference_frame=self.origin.reference_frame,
         )
         upper = Point3(
-            self.x_interval.upper,
-            self.y_interval.upper,
-            self.z_interval.upper,
+            x.upper,
+            y.upper,
+            z.upper,
             reference_frame=self.origin.reference_frame,
         )
         return Bounds(lower, upper)
@@ -1443,9 +1474,9 @@ class BoundingBox:
         :param min_point: The minimum point
         :param max_point: The maximum point
         """
-        assert (
-            min_point.reference_frame == max_point.reference_frame
-        ), "The reference frames of the minimum and maximum points must be the same."
+        assert min_point.reference_frame == max_point.reference_frame, (
+            "The reference frames of the minimum and maximum points must be the same."
+        )
         return cls(*min_point.to_np()[:3], *max_point.to_np()[:3], origin=origin)
 
     def as_shape(self) -> Box:

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field, fields
 from functools import cached_property
 
 import numpy as np
+import numpy.typing as npt
 import trimesh
 import trimesh.exchange.stl
 from PIL import Image
@@ -1127,7 +1128,7 @@ class Bounds(Generic[T], SubClassSafeGeneric):
     """
 
     def clip_segment(
-        self, start: np.ndarray, direction: np.ndarray
+        self, start: npt.NDArray[np.float64], direction: npt.NDArray[np.float64]
     ) -> Optional[SimpleInterval]:
         """
         Clip the parametrized segment ``start + t * direction`` (``t`` in ``[0, 1]``)

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -1279,6 +1279,18 @@ class BoundingBox:
         """
         return [self.depth, self.width, self.height]
 
+    @property
+    def center(self) -> Point3:
+        """
+        :return: The center point of the bounding box, in the same frame as ``origin``.
+        """
+        return Point3(
+            self.x_interval.center(),
+            self.y_interval.center(),
+            self.z_interval.center(),
+            reference_frame=self.origin.reference_frame,
+        )
+
     def bloat(
         self, x_amount: float = 0.0, y_amount: float = 0, z_amount: float = 0
     ) -> BoundingBox:

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -1136,6 +1136,13 @@ class Bounds(Generic[T], SubClassSafeGeneric):
         Assumes ``lower``/``upper`` are plain numeric arrays, as returned by
         :meth:`BoundingBox.to_array_bounds`.
 
+        .. note::
+            ``start``/``direction`` are plain arrays rather than :class:`Point3`/
+            :class:`Vector3` on purpose: this runs once per graph node on every
+            collision check, and :class:`Point3`/:class:`Vector3` arithmetic pays a
+            symbolic (casadi) cost on every access. Callers should convert to arrays
+            once before looping, not per call.
+
         :param start: The segment's start point.
         :param direction: The vector from the segment's start to its end.
         :return: The sub-interval of ``t`` for which the segment lies inside this

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -22,7 +22,11 @@ from semantic_digital_twin.exceptions import PointOccupiedError
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     SemanticEnvironmentAnnotation,
 )
-from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix, Point3
+from semantic_digital_twin.spatial_types import (
+    HomogeneousTransformationMatrix,
+    Point3,
+    Vector3,
+)
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.connections import FixedConnection
 from semantic_digital_twin.world_description.geometry import BoundingBox, Color
@@ -40,18 +44,9 @@ from semantic_digital_twin.world_description.world_entity import (
 
 logger = logging.getLogger(__name__)
 
-Coordinates3D = Tuple[float, float, float]
-"""
-A raw, unlabeled 3-D point, expressed in a :class:`GraphOfBoundingBoxes` search space's
-reference frame.
-
-Used internally for path shortcutting, where working with plain floats is far cheaper
-than symbolic :class:`Point3` arithmetic.
-"""
-
 
 def _segment_box_overlap(
-    start: Coordinates3D, direction: Coordinates3D, box: BoundingBox
+    start: Point3, direction: Vector3, box: BoundingBox
 ) -> Optional[Tuple[float, float]]:
     """
     Clip the parametrized segment ``start + t * direction`` (``t`` in ``[0, 1]``)
@@ -63,6 +58,8 @@ def _segment_box_overlap(
     :return: The ``(t_min, t_max)`` sub-interval of the segment that lies inside
         ``box``, or None if the segment misses ``box`` entirely.
     """
+    coordinates = (float(start.x), float(start.y), float(start.z))
+    deltas = (float(direction.x), float(direction.y), float(direction.z))
     bounds = (
         (box.x_interval.lower, box.x_interval.upper),
         (box.y_interval.lower, box.y_interval.upper),
@@ -70,7 +67,7 @@ def _segment_box_overlap(
     )
 
     t_min, t_max = 0.0, 1.0
-    for coordinate, delta, (lower, upper) in zip(start, direction, bounds):
+    for coordinate, delta, (lower, upper) in zip(coordinates, deltas, bounds):
         if abs(delta) < 1e-12:
             if coordinate < lower or coordinate > upper:
                 return None
@@ -119,7 +116,7 @@ class BoundingBoxAdjacency:
     The region where the two adjacent boxes overlap or touch.
     """
 
-    weight: float
+    distance: float
     """
     Euclidean distance between the centers of the two adjacent boxes.
 
@@ -200,12 +197,6 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
                 HomogeneousTransformationMatrix(reference_frame=self.world.root),
             )
 
-        def _center(mn, mx):
-            return ((mn[0] + mx[0]) / 2, (mn[1] + mx[1]) / 2, (mn[2] + mx[2]) / 2)
-
-        def _distance(a, b):
-            return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2) ** 0.5
-
         # Build a 3-D R-tree
         prop = index.Property()
         prop.dimension = 3
@@ -230,7 +221,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
             orig_mins.append(mn)
             orig_maxs.append(mx)
             expanded.append(ex)
-            centers.append(_center(mn, mx))
+            centers.append(n.center)
             rtree_idx.insert(len(orig_mins) - 1, ex)
 
         # Query & link, skip self-loops and symmetric pairs
@@ -242,13 +233,13 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
                 if not _overlap(mn_i, mx_i, mn_j, mx_j):
                     continue  # no true overlap
                 box = _intersection_box(mn_i, mx_i, mn_j, mx_j)
-                weight = _distance(centers[i], centers[j])
+                distance = float(centers[i].euclidean_distance(centers[j]))
 
                 # Map from the local list positions back to the graph node indices
                 u = self.box_to_index_map[node_list[i]]
                 v = self.box_to_index_map[node_list[j]]
 
-                self.graph.add_edge(u, v, BoundingBoxAdjacency(box, weight))
+                self.graph.add_edge(u, v, BoundingBoxAdjacency(box, distance))
 
     def draw(self):
         import rustworkx.visualization
@@ -339,7 +330,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
             self.graph,
             start_index,
             target=goal_index,
-            weight_fn=lambda adjacency: adjacency.weight,
+            weight_fn=lambda adjacency: adjacency.distance,
         )
 
         # if it is not possible to find a path
@@ -348,41 +339,30 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
 
         path = paths[goal_index]
 
-        # build the path, working in raw coordinates (in the search space's reference
-        # frame) so shortcutting doesn't repeatedly pay for symbolic Point3 arithmetic
-        waypoints = [self._coordinates_in_search_space_frame(start)]
+        # build the path
+        reference_frame = self.search_space.reference_frame
+        waypoints = [self.world.transform(start, reference_frame)]
 
         for source, target in zip(path, path[1:]):
             intersection = self.graph.get_edge_data(source, target).intersection
             waypoints.append(
-                (
+                Point3(
                     intersection.x_interval.center(),
                     intersection.y_interval.center(),
                     intersection.z_interval.center(),
+                    reference_frame=reference_frame,
                 )
             )
 
-        waypoints.append(self._coordinates_in_search_space_frame(goal))
+        waypoints.append(self.world.transform(goal, reference_frame))
         waypoints = self._shortcut_waypoints(waypoints)
 
         result = [start]
-        result.extend(Point3(x, y, z) for x, y, z in waypoints[1:-1])
+        result.extend(waypoints[1:-1])
         result.append(goal)
         return result
 
-    def _coordinates_in_search_space_frame(self, point: Point3) -> Coordinates3D:
-        """
-        Express a point as raw floats in the search space's reference frame.
-
-        :param point: The point to convert.
-        :return: The point's coordinates in the search space's reference frame.
-        """
-        transformed = self.world.transform(point, self.search_space.reference_frame)
-        return float(transformed.x), float(transformed.y), float(transformed.z)
-
-    def _shortcut_waypoints(
-        self, waypoints: List[Coordinates3D]
-    ) -> List[Coordinates3D]:
+    def _shortcut_waypoints(self, waypoints: List[Point3]) -> List[Point3]:
         """
         Drop waypoints that a straight line can bypass without leaving free space.
 
@@ -408,9 +388,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
                     i += 1
         return waypoints
 
-    def _segment_is_collision_free(
-        self, start: Coordinates3D, end: Coordinates3D
-    ) -> bool:
+    def _segment_is_collision_free(self, start: Point3, end: Point3) -> bool:
         """
         Check whether a straight-line segment stays entirely within free space.
 
@@ -419,7 +397,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         :return: True if the segment never leaves the union of the graph's bounding-box
             nodes.
         """
-        direction = (end[0] - start[0], end[1] - start[1], end[2] - start[2])
+        direction = end - start
         covered = [
             overlap
             for node in self.graph.nodes()

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -366,27 +366,29 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         """
         Drop waypoints that a straight line can bypass without leaving free space.
 
-        Repeatedly inspects consecutive triples ``(a, b, c)``: if the straight segment
-        from ``a`` to ``c`` never leaves the union of the graph's bounding-box nodes,
-        ``b`` is redundant and gets dropped. Runs to a fixed point, so shortcuts cascade
-        (e.g. dropping ``b`` may then let ``a`` connect straight to ``d``).
+        Greedily extends the current anchor waypoint forward as far as a straight
+        line to it stays collision-free, then commits the farthest waypoint still
+        visible from it and continues from there (classic "string pulling"). Each
+        waypoint is tested against the current anchor at most once, so this is
+        linear in the number of waypoints rather than quadratic.
 
         :param waypoints: The waypoints of a path, in the search space's reference
             frame.
         :return: The shortcut waypoints.
         """
-        waypoints = list(waypoints)
-        shortened = True
-        while shortened and len(waypoints) > 2:
-            shortened = False
-            i = 0
-            while i < len(waypoints) - 2:
-                if self._segment_is_collision_free(waypoints[i], waypoints[i + 2]):
-                    del waypoints[i + 1]
-                    shortened = True
-                else:
-                    i += 1
-        return waypoints
+        if len(waypoints) <= 2:
+            return list(waypoints)
+
+        result = [waypoints[0]]
+        anchor_index = 0
+        for index in range(2, len(waypoints)):
+            if not self._segment_is_collision_free(
+                waypoints[anchor_index], waypoints[index]
+            ):
+                result.append(waypoints[index - 1])
+                anchor_index = index - 1
+        result.append(waypoints[-1])
+        return result
 
     def _segment_is_collision_free(self, start: Point3, end: Point3) -> bool:
         """

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -14,7 +14,7 @@ from random_events.product_algebra import Event
 from random_events.product_algebra import SimpleEvent
 from rtree import index
 from sortedcontainers import SortedSet
-from typing_extensions import List, Optional, Dict, Sequence, Self
+from typing_extensions import List, Optional, Dict, Sequence, Self, Tuple
 
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.datastructures.variables import SpatialVariables
@@ -40,6 +40,93 @@ from semantic_digital_twin.world_description.world_entity import (
 
 logger = logging.getLogger(__name__)
 
+Coordinates3D = Tuple[float, float, float]
+"""
+A raw, unlabeled 3-D point, expressed in a :class:`GraphOfBoundingBoxes` search space's
+reference frame.
+
+Used internally for path shortcutting, where working with plain floats is far cheaper
+than symbolic :class:`Point3` arithmetic.
+"""
+
+
+def _segment_box_overlap(
+    start: Coordinates3D, direction: Coordinates3D, box: BoundingBox
+) -> Optional[Tuple[float, float]]:
+    """
+    Clip the parametrized segment ``start + t * direction`` (``t`` in ``[0, 1]``)
+    against an axis-aligned box, using the slab method.
+
+    :param start: The segment's start point.
+    :param direction: The vector from the segment's start to its end.
+    :param box: The box to clip the segment against.
+    :return: The ``(t_min, t_max)`` sub-interval of the segment that lies inside
+        ``box``, or None if the segment misses ``box`` entirely.
+    """
+    bounds = (
+        (box.x_interval.lower, box.x_interval.upper),
+        (box.y_interval.lower, box.y_interval.upper),
+        (box.z_interval.lower, box.z_interval.upper),
+    )
+
+    t_min, t_max = 0.0, 1.0
+    for coordinate, delta, (lower, upper) in zip(start, direction, bounds):
+        if abs(delta) < 1e-12:
+            if coordinate < lower or coordinate > upper:
+                return None
+            continue
+        t_enter = (lower - coordinate) / delta
+        t_exit = (upper - coordinate) / delta
+        if t_enter > t_exit:
+            t_enter, t_exit = t_exit, t_enter
+        t_min = max(t_min, t_enter)
+        t_max = min(t_max, t_exit)
+        if t_min > t_max:
+            return None
+    return t_min, t_max
+
+
+def _covers_unit_interval(
+    intervals: List[Tuple[float, float]], tolerance: float = 1e-6
+) -> bool:
+    """
+    Check whether a set of ``(t_min, t_max)`` intervals fully covers ``[0, 1]``.
+
+    :param intervals: The intervals to merge and check.
+    :param tolerance: The largest gap between neighbouring intervals that still counts
+        as continuous coverage, to absorb floating-point noise at box boundaries.
+    :return: True if the union of ``intervals`` covers ``[0, 1]``.
+    """
+    covered_up_to = 0.0
+    for lower, upper in sorted(intervals):
+        if lower > covered_up_to + tolerance:
+            return False
+        covered_up_to = max(covered_up_to, upper)
+        if covered_up_to >= 1.0 - tolerance:
+            return True
+    return covered_up_to >= 1.0 - tolerance
+
+
+@dataclass
+class BoundingBoxAdjacency:
+    """
+    Edge payload connecting two adjacent bounding boxes in a
+    :class:`GraphOfBoundingBoxes`.
+    """
+
+    intersection: BoundingBox
+    """
+    The region where the two adjacent boxes overlap or touch.
+    """
+
+    weight: float
+    """
+    Euclidean distance between the centers of the two adjacent boxes.
+
+    Used as the edge cost for shortest-path search, so that the search minimizes
+    travelled distance instead of the number of boxes crossed.
+    """
+
 
 @dataclass
 class GraphOfBoundingBoxes(GraphOfConvexSets):
@@ -51,7 +138,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
     node is a box; every edge represents the adjacency between two boxes.
     """
 
-    graph: rx.PyGraph[BoundingBox] = field(
+    graph: rx.PyGraph[BoundingBox, BoundingBoxAdjacency] = field(
         default_factory=lambda: rx.PyGraph(multigraph=False)
     )
     """
@@ -84,7 +171,9 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         """
         Calculate the connectivity of the graph by checking for intersections between
         the bounding boxes of the nodes. This uses an R-tree for efficient spatial
-        indexing and intersection queries.
+        indexing and intersection queries. Each edge is weighted by the Euclidean
+        distance between the centers of the two boxes it connects, for use by
+        :meth:`path_from_to`.
 
         :param tolerance: The tolerance for the intersection when calculating the
             connectivity.
@@ -111,13 +200,19 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
                 HomogeneousTransformationMatrix(reference_frame=self.world.root),
             )
 
+        def _center(mn, mx):
+            return ((mn[0] + mx[0]) / 2, (mn[1] + mx[1]) / 2, (mn[2] + mx[2]) / 2)
+
+        def _distance(a, b):
+            return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2) ** 0.5
+
         # Build a 3-D R-tree
         prop = index.Property()
         prop.dimension = 3
         rtree_idx = index.Index(properties=prop)
 
         node_list = list(self.graph.nodes())
-        orig_mins, orig_maxs, expanded = [], [], []
+        orig_mins, orig_maxs, expanded, centers = [], [], [], []
 
         # Record every node once, insert it into the index
         for n in node_list:
@@ -135,6 +230,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
             orig_mins.append(mn)
             orig_maxs.append(mx)
             expanded.append(ex)
+            centers.append(_center(mn, mx))
             rtree_idx.insert(len(orig_mins) - 1, ex)
 
         # Query & link, skip self-loops and symmetric pairs
@@ -146,12 +242,13 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
                 if not _overlap(mn_i, mx_i, mn_j, mx_j):
                     continue  # no true overlap
                 box = _intersection_box(mn_i, mx_i, mn_j, mx_j)
+                weight = _distance(centers[i], centers[j])
 
                 # Map from the local list positions back to the graph node indices
                 u = self.box_to_index_map[node_list[i]]
                 v = self.box_to_index_map[node_list[j]]
 
-                self.graph.add_edge(u, v, box)
+                self.graph.add_edge(u, v, BoundingBoxAdjacency(box, weight))
 
     def draw(self):
         import rustworkx.visualization
@@ -205,11 +302,17 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         Calculate a connected path from a start pose to a goal pose.
 
         .. note::
-            Uses a single-source Dijkstra search (unweighted, i.e. hop-count shortest
-            path) rather than enumerating all shortest paths and picking the first one.
-            Free-space decompositions with thousands of nodes routinely have an
-            exponential number of equally-short paths, which makes enumerating all of
-            them intractable; finding just one is not.
+            Uses a single-source Dijkstra search, weighted by the Euclidean distance
+            between adjacent boxes' centers, rather than enumerating all shortest paths
+            and picking the first one. Free-space decompositions with thousands of
+            nodes routinely have an exponential number of equally-short (by hop count)
+            paths, which makes enumerating all of them intractable; finding the one
+            that minimizes travelled distance is not.
+
+        .. note::
+            The resulting waypoints are shortcut afterwards: any waypoint that a
+            straight line can bypass without leaving free space is dropped. See
+            :meth:`_shortcut_waypoints`.
 
         :param start: The start pose.
         :param goal: The goal pose.
@@ -232,7 +335,12 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         start_index = self.box_to_index_map[start_node]
         goal_index = self.box_to_index_map[goal_node]
 
-        paths = rx.dijkstra_shortest_paths(self.graph, start_index, target=goal_index)
+        paths = rx.dijkstra_shortest_paths(
+            self.graph,
+            start_index,
+            target=goal_index,
+            weight_fn=lambda adjacency: adjacency.weight,
+        )
 
         # if it is not possible to find a path
         if goal_index not in paths:
@@ -240,19 +348,84 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
 
         path = paths[goal_index]
 
-        # build the path
-        result = [start]
+        # build the path, working in raw coordinates (in the search space's reference
+        # frame) so shortcutting doesn't repeatedly pay for symbolic Point3 arithmetic
+        waypoints = [self._coordinates_in_search_space_frame(start)]
 
         for source, target in zip(path, path[1:]):
+            intersection = self.graph.get_edge_data(source, target).intersection
+            waypoints.append(
+                (
+                    intersection.x_interval.center(),
+                    intersection.y_interval.center(),
+                    intersection.z_interval.center(),
+                )
+            )
 
-            intersection: BoundingBox = self.graph.get_edge_data(source, target)
-            x_target = intersection.x_interval.center()
-            y_target = intersection.y_interval.center()
-            z_target = intersection.z_interval.center()
-            result.append(Point3(x_target, y_target, z_target))
+        waypoints.append(self._coordinates_in_search_space_frame(goal))
+        waypoints = self._shortcut_waypoints(waypoints)
 
+        result = [start]
+        result.extend(Point3(x, y, z) for x, y, z in waypoints[1:-1])
         result.append(goal)
         return result
+
+    def _coordinates_in_search_space_frame(self, point: Point3) -> Coordinates3D:
+        """
+        Express a point as raw floats in the search space's reference frame.
+
+        :param point: The point to convert.
+        :return: The point's coordinates in the search space's reference frame.
+        """
+        transformed = self.world.transform(point, self.search_space.reference_frame)
+        return float(transformed.x), float(transformed.y), float(transformed.z)
+
+    def _shortcut_waypoints(
+        self, waypoints: List[Coordinates3D]
+    ) -> List[Coordinates3D]:
+        """
+        Drop waypoints that a straight line can bypass without leaving free space.
+
+        Repeatedly inspects consecutive triples ``(a, b, c)``: if the straight segment
+        from ``a`` to ``c`` never leaves the union of the graph's bounding-box nodes,
+        ``b`` is redundant and gets dropped. Runs to a fixed point, so shortcuts cascade
+        (e.g. dropping ``b`` may then let ``a`` connect straight to ``d``).
+
+        :param waypoints: The waypoints of a path, in the search space's reference
+            frame.
+        :return: The shortcut waypoints.
+        """
+        waypoints = list(waypoints)
+        shortened = True
+        while shortened and len(waypoints) > 2:
+            shortened = False
+            i = 0
+            while i < len(waypoints) - 2:
+                if self._segment_is_collision_free(waypoints[i], waypoints[i + 2]):
+                    del waypoints[i + 1]
+                    shortened = True
+                else:
+                    i += 1
+        return waypoints
+
+    def _segment_is_collision_free(
+        self, start: Coordinates3D, end: Coordinates3D
+    ) -> bool:
+        """
+        Check whether a straight-line segment stays entirely within free space.
+
+        :param start: The segment's start point, in the search space's reference frame.
+        :param end: The segment's end point, in the search space's reference frame.
+        :return: True if the segment never leaves the union of the graph's bounding-box
+            nodes.
+        """
+        direction = (end[0] - start[0], end[1] - start[1], end[2] - start[2])
+        covered = [
+            overlap
+            for node in self.graph.nodes()
+            if (overlap := _segment_box_overlap(start, direction, node)) is not None
+        ]
+        return _covers_unit_interval(covered)
 
     @classmethod
     def obstacles_from_semantic_annotations(

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -7,14 +7,15 @@ from functools import reduce
 from operator import or_
 
 import matplotlib.pyplot as plt
+import numpy as np
 import plotly.graph_objects as go
 import rustworkx as rx
-from random_events.interval import reals, closed
+from random_events.interval import reals, closed, Interval
 from random_events.product_algebra import Event
 from random_events.product_algebra import SimpleEvent
 from rtree import index
 from sortedcontainers import SortedSet
-from typing_extensions import List, Optional, Dict, Sequence, Self, Tuple
+from typing_extensions import List, Optional, Dict, Sequence, Self
 
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.datastructures.variables import SpatialVariables
@@ -25,11 +26,10 @@ from semantic_digital_twin.semantic_annotations.semantic_annotations import (
 from semantic_digital_twin.spatial_types import (
     HomogeneousTransformationMatrix,
     Point3,
-    Vector3,
 )
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.connections import FixedConnection
-from semantic_digital_twin.world_description.geometry import BoundingBox, Color
+from semantic_digital_twin.world_description.geometry import BoundingBox, Bounds, Color
 from semantic_digital_twin.world_description.graph_of_convex_sets.base import (
     GraphOfConvexSets,
 )
@@ -43,61 +43,6 @@ from semantic_digital_twin.world_description.world_entity import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _segment_box_overlap(
-    coordinates: Tuple[float, float, float],
-    deltas: Tuple[float, float, float],
-    lower: Tuple[float, float, float],
-    upper: Tuple[float, float, float],
-) -> Optional[Tuple[float, float]]:
-    """
-    Clip the parametrized segment ``coordinates + t * deltas`` (``t`` in ``[0, 1]``)
-    against an axis-aligned box, using the slab method.
-
-    :param coordinates: The segment's start point, as plain floats.
-    :param deltas: The vector from the segment's start to its end, as plain floats.
-    :param lower: The box's minimum corner, as plain floats.
-    :param upper: The box's maximum corner, as plain floats.
-    :return: The ``(t_min, t_max)`` sub-interval of the segment that lies inside
-        the box, or None if the segment misses it entirely.
-    """
-    t_min, t_max = 0.0, 1.0
-    for coordinate, delta, lo, hi in zip(coordinates, deltas, lower, upper):
-        if abs(delta) < 1e-12:
-            if coordinate < lo or coordinate > hi:
-                return None
-            continue
-        t_enter = (lo - coordinate) / delta
-        t_exit = (hi - coordinate) / delta
-        if t_enter > t_exit:
-            t_enter, t_exit = t_exit, t_enter
-        t_min = max(t_min, t_enter)
-        t_max = min(t_max, t_exit)
-        if t_min > t_max:
-            return None
-    return t_min, t_max
-
-
-def _covers_unit_interval(
-    intervals: List[Tuple[float, float]], tolerance: float = 1e-6
-) -> bool:
-    """
-    Check whether a set of ``(t_min, t_max)`` intervals fully covers ``[0, 1]``.
-
-    :param intervals: The intervals to merge and check.
-    :param tolerance: The largest gap between neighbouring intervals that still counts
-        as continuous coverage, to absorb floating-point noise at box boundaries.
-    :return: True if the union of ``intervals`` covers ``[0, 1]``.
-    """
-    covered_up_to = 0.0
-    for lower, upper in sorted(intervals):
-        if lower > covered_up_to + tolerance:
-            return False
-        covered_up_to = max(covered_up_to, upper)
-        if covered_up_to >= 1.0 - tolerance:
-            return True
-    return covered_up_to >= 1.0 - tolerance
 
 
 @dataclass
@@ -378,12 +323,7 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         # BoundingBox.x_interval/y_interval/z_interval recompute symbolic arithmetic
         # on every access, so every node's bounds are read as plain floats exactly
         # once here rather than once per collision check below.
-        node_bounds = []
-        for node in self.graph.nodes():
-            x, y, z = node.x_interval, node.y_interval, node.z_interval
-            node_bounds.append(
-                ((x.lower, y.lower, z.lower), (x.upper, y.upper, z.upper))
-            )
+        node_bounds = [node.to_array_bounds() for node in self.graph.nodes()]
 
         result = [waypoints[0]]
         anchor_index = 0
@@ -397,33 +337,30 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         return result
 
     def _segment_is_collision_free(
-        self,
-        start: Point3,
-        end: Point3,
-        node_bounds: List[
-            Tuple[Tuple[float, float, float], Tuple[float, float, float]]
-        ],
+        self, start: Point3, end: Point3, node_bounds: List[Bounds[np.ndarray]]
     ) -> bool:
         """
         Check whether a straight-line segment stays entirely within free space.
 
         :param start: The segment's start point, in the search space's reference frame.
         :param end: The segment's end point, in the search space's reference frame.
-        :param node_bounds: The graph's nodes' ``(lower, upper)`` corners, as plain
-            floats, in the same order as :meth:`_shortcut_waypoints` collected them.
+        :param node_bounds: The graph's nodes' bounds, in the same order
+            :meth:`_shortcut_waypoints` collected them.
         :return: True if the segment never leaves the union of the graph's bounding-box
             nodes.
         """
         direction = end - start
-        coordinates = (float(start.x), float(start.y), float(start.z))
-        deltas = (float(direction.x), float(direction.y), float(direction.z))
-        covered = [
-            overlap
-            for lower, upper in node_bounds
-            if (overlap := _segment_box_overlap(coordinates, deltas, lower, upper))
-            is not None
+        coordinates = np.array([float(start.x), float(start.y), float(start.z)])
+        deltas = np.array([float(direction.x), float(direction.y), float(direction.z)])
+        covered_intervals = [
+            interval
+            for bounds in node_bounds
+            if (interval := bounds.clip_segment(coordinates, deltas)) is not None
         ]
-        return _covers_unit_interval(covered)
+        if not covered_intervals:
+            return False
+        covered = Interval.from_simple_sets(*covered_intervals).make_disjoint()
+        return (closed(0.0, 1.0) - covered).is_empty()
 
     @classmethod
     def obstacles_from_semantic_annotations(

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -46,20 +46,20 @@ logger = logging.getLogger(__name__)
 
 
 def _segment_box_overlap(
-    start: Point3, direction: Vector3, box: BoundingBox
+    coordinates: Tuple[float, float, float],
+    deltas: Tuple[float, float, float],
+    box: BoundingBox,
 ) -> Optional[Tuple[float, float]]:
     """
-    Clip the parametrized segment ``start + t * direction`` (``t`` in ``[0, 1]``)
+    Clip the parametrized segment ``coordinates + t * deltas`` (``t`` in ``[0, 1]``)
     against an axis-aligned box, using the slab method.
 
-    :param start: The segment's start point.
-    :param direction: The vector from the segment's start to its end.
+    :param coordinates: The segment's start point, as plain floats.
+    :param deltas: The vector from the segment's start to its end, as plain floats.
     :param box: The box to clip the segment against.
     :return: The ``(t_min, t_max)`` sub-interval of the segment that lies inside
         ``box``, or None if the segment misses ``box`` entirely.
     """
-    coordinates = (float(start.x), float(start.y), float(start.z))
-    deltas = (float(direction.x), float(direction.y), float(direction.z))
     bounds = (
         (box.x_interval.lower, box.x_interval.upper),
         (box.y_interval.lower, box.y_interval.upper),
@@ -398,10 +398,12 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
             nodes.
         """
         direction = end - start
+        coordinates = (float(start.x), float(start.y), float(start.z))
+        deltas = (float(direction.x), float(direction.y), float(direction.z))
         covered = [
             overlap
             for node in self.graph.nodes()
-            if (overlap := _segment_box_overlap(start, direction, node)) is not None
+            if (overlap := _segment_box_overlap(coordinates, deltas, node)) is not None
         ]
         return _covers_unit_interval(covered)
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/graph_of_convex_sets/boxes.py
@@ -48,7 +48,8 @@ logger = logging.getLogger(__name__)
 def _segment_box_overlap(
     coordinates: Tuple[float, float, float],
     deltas: Tuple[float, float, float],
-    box: BoundingBox,
+    lower: Tuple[float, float, float],
+    upper: Tuple[float, float, float],
 ) -> Optional[Tuple[float, float]]:
     """
     Clip the parametrized segment ``coordinates + t * deltas`` (``t`` in ``[0, 1]``)
@@ -56,24 +57,19 @@ def _segment_box_overlap(
 
     :param coordinates: The segment's start point, as plain floats.
     :param deltas: The vector from the segment's start to its end, as plain floats.
-    :param box: The box to clip the segment against.
+    :param lower: The box's minimum corner, as plain floats.
+    :param upper: The box's maximum corner, as plain floats.
     :return: The ``(t_min, t_max)`` sub-interval of the segment that lies inside
-        ``box``, or None if the segment misses ``box`` entirely.
+        the box, or None if the segment misses it entirely.
     """
-    bounds = (
-        (box.x_interval.lower, box.x_interval.upper),
-        (box.y_interval.lower, box.y_interval.upper),
-        (box.z_interval.lower, box.z_interval.upper),
-    )
-
     t_min, t_max = 0.0, 1.0
-    for coordinate, delta, (lower, upper) in zip(coordinates, deltas, bounds):
+    for coordinate, delta, lo, hi in zip(coordinates, deltas, lower, upper):
         if abs(delta) < 1e-12:
-            if coordinate < lower or coordinate > upper:
+            if coordinate < lo or coordinate > hi:
                 return None
             continue
-        t_enter = (lower - coordinate) / delta
-        t_exit = (upper - coordinate) / delta
+        t_enter = (lo - coordinate) / delta
+        t_exit = (hi - coordinate) / delta
         if t_enter > t_exit:
             t_enter, t_exit = t_exit, t_enter
         t_min = max(t_min, t_enter)
@@ -379,23 +375,42 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         if len(waypoints) <= 2:
             return list(waypoints)
 
+        # BoundingBox.x_interval/y_interval/z_interval recompute symbolic arithmetic
+        # on every access, so every node's bounds are read as plain floats exactly
+        # once here rather than once per collision check below.
+        node_bounds = []
+        for node in self.graph.nodes():
+            x, y, z = node.x_interval, node.y_interval, node.z_interval
+            node_bounds.append(
+                ((x.lower, y.lower, z.lower), (x.upper, y.upper, z.upper))
+            )
+
         result = [waypoints[0]]
         anchor_index = 0
         for index in range(2, len(waypoints)):
             if not self._segment_is_collision_free(
-                waypoints[anchor_index], waypoints[index]
+                waypoints[anchor_index], waypoints[index], node_bounds
             ):
                 result.append(waypoints[index - 1])
                 anchor_index = index - 1
         result.append(waypoints[-1])
         return result
 
-    def _segment_is_collision_free(self, start: Point3, end: Point3) -> bool:
+    def _segment_is_collision_free(
+        self,
+        start: Point3,
+        end: Point3,
+        node_bounds: List[
+            Tuple[Tuple[float, float, float], Tuple[float, float, float]]
+        ],
+    ) -> bool:
         """
         Check whether a straight-line segment stays entirely within free space.
 
         :param start: The segment's start point, in the search space's reference frame.
         :param end: The segment's end point, in the search space's reference frame.
+        :param node_bounds: The graph's nodes' ``(lower, upper)`` corners, as plain
+            floats, in the same order as :meth:`_shortcut_waypoints` collected them.
         :return: True if the segment never leaves the union of the graph's bounding-box
             nodes.
         """
@@ -404,8 +419,9 @@ class GraphOfBoundingBoxes(GraphOfConvexSets):
         deltas = (float(direction.x), float(direction.y), float(direction.z))
         covered = [
             overlap
-            for node in self.graph.nodes()
-            if (overlap := _segment_box_overlap(coordinates, deltas, node)) is not None
+            for lower, upper in node_bounds
+            if (overlap := _segment_box_overlap(coordinates, deltas, lower, upper))
+            is not None
         ]
         return _covers_unit_interval(covered)
 

--- a/test/semantic_digital_twin_test/test_worlds/test_gcs.py
+++ b/test/semantic_digital_twin_test/test_worlds/test_gcs.py
@@ -100,7 +100,9 @@ def test_reachability(graph_of_convex_sets_unit_box: GraphOfBoundingBoxesFixture
     path = graph_of_convex_sets_unit_box.graph_of_convex_sets.path_from_to(
         start_point, target_point
     )
-    assert len(path) == 4
+    # Shortcutting collapses the two waypoints hugging the box's corner into one,
+    # since a straight line from start_point to (0, 2, 0.5) already clears the box.
+    assert len(path) == 3
 
 
 def test_plot(graph_of_convex_sets_unit_box: GraphOfBoundingBoxesFixture):
@@ -260,6 +262,91 @@ def test_from_world_with_rotated_box():
         assert bounding_box_T_world.roll == 0
         assert bounding_box_T_world.pitch == 0
         assert allclose(bounding_box_T_world.yaw, rotated_box_body_pose.to_pose().yaw)
+
+
+def test_path_from_to_prefers_shorter_distance_over_fewer_hops():
+    """
+    A detour with many small hops that is geometrically short must be preferred over a
+    detour with few large hops that is geometrically long.
+
+    Regression test: ``path_from_to`` used to run an unweighted (hop-count) Dijkstra
+    search, so a four-hop detour through three huge boxes could beat an eleven-hop
+    detour through small boxes even though the four-hop detour is far longer in real
+    distance. There is no direct line of sight between start and goal (a "wall" blocks
+    it), so this keeps being true even after shortcutting simplifies whichever detour
+    was chosen.
+    """
+    world = World()
+    with world.modify_world():
+        world.add_kinematic_structure_entity(Body())
+
+    graph_of_convex_sets = GraphOfBoundingBoxes(world)
+
+    origin = world.root.global_pose
+    start_box = BoundingBox(0, 0, 0, 1, 1, 1, origin)
+    goal_box = BoundingBox(10, 0, 0, 11, 1, 1, origin)
+    # No boxes exist at y=[0, 1] between start_box and goal_box - a "wall" that rules
+    # out a direct line of sight, so reaching goal_box always requires a detour.
+
+    # Short way: hop over the wall through a chain of ten small boxes.
+    over_the_wall = [BoundingBox(i, 1, 0, i + 1, 2, 1, origin) for i in range(10)]
+
+    # Long way: dip far below the wall and back up through three huge boxes. Costs
+    # only four hops overall, but each hop's center-to-center distance is huge.
+    below_the_wall = [
+        BoundingBox(0, -100, 0, 1, 1, 1, origin),
+        BoundingBox(0, -100, 0, 11, -99, 1, origin),
+        BoundingBox(10, -100, 0, 11, 1, 1, origin),
+    ]
+
+    for box in [start_box, goal_box, *over_the_wall, *below_the_wall]:
+        graph_of_convex_sets.add_node(box)
+    graph_of_convex_sets.calculate_connectivity()
+
+    start = Point3(0.5, 0.5, 0.5, reference_frame=world.root)
+    goal = Point3(10.5, 0.5, 0.5, reference_frame=world.root)
+
+    path = graph_of_convex_sets.path_from_to(start, goal)
+
+    total_length = sum(
+        float(np.linalg.norm(a.to_np()[:3] - b.to_np()[:3]))
+        for a, b in zip(path, path[1:])
+    )
+    # The short way over the wall totals roughly 10-11 units; the long way below it
+    # totals roughly 200 (a ~100-unit dip, there and back). 30 comfortably separates
+    # the two, so this only passes if the short way was chosen.
+    assert total_length < 30
+
+
+def test_path_from_to_shortcuts_redundant_waypoints():
+    """
+    Waypoints that a straight line can bypass without leaving free space must be dropped
+    from the returned path.
+    """
+    world = World()
+    with world.modify_world():
+        world.add_kinematic_structure_entity(Body())
+
+    graph_of_convex_sets = GraphOfBoundingBoxes(world)
+
+    origin = world.root.global_pose
+    start_box = BoundingBox(0, 0, 0, 1, 1, 1, origin)
+    # Ten boxes tiling one straight, unobstructed corridor from start_box to goal_box.
+    chain = [BoundingBox(i, 0, 0, i + 1, 1, 1, origin) for i in range(1, 10)]
+    goal_box = BoundingBox(10, 0, 0, 11, 1, 1, origin)
+
+    for box in [start_box, *chain, goal_box]:
+        graph_of_convex_sets.add_node(box)
+    graph_of_convex_sets.calculate_connectivity()
+
+    start = Point3(0.5, 0.5, 0.5, reference_frame=world.root)
+    goal = Point3(10.5, 0.5, 0.5, reference_frame=world.root)
+
+    path = graph_of_convex_sets.path_from_to(start, goal)
+
+    # Every intermediate waypoint is redundant: the straight line from start to goal
+    # never leaves the corridor, so it should be shortcut down to just the endpoints.
+    assert path == [start, goal]
 
 
 def test_path_from_to_scales_to_a_real_apartment_scene():


### PR DESCRIPTION
…utting

path_from_to previously ran an unweighted (hop-count) Dijkstra search, so a detour through a few huge boxes could beat a longer chain of small boxes even when it was far longer in real distance. Edges are now weighted by the Euclidean distance between adjacent boxes' centers, and Dijkstra minimizes that instead of hop count.

The resulting waypoints are also shortcut afterwards: any waypoint that a straight line can bypass without leaving free space is dropped, removing unnecessary zigzags through the box partition.

Made with the help of Claude.

## GCS Path-Finding: Before/After Across CRAM's URDF Environments

_Old = unweighted Dijkstra, no shortcutting. New = weighted Dijkstra + shortcutting (this PR). 20 randomly sampled free-space point pairs per environment, 2-D navigation map over each environment's full XY footprint at a fixed 1.2 m height band._

| Environment | Nodes / Edges | Time (mean, old→new) | Hops (mean, old→new) | Distance (mean, old→new) |
|---|---|---|---|---|
| Apartment | 487 / 494 | 0.070s → 0.162s | 10.85 → 1.90 (**−82%**) | 9.06m → 7.54m (**−17%**) |
| Apartment (no walls) | 294 / 300 | 0.230s → 0.264s | 11.00 → 1.55 (**−86%**) | 6.19m → 5.98m (**−3%**) |
| Kitchen | 128 / 129 | 0.043s → 0.063s | 6.25 → 2.05 (**−67%**) | 4.60m → 3.84m (**−17%**) |
| Kitchen (small) | 63 / 65 | 0.008s → 0.019s | 5.05 → 2.30 (**−54%**) | 5.19m → 4.43m (**−15%**) |
| Broken Kitchen | 175 / 177 | 0.046s → 0.082s | 10.55 → 2.25 (**−79%**) | 6.60m → 4.56m (**−31%**) |
| IAI Kitchen | — | Failed: no collision geometry (all-visual URDF, unrelated to this PR) | — | — |
| **Average (5 envs)** | — | 0.079s → 0.118s (**1.5×**) | 8.74 → 2.01 (**−77%**) | 6.33m → 5.27m (**−17%**) |

Consistent story across every real environment: **~77% fewer waypoints and ~17% shorter paths, at a ~1.5× time cost** (all still sub-second).

**Caveats:**
- IAI Kitchen has no `has_collision()` bodies at all in this checkout — a pre-existing property of the asset, not something this PR touches.
- The height band (`[min_z, min_z+1.2m]`) is auto-derived from each environment's lowest collision geometry, not hand-tuned per room — e.g. Apartment's band came out as `[-0.70, 0.50]`, which may include some below-floor structure. Good enough for a relative before/after comparison, not a claim of an ideal navigation slice.
- Profiling shows the dominant remaining cost in `path_from_to` (both old and new) is `node_of_point`'s O(n) linear scan with uncached symbolic bounding-box checks — pre-existing, not introduced by this PR.