### PR TITLE
Add a prefix-path package locator to semantic_digital_twin

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/package_resolver.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/package_resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import glob
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -61,13 +62,78 @@ class ROSPackagePathLocator(PackageLocator):
 
 
 @dataclass
+class PrefixPathPackageLocator(PackageLocator):
+    """
+    Resolves packages by searching install prefixes directly on disk, without any ROS
+    tooling installed.
+    """
+
+    additional_prefixes: List[str] = field(default_factory=list)
+    """
+    Extra install prefixes to search before the environment and workspace prefixes.
+    """
+
+    def _environment_prefixes(self) -> List[str]:
+        """
+        :return: Prefixes named by ``AMENT_PREFIX_PATH`` and ``CMAKE_PREFIX_PATH``.
+        """
+        prefixes = []
+        for variable in ("AMENT_PREFIX_PATH", "CMAKE_PREFIX_PATH"):
+            prefixes += [
+                entry for entry in os.environ.get(variable, "").split(":") if entry
+            ]
+        return prefixes
+
+    def _workspace_prefixes(self) -> List[str]:
+        """
+        :return: Install directories of common workspace layouts under the home
+            directory and ``/opt/ros``.
+        """
+        home = os.path.expanduser("~")
+        return [
+            *glob.glob(os.path.join(home, "*_ws", "install")),
+            *glob.glob(os.path.join(home, "*", "install")),
+            *glob.glob("/opt/ros/*"),
+        ]
+
+    def search_prefixes(self) -> List[str]:
+        """
+        :return: Every install prefix searched, in order of precedence.
+        """
+        return [
+            *self.additional_prefixes,
+            *self._environment_prefixes(),
+            *self._workspace_prefixes(),
+        ]
+
+    def resolve(self, package_name: str) -> str:
+        prefixes = self.search_prefixes()
+        for prefix in prefixes:
+            for candidate in (
+                os.path.join(prefix, package_name, "share", package_name),
+                os.path.join(prefix, "share", package_name),
+                os.path.join(prefix, package_name),
+            ):
+                if os.path.isdir(candidate):
+                    return candidate
+        raise PackageResolutionError(
+            package_name=package_name,
+            details=f"not found in any of {len(prefixes)} install prefixes",
+        )
+
+
+@dataclass
 class ROSPackageLocator(PackageLocator):
     """
     Tries multiple package locators in order.
     """
 
     locators: List[PackageLocator] = field(
-        default_factory=lambda: [AmentPackageLocator(), ROSPackagePathLocator()]
+        default_factory=lambda: [
+            AmentPackageLocator(),
+            ROSPackagePathLocator(),
+            PrefixPathPackageLocator(),
+        ]
     )
 
     def resolve(self, package_name: str) -> str:

--- a/test/semantic_digital_twin_test/test_adapters/test_package_resolver.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_package_resolver.py
@@ -1,0 +1,160 @@
+import os
+
+import pytest
+
+from semantic_digital_twin.adapters.package_resolver import (
+    PackageUriResolver,
+    PrefixPathPackageLocator,
+    ROSPackageLocator,
+)
+from semantic_digital_twin.exceptions import PackageResolutionError
+
+
+def _make_package(base_directory, *segments):
+    """
+    :return: The path of a package share directory created under ``base_directory``.
+    """
+    package_directory = os.path.join(base_directory, *segments)
+    os.makedirs(package_directory, exist_ok=True)
+    return package_directory
+
+
+# %% resolving install prefix layouts
+
+
+class TestPrefixPathPackageLocator:
+    """
+    Resolution of a package name by searching install prefixes directly on disk.
+    """
+
+    def test_resolves_package_directory_from_ament_prefix_path(
+        self, tmp_path, monkeypatch
+    ):
+        expected = _make_package(tmp_path, "some_package", "share", "some_package")
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(tmp_path))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator()
+
+        assert locator.resolve("some_package") == expected
+
+    def test_resolves_package_directory_from_cmake_prefix_path(
+        self, tmp_path, monkeypatch
+    ):
+        expected = _make_package(tmp_path, "some_package", "share", "some_package")
+        monkeypatch.delenv("AMENT_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("CMAKE_PREFIX_PATH", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator()
+
+        assert locator.resolve("some_package") == expected
+
+    def test_resolves_merged_install_share_layout(self, tmp_path, monkeypatch):
+        expected = _make_package(tmp_path, "share", "some_package")
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(tmp_path))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator()
+
+        assert locator.resolve("some_package") == expected
+
+    def test_resolves_bare_package_directory(self, tmp_path, monkeypatch):
+        expected = _make_package(tmp_path, "some_package")
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(tmp_path))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator()
+
+        assert locator.resolve("some_package") == expected
+
+    def test_resolves_against_workspace_glob_under_home_directory(
+        self, tmp_path, monkeypatch
+    ):
+        expected = _make_package(
+            tmp_path, "robot_ws", "install", "some_package", "share", "some_package"
+        )
+        monkeypatch.delenv("AMENT_PREFIX_PATH", raising=False)
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        locator = PrefixPathPackageLocator()
+
+        assert locator.resolve("some_package") == expected
+
+    def test_additional_prefixes_take_precedence_over_environment(
+        self, tmp_path, monkeypatch
+    ):
+        environment_prefix = tmp_path / "from_environment"
+        additional_prefix = tmp_path / "from_additional_prefixes"
+        environment_match = _make_package(
+            str(environment_prefix), "some_package", "share", "some_package"
+        )
+        additional_match = _make_package(
+            str(additional_prefix), "some_package", "share", "some_package"
+        )
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(environment_prefix))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator(additional_prefixes=[str(additional_prefix)])
+
+        assert locator.resolve("some_package") == additional_match
+        assert additional_match != environment_match
+
+    def test_raises_package_resolution_error_when_not_found_anywhere(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("AMENT_PREFIX_PATH", raising=False)
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        locator = PrefixPathPackageLocator()
+
+        with pytest.raises(PackageResolutionError) as error:
+            locator.resolve("missing_package")
+        assert error.value.package_name == "missing_package"
+
+
+# %% integration with the default resolver chain
+
+
+class TestROSPackageLocatorDefaultChain:
+    """
+    The default locator chain closes the gap for every consumer that builds a resolver
+    with no explicit configuration.
+    """
+
+    def test_default_chain_resolves_via_prefix_path_locator(
+        self, tmp_path, monkeypatch
+    ):
+        expected = _make_package(tmp_path, "some_package", "share", "some_package")
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(tmp_path))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.delenv("ROS_PACKAGE_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        resolved = ROSPackageLocator().resolve("some_package")
+
+        assert resolved == expected
+
+    def test_package_uri_resolver_resolves_a_file_via_prefix_path(
+        self, tmp_path, monkeypatch
+    ):
+        package_directory = _make_package(
+            tmp_path, "some_package", "share", "some_package"
+        )
+        expected_file = os.path.join(package_directory, "model.urdf")
+        with open(expected_file, "w") as file:
+            file.write("<robot/>")
+        monkeypatch.setenv("AMENT_PREFIX_PATH", str(tmp_path))
+        monkeypatch.delenv("CMAKE_PREFIX_PATH", raising=False)
+        monkeypatch.delenv("ROS_PACKAGE_PATH", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+
+        resolved = PackageUriResolver().resolve("package://some_package/model.urdf")
+
+        assert resolved == expected_file


### PR DESCRIPTION
Adds `PrefixPathPackageLocator` to `semantic_digital_twin`'s package resolver, so it can find a ROS package via `AMENT_PREFIX_PATH`/`CMAKE_PREFIX_PATH` and common workspace layouts, without any ROS tooling installed. Wired into `ROSPackageLocator`'s default chain for every consumer.

New tests in `test_package_resolver.py`, 

