### PR TITLE
MotionStatechart plotter collapses Collision Avoidance Goals to improve readability

### DIFF
--- a/coraplex/src/coraplex/orm/ormatic_interface.py
+++ b/coraplex/src/coraplex/orm/ormatic_interface.py
@@ -24,7 +24,6 @@ import coraplex.datastructures.dataclasses
 import coraplex.datastructures.enums
 import coraplex.datastructures.execution_data
 import coraplex.datastructures.grasp
-import coraplex.datastructures.grasp_scoring
 import coraplex.datastructures.trajectory
 import coraplex.exceptions
 import coraplex.execution_environment
@@ -200,6 +199,8 @@ import semantic_digital_twin.pipeline.mesh_decomposition.coacd
 import semantic_digital_twin.pipeline.mesh_decomposition.vhacd
 import semantic_digital_twin.pipeline.pipeline
 import semantic_digital_twin.reasoning.predicates
+import semantic_digital_twin.reasoning.reasoner
+import semantic_digital_twin.reasoning.world_reasoner
 import semantic_digital_twin.robots.armar7
 import semantic_digital_twin.robots.daisy
 import semantic_digital_twin.robots.garmi
@@ -229,6 +230,10 @@ import semantic_digital_twin.world_description.connection_properties
 import semantic_digital_twin.world_description.connections
 import semantic_digital_twin.world_description.degree_of_freedom
 import semantic_digital_twin.world_description.geometry
+import semantic_digital_twin.world_description.graph_of_convex_sets.base
+import semantic_digital_twin.world_description.graph_of_convex_sets.boxes
+import semantic_digital_twin.world_description.graph_of_convex_sets.exceptions
+import semantic_digital_twin.world_description.graph_of_convex_sets.polygons
 import semantic_digital_twin.world_description.inertial_properties
 import semantic_digital_twin.world_description.shape_collection
 import semantic_digital_twin.world_description.soft_connections
@@ -599,44 +604,23 @@ class UpdateTemporaryCollisionRulesDAO_temporary_rules_association(
     )
 
 
-class _CancelBecauseExternalCollisionViolatedDAO_tasks_association(
+class _CancelBecauseCollisionViolatedDAO_tasks_association(
     Base, AssociationDataAccessObject
 ):
-    __tablename__ = "_61317592250710120083516058746018886131181879083799255436396839"
+    __tablename__ = "_65560379044950887437414016967911775174421418923510923372619919"
 
     database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
 
-    source__cancelbecauseexternalcollisionviolateddao_id: Mapped[int] = mapped_column(
-        ForeignKey("_CancelBecauseExternalCollisionViolatedDAO.database_id")
+    source__cancelbecausecollisionviolateddao_id: Mapped[int] = mapped_column(
+        ForeignKey("_CancelBecauseCollisionViolatedDAO.database_id")
     )
-    target__externalcollisionavoidancetaskdao_id: Mapped[int] = mapped_column(
-        ForeignKey("_ExternalCollisionAvoidanceTaskDAO.database_id")
-    )
-
-    target: Mapped[_ExternalCollisionAvoidanceTaskDAO] = relationship(
-        "_ExternalCollisionAvoidanceTaskDAO",
-        foreign_keys=[target__externalcollisionavoidancetaskdao_id],
-        lazy="selectin",
+    target__collisionavoidancetaskdao_id: Mapped[int] = mapped_column(
+        ForeignKey("_CollisionAvoidanceTaskDAO.database_id")
     )
 
-
-class _CancelBecauseSelfCollisionViolatedDAO_tasks_association(
-    Base, AssociationDataAccessObject
-):
-    __tablename__ = "_38097831367697269256703944597006782870656880191646932194980459"
-
-    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
-
-    source__cancelbecauseselfcollisionviolateddao_id: Mapped[int] = mapped_column(
-        ForeignKey("_CancelBecauseSelfCollisionViolatedDAO.database_id")
-    )
-    target__selfcollisionavoidancetaskdao_id: Mapped[int] = mapped_column(
-        ForeignKey("_SelfCollisionAvoidanceTaskDAO.database_id")
-    )
-
-    target: Mapped[_SelfCollisionAvoidanceTaskDAO] = relationship(
-        "_SelfCollisionAvoidanceTaskDAO",
-        foreign_keys=[target__selfcollisionavoidancetaskdao_id],
+    target: Mapped[_CollisionAvoidanceTaskDAO] = relationship(
+        "_CollisionAvoidanceTaskDAO",
+        foreign_keys=[target__collisionavoidancetaskdao_id],
         lazy="selectin",
     )
 
@@ -1495,6 +1479,44 @@ class WorldModelManagerDAO_model_modification_blocks_association(
     target: Mapped[WorldModelModificationBlockDAO] = relationship(
         "WorldModelModificationBlockDAO",
         foreign_keys=[target_worldmodelmodificationblockdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_obstacles_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_10097511437740384067152589240138880074945231015404257411712969"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedconvexsetdao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedConvexSetDAO.database_id")
+    )
+
+    target: Mapped[_MockedConvexSetDAO] = relationship(
+        "_MockedConvexSetDAO",
+        foreign_keys=[target__mockedconvexsetdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_regions_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_21683303155680797721654562863218184758483517575191610116427927"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedhpolyhedrondao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedHPolyhedronDAO.database_id")
+    )
+
+    target: Mapped[_MockedHPolyhedronDAO] = relationship(
+        "_MockedHPolyhedronDAO",
+        foreign_keys=[target__mockedhpolyhedrondao_id],
         lazy="selectin",
     )
 
@@ -3022,55 +3044,6 @@ class PreferredGraspAlignmentDAO(
         krrood.ormatic.custom_types.PolymorphicEnumType,
         nullable=True,
         use_existing_column=True,
-    )
-
-
-class GraspScorerDAO(
-    Base, DataAccessObject[coraplex.datastructures.grasp_scoring.GraspScorer]
-):
-    __tablename__ = "GraspScorerDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    weight_normal: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    weight_distance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    weight_clearance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    penalty_collision: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    collision_tolerance: Mapped[builtins.float] = mapped_column(
-        use_existing_column=True
-    )
-    penalty_clearance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    penalty_unstable: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    score_partial_contact: Mapped[builtins.float] = mapped_column(
-        use_existing_column=True
-    )
-    ground_plane_z: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-
-
-class ScoredGraspDAO(
-    Base, DataAccessObject[coraplex.datastructures.grasp_scoring.ScoredGrasp]
-):
-    __tablename__ = "ScoredGraspDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    score: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    id: Mapped[builtins.str] = mapped_column(
-        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
-    )
-
-    pose_id: Mapped[int] = mapped_column(
-        ForeignKey("PoseMappingDAO.database_id", use_alter=True),
-        nullable=True,
-        use_existing_column=True,
-    )
-
-    pose: Mapped[PoseMappingDAO] = relationship(
-        "PoseMappingDAO", uselist=False, foreign_keys=[pose_id], post_update=True
     )
 
 
@@ -9207,6 +9180,19 @@ class MotionStatechartNodeDAO(
         String(255), nullable=False, use_existing_column=True
     )
 
+    plot_specifications_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specifications: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO",
+        uselist=False,
+        foreign_keys=[plot_specifications_id],
+        post_update=True,
+    )
+
     __mapper_args__ = {
         "polymorphic_on": "polymorphic_type",
         "polymorphic_identity": "MotionStatechartNodeDAO",
@@ -9383,6 +9369,16 @@ class CancelMotionDAO(
         use_existing_column=True,
     )
 
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
+
     __mapper_args__ = {
         "polymorphic_identity": "CancelMotionDAO",
         "inherit_condition": database_id == MotionStatechartNodeDAO.database_id,
@@ -9390,8 +9386,39 @@ class CancelMotionDAO(
     }
 
 
-class _CancelBecauseExternalCollisionViolatedDAO(
+class _CancelBecauseCollisionViolatedDAO(
     CancelMotionDAO,
+    DataAccessObject[
+        giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseCollisionViolated
+    ],
+):
+    __tablename__ = "_CancelBecauseCollisionViolatedDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(CancelMotionDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    tasks: Mapped[
+        builtins.list[_CancelBecauseCollisionViolatedDAO_tasks_association]
+    ] = relationship(
+        "_CancelBecauseCollisionViolatedDAO_tasks_association",
+        collection_class=builtins.list,
+        cascade="all, delete-orphan",
+        foreign_keys="[_CancelBecauseCollisionViolatedDAO_tasks_association.source__cancelbecausecollisionviolateddao_id]",
+        lazy="selectin",
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "_CancelBecauseCollisionViolatedDAO",
+        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class _CancelBecauseExternalCollisionViolatedDAO(
+    _CancelBecauseCollisionViolatedDAO,
     DataAccessObject[
         giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseExternalCollisionViolated
     ],
@@ -9399,30 +9426,21 @@ class _CancelBecauseExternalCollisionViolatedDAO(
     __tablename__ = "_CancelBecauseExternalCollisionViolatedDAO"
 
     database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(CancelMotionDAO.database_id),
+        ForeignKey(_CancelBecauseCollisionViolatedDAO.database_id),
         primary_key=True,
         use_existing_column=True,
     )
 
-    tasks: Mapped[
-        builtins.list[_CancelBecauseExternalCollisionViolatedDAO_tasks_association]
-    ] = relationship(
-        "_CancelBecauseExternalCollisionViolatedDAO_tasks_association",
-        collection_class=builtins.list,
-        cascade="all, delete-orphan",
-        foreign_keys="[_CancelBecauseExternalCollisionViolatedDAO_tasks_association.source__cancelbecauseexternalcollisionviolateddao_id]",
-        lazy="selectin",
-    )
-
     __mapper_args__ = {
         "polymorphic_identity": "_CancelBecauseExternalCollisionViolatedDAO",
-        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "inherit_condition": database_id
+        == _CancelBecauseCollisionViolatedDAO.database_id,
         "polymorphic_load": "selectin",
     }
 
 
 class _CancelBecauseSelfCollisionViolatedDAO(
-    CancelMotionDAO,
+    _CancelBecauseCollisionViolatedDAO,
     DataAccessObject[
         giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseSelfCollisionViolated
     ],
@@ -9430,24 +9448,15 @@ class _CancelBecauseSelfCollisionViolatedDAO(
     __tablename__ = "_CancelBecauseSelfCollisionViolatedDAO"
 
     database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(CancelMotionDAO.database_id),
+        ForeignKey(_CancelBecauseCollisionViolatedDAO.database_id),
         primary_key=True,
         use_existing_column=True,
     )
 
-    tasks: Mapped[
-        builtins.list[_CancelBecauseSelfCollisionViolatedDAO_tasks_association]
-    ] = relationship(
-        "_CancelBecauseSelfCollisionViolatedDAO_tasks_association",
-        collection_class=builtins.list,
-        cascade="all, delete-orphan",
-        foreign_keys="[_CancelBecauseSelfCollisionViolatedDAO_tasks_association.source__cancelbecauseselfcollisionviolateddao_id]",
-        lazy="selectin",
-    )
-
     __mapper_args__ = {
         "polymorphic_identity": "_CancelBecauseSelfCollisionViolatedDAO",
-        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "inherit_condition": database_id
+        == _CancelBecauseCollisionViolatedDAO.database_id,
         "polymorphic_load": "selectin",
     }
 
@@ -9469,6 +9478,16 @@ class EndMotionDAO(
     )
     minimum_threshold: Mapped[builtins.float] = mapped_column(use_existing_column=True)
     maximum_threshold: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "EndMotionDAO",
@@ -9593,12 +9612,20 @@ class SelfCollisionAvoidanceDAO(
         use_existing_column=True
     )
 
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
     robot_id: Mapped[int] = mapped_column(
         ForeignKey("AbstractRobotDAO.database_id", use_alter=True),
         nullable=True,
         use_existing_column=True,
     )
 
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
     robot: Mapped[AbstractRobotDAO] = relationship(
         "AbstractRobotDAO", uselist=False, foreign_keys=[robot_id], post_update=True
     )
@@ -10010,6 +10037,16 @@ class TaskDAO(
     )
 
     weight: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "TaskDAO",
@@ -11694,6 +11731,7 @@ class NodePlotSpecDAO(
     )
 
     visible: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
+    collapse_children: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
     style: Mapped[builtins.str] = mapped_column(
         sqlalchemy.sql.sqltypes.Text, use_existing_column=True
     )
@@ -22362,6 +22400,40 @@ class RightOfDAO(
     }
 
 
+class CaseReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.reasoner.CaseReasoner]
+):
+    __tablename__ = "CaseReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    model_directory: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+
+class WorldReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.world_reasoner.WorldReasoner]
+):
+    __tablename__ = "WorldReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+
 class RobotPartMixinDAO(
     Base,
     DataAccessObject[semantic_digital_twin.robots.robot_part_mixins.RobotPartMixin],
@@ -23446,6 +23518,16 @@ class BoundingBoxDAO(
     )
 
 
+class BoundsDAO(
+    Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Bounds]
+):
+    __tablename__ = "BoundsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
 class ColorDAO(
     Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Color]
 ):
@@ -23635,6 +23717,264 @@ class TextureDAO(
 
     repeat: Mapped[typing.List[builtins.float]] = mapped_column(
         JSON, nullable=False, use_existing_column=True
+    )
+
+
+class GraphOfConvexSetsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.base.GraphOfConvexSets
+    ],
+):
+    __tablename__ = "GraphOfConvexSetsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    polymorphic_type: Mapped[str] = mapped_column(
+        String(255), nullable=False, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    search_space_id: Mapped[typing.Optional[builtins.int]] = mapped_column(
+        ForeignKey("BoundingBoxCollectionDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+    search_space: Mapped[BoundingBoxCollectionDAO] = relationship(
+        "BoundingBoxCollectionDAO",
+        uselist=False,
+        foreign_keys=[search_space_id],
+        post_update=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_on": "polymorphic_type",
+        "polymorphic_identity": "GraphOfConvexSetsDAO",
+    }
+
+
+class GraphOfBoundingBoxesDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.boxes.GraphOfBoundingBoxes
+    ],
+):
+    __tablename__ = "GraphOfBoundingBoxesDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfBoundingBoxesDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class UnboundedSearchSpaceErrorDAO(
+    UsageErrorDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.exceptions.UnboundedSearchSpaceError
+    ],
+):
+    __tablename__ = "UnboundedSearchSpaceErrorDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(UsageErrorDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "UnboundedSearchSpaceErrorDAO",
+        "inherit_condition": database_id == UsageErrorDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class GraphOfConvexPolygonsDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.GraphOfConvexPolygons
+    ],
+):
+    __tablename__ = "GraphOfConvexPolygonsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    obstacles: Mapped[builtins.list[GraphOfConvexPolygonsDAO_obstacles_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_obstacles_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_obstacles_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+    regions: Mapped[builtins.list[GraphOfConvexPolygonsDAO_regions_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_regions_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_regions_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfConvexPolygonsDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class IrisSeedingSettingsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.IrisSeedingSettings
+    ],
+):
+    __tablename__ = "IrisSeedingSettingsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    grid_resolution: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    max_regions: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    iris_options_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedIrisOptionsDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    iris_options: Mapped[_MockedIrisOptionsDAO] = relationship(
+        "_MockedIrisOptionsDAO",
+        uselist=False,
+        foreign_keys=[iris_options_id],
+        post_update=True,
+    )
+
+
+class _MockedConvexSetDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedConvexSet
+    ],
+):
+    __tablename__ = "_MockedConvexSetDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedGcsTrajectoryOptimizationDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedGcsTrajectoryOptimization
+    ],
+):
+    __tablename__ = "_MockedGcsTrajectoryOptimizationDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedHPolyhedronDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedHPolyhedron
+    ],
+):
+    __tablename__ = "_MockedHPolyhedronDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIris
+    ],
+):
+    __tablename__ = "_MockedIrisDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisOptionsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIrisOptions
+    ],
+):
+    __tablename__ = "_MockedIrisOptionsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedPointDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedPoint
+    ],
+):
+    __tablename__ = "_MockedPointDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedSubgraphDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedSubgraph
+    ],
+):
+    __tablename__ = "_MockedSubgraphDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedVPolytopeDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedVPolytope
+    ],
+):
+    __tablename__ = "_MockedVPolytopeDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
     )
 
 

--- a/experiments/src/experiments/orm/ormatic_interface.py
+++ b/experiments/src/experiments/orm/ormatic_interface.py
@@ -24,7 +24,6 @@ import coraplex.datastructures.dataclasses
 import coraplex.datastructures.enums
 import coraplex.datastructures.execution_data
 import coraplex.datastructures.grasp
-import coraplex.datastructures.grasp_scoring
 import coraplex.datastructures.trajectory
 import coraplex.exceptions
 import coraplex.execution_environment
@@ -67,9 +66,11 @@ import datetime
 import enum
 import experiments.eql_experiments.monitoring_profile
 import experiments.experiment_definitions
+import experiments.free_space_volume_estimation
 import experiments.graph_of_convex_sets_experiments
 import experiments.ormatic_experiments.reliability
 import experiments.ormatic_experiments.scalability
+import experiments.querying
 import experiments.random_events_experiments.complement_worst_case_experiment
 import experiments.random_events_experiments.scalability_experiment
 import experiments.sage_10k.demos
@@ -210,6 +211,8 @@ import semantic_digital_twin.pipeline.mesh_decomposition.coacd
 import semantic_digital_twin.pipeline.mesh_decomposition.vhacd
 import semantic_digital_twin.pipeline.pipeline
 import semantic_digital_twin.reasoning.predicates
+import semantic_digital_twin.reasoning.reasoner
+import semantic_digital_twin.reasoning.world_reasoner
 import semantic_digital_twin.robots.armar7
 import semantic_digital_twin.robots.daisy
 import semantic_digital_twin.robots.garmi
@@ -239,6 +242,10 @@ import semantic_digital_twin.world_description.connection_properties
 import semantic_digital_twin.world_description.connections
 import semantic_digital_twin.world_description.degree_of_freedom
 import semantic_digital_twin.world_description.geometry
+import semantic_digital_twin.world_description.graph_of_convex_sets.base
+import semantic_digital_twin.world_description.graph_of_convex_sets.boxes
+import semantic_digital_twin.world_description.graph_of_convex_sets.exceptions
+import semantic_digital_twin.world_description.graph_of_convex_sets.polygons
 import semantic_digital_twin.world_description.inertial_properties
 import semantic_digital_twin.world_description.shape_collection
 import semantic_digital_twin.world_description.soft_connections
@@ -533,6 +540,27 @@ class ExperimentsTableDAO_experiments_association(Base, AssociationDataAccessObj
     )
 
 
+class MonteCarloFreeSpaceSamplerDAO_obstacle_containment_checkers_association(
+    Base, AssociationDataAccessObject
+):
+    __tablename__ = "_40096917417131016611267583495286757416612266059543318053167196"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_montecarlofreespacesamplerdao_id: Mapped[int] = mapped_column(
+        ForeignKey("MonteCarloFreeSpaceSamplerDAO.database_id")
+    )
+    target_obstaclecontainmentcheckerdao_id: Mapped[int] = mapped_column(
+        ForeignKey("ObstacleContainmentCheckerDAO.database_id")
+    )
+
+    target: Mapped[ObstacleContainmentCheckerDAO] = relationship(
+        "ObstacleContainmentCheckerDAO",
+        foreign_keys=[target_obstaclecontainmentcheckerdao_id],
+        lazy="selectin",
+    )
+
+
 class GiskardTesterDAO_robot_names_association(Base, AssociationDataAccessObject):
     __tablename__ = "_18552742813313585395849894661168412239528432174761485585780336"
 
@@ -628,44 +656,23 @@ class UpdateTemporaryCollisionRulesDAO_temporary_rules_association(
     )
 
 
-class _CancelBecauseExternalCollisionViolatedDAO_tasks_association(
+class _CancelBecauseCollisionViolatedDAO_tasks_association(
     Base, AssociationDataAccessObject
 ):
-    __tablename__ = "_61317592250710120083516058746018886131181879083799255436396839"
+    __tablename__ = "_65560379044950887437414016967911775174421418923510923372619919"
 
     database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
 
-    source__cancelbecauseexternalcollisionviolateddao_id: Mapped[int] = mapped_column(
-        ForeignKey("_CancelBecauseExternalCollisionViolatedDAO.database_id")
+    source__cancelbecausecollisionviolateddao_id: Mapped[int] = mapped_column(
+        ForeignKey("_CancelBecauseCollisionViolatedDAO.database_id")
     )
-    target__externalcollisionavoidancetaskdao_id: Mapped[int] = mapped_column(
-        ForeignKey("_ExternalCollisionAvoidanceTaskDAO.database_id")
-    )
-
-    target: Mapped[_ExternalCollisionAvoidanceTaskDAO] = relationship(
-        "_ExternalCollisionAvoidanceTaskDAO",
-        foreign_keys=[target__externalcollisionavoidancetaskdao_id],
-        lazy="selectin",
+    target__collisionavoidancetaskdao_id: Mapped[int] = mapped_column(
+        ForeignKey("_CollisionAvoidanceTaskDAO.database_id")
     )
 
-
-class _CancelBecauseSelfCollisionViolatedDAO_tasks_association(
-    Base, AssociationDataAccessObject
-):
-    __tablename__ = "_38097831367697269256703944597006782870656880191646932194980459"
-
-    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
-
-    source__cancelbecauseselfcollisionviolateddao_id: Mapped[int] = mapped_column(
-        ForeignKey("_CancelBecauseSelfCollisionViolatedDAO.database_id")
-    )
-    target__selfcollisionavoidancetaskdao_id: Mapped[int] = mapped_column(
-        ForeignKey("_SelfCollisionAvoidanceTaskDAO.database_id")
-    )
-
-    target: Mapped[_SelfCollisionAvoidanceTaskDAO] = relationship(
-        "_SelfCollisionAvoidanceTaskDAO",
-        foreign_keys=[target__selfcollisionavoidancetaskdao_id],
+    target: Mapped[_CollisionAvoidanceTaskDAO] = relationship(
+        "_CollisionAvoidanceTaskDAO",
+        foreign_keys=[target__collisionavoidancetaskdao_id],
         lazy="selectin",
     )
 
@@ -1524,6 +1531,44 @@ class WorldModelManagerDAO_model_modification_blocks_association(
     target: Mapped[WorldModelModificationBlockDAO] = relationship(
         "WorldModelModificationBlockDAO",
         foreign_keys=[target_worldmodelmodificationblockdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_obstacles_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_10097511437740384067152589240138880074945231015404257411712969"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedconvexsetdao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedConvexSetDAO.database_id")
+    )
+
+    target: Mapped[_MockedConvexSetDAO] = relationship(
+        "_MockedConvexSetDAO",
+        foreign_keys=[target__mockedconvexsetdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_regions_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_21683303155680797721654562863218184758483517575191610116427927"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedhpolyhedrondao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedHPolyhedronDAO.database_id")
+    )
+
+    target: Mapped[_MockedHPolyhedronDAO] = relationship(
+        "_MockedHPolyhedronDAO",
+        foreign_keys=[target__mockedhpolyhedrondao_id],
         lazy="selectin",
     )
 
@@ -3051,55 +3096,6 @@ class PreferredGraspAlignmentDAO(
         krrood.ormatic.custom_types.PolymorphicEnumType,
         nullable=True,
         use_existing_column=True,
-    )
-
-
-class GraspScorerDAO(
-    Base, DataAccessObject[coraplex.datastructures.grasp_scoring.GraspScorer]
-):
-    __tablename__ = "GraspScorerDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    weight_normal: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    weight_distance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    weight_clearance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    penalty_collision: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    collision_tolerance: Mapped[builtins.float] = mapped_column(
-        use_existing_column=True
-    )
-    penalty_clearance: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    penalty_unstable: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    score_partial_contact: Mapped[builtins.float] = mapped_column(
-        use_existing_column=True
-    )
-    ground_plane_z: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-
-
-class ScoredGraspDAO(
-    Base, DataAccessObject[coraplex.datastructures.grasp_scoring.ScoredGrasp]
-):
-    __tablename__ = "ScoredGraspDAO"
-
-    database_id: Mapped[builtins.int] = mapped_column(
-        Integer, primary_key=True, use_existing_column=True
-    )
-
-    score: Mapped[builtins.float] = mapped_column(use_existing_column=True)
-    id: Mapped[builtins.str] = mapped_column(
-        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
-    )
-
-    pose_id: Mapped[int] = mapped_column(
-        ForeignKey("PoseMappingDAO.database_id", use_alter=True),
-        nullable=True,
-        use_existing_column=True,
-    )
-
-    pose: Mapped[PoseMappingDAO] = relationship(
-        "PoseMappingDAO", uselist=False, foreign_keys=[pose_id], post_update=True
     )
 
 
@@ -7280,6 +7276,94 @@ class TypstRendererDAO(
     )
 
 
+class MonteCarloFreeSpaceSamplerDAO(
+    Base,
+    DataAccessObject[
+        experiments.free_space_volume_estimation.MonteCarloFreeSpaceSampler
+    ],
+):
+    __tablename__ = "MonteCarloFreeSpaceSamplerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    sample_count: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    confidence_level: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    random_seed: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    search_space_bounding_box_id: Mapped[int] = mapped_column(
+        ForeignKey("BoundingBoxDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    search_space_bounding_box: Mapped[BoundingBoxDAO] = relationship(
+        "BoundingBoxDAO",
+        uselist=False,
+        foreign_keys=[search_space_bounding_box_id],
+        post_update=True,
+    )
+    obstacle_containment_checkers: Mapped[
+        builtins.list[
+            MonteCarloFreeSpaceSamplerDAO_obstacle_containment_checkers_association
+        ]
+    ] = relationship(
+        "MonteCarloFreeSpaceSamplerDAO_obstacle_containment_checkers_association",
+        collection_class=builtins.list,
+        cascade="all, delete-orphan",
+        foreign_keys="[MonteCarloFreeSpaceSamplerDAO_obstacle_containment_checkers_association.source_montecarlofreespacesamplerdao_id]",
+        lazy="selectin",
+    )
+
+
+class ObstacleContainmentCheckerDAO(
+    Base,
+    DataAccessObject[
+        experiments.free_space_volume_estimation.ObstacleContainmentChecker
+    ],
+):
+    __tablename__ = "ObstacleContainmentCheckerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    world_meshes: Mapped[typing.List[trimesh.base.Trimesh]] = mapped_column(
+        JSON, nullable=False, use_existing_column=True
+    )
+
+    world_bounding_box_id: Mapped[int] = mapped_column(
+        ForeignKey("BoundingBoxDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world_bounding_box: Mapped[BoundingBoxDAO] = relationship(
+        "BoundingBoxDAO",
+        uselist=False,
+        foreign_keys=[world_bounding_box_id],
+        post_update=True,
+    )
+
+
+class GraphOfConvexSetsFreespaceBenchmarkDAO(
+    Base,
+    DataAccessObject[
+        experiments.graph_of_convex_sets_experiments.GraphOfConvexSetsFreespaceBenchmark
+    ],
+):
+    __tablename__ = "GraphOfConvexSetsFreespaceBenchmarkDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    environment_name: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+
 class GraphOfConvexSetsFreespaceExperimentResultDAO(
     ExperimentResultDAO,
     DataAccessObject[
@@ -7306,7 +7390,19 @@ class GraphOfConvexSetsFreespaceExperimentResultDAO(
     )
     graph_node_count: Mapped[builtins.int] = mapped_column(use_existing_column=True)
     graph_edge_count: Mapped[builtins.int] = mapped_column(use_existing_column=True)
-    end_to_end_duration_milliseconds: Mapped[builtins.float] = mapped_column(
+    mesh_obstacle_volume_total: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+    naive_free_volume_lower_bound: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+    box_free_space_volume: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+    graph_of_convex_polygons_region_count: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    graph_of_convex_polygons_region_volume_sum: Mapped[builtins.float] = mapped_column(
         use_existing_column=True
     )
     environment_name: Mapped[builtins.str] = mapped_column(
@@ -7325,6 +7421,33 @@ class GraphOfConvexSetsFreespaceExperimentResultDAO(
     )
     connectivity_duration_milliseconds_id: Mapped[int] = mapped_column(
         ForeignKey("MeanAndStandardDeviationDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    box_construction_duration_milliseconds_id: Mapped[int] = mapped_column(
+        ForeignKey("MeanAndStandardDeviationDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    true_free_volume_bound_id: Mapped[int] = mapped_column(
+        ForeignKey("VolumeBoundDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    graph_of_convex_polygons_construction_duration_milliseconds_id: Mapped[int] = (
+        mapped_column(
+            ForeignKey("MeanAndStandardDeviationDAO.database_id", use_alter=True),
+            nullable=True,
+            use_existing_column=True,
+        )
+    )
+    graph_of_convex_polygons_coverage_bound_id: Mapped[int] = mapped_column(
+        ForeignKey("VolumeBoundDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    graph_of_convex_polygons_coverage_percentage_id: Mapped[int] = mapped_column(
+        ForeignKey("PercentageBoundDAO.database_id", use_alter=True),
         nullable=True,
         use_existing_column=True,
     )
@@ -7350,6 +7473,42 @@ class GraphOfConvexSetsFreespaceExperimentResultDAO(
             "MeanAndStandardDeviationDAO",
             uselist=False,
             foreign_keys=[connectivity_duration_milliseconds_id],
+            post_update=True,
+        )
+    )
+    box_construction_duration_milliseconds: Mapped[MeanAndStandardDeviationDAO] = (
+        relationship(
+            "MeanAndStandardDeviationDAO",
+            uselist=False,
+            foreign_keys=[box_construction_duration_milliseconds_id],
+            post_update=True,
+        )
+    )
+    true_free_volume_bound: Mapped[VolumeBoundDAO] = relationship(
+        "VolumeBoundDAO",
+        uselist=False,
+        foreign_keys=[true_free_volume_bound_id],
+        post_update=True,
+    )
+    graph_of_convex_polygons_construction_duration_milliseconds: Mapped[
+        MeanAndStandardDeviationDAO
+    ] = relationship(
+        "MeanAndStandardDeviationDAO",
+        uselist=False,
+        foreign_keys=[graph_of_convex_polygons_construction_duration_milliseconds_id],
+        post_update=True,
+    )
+    graph_of_convex_polygons_coverage_bound: Mapped[VolumeBoundDAO] = relationship(
+        "VolumeBoundDAO",
+        uselist=False,
+        foreign_keys=[graph_of_convex_polygons_coverage_bound_id],
+        post_update=True,
+    )
+    graph_of_convex_polygons_coverage_percentage: Mapped[PercentageBoundDAO] = (
+        relationship(
+            "PercentageBoundDAO",
+            uselist=False,
+            foreign_keys=[graph_of_convex_polygons_coverage_percentage_id],
             post_update=True,
         )
     )
@@ -7631,6 +7790,53 @@ class ORMaticScalabilityExperimentResultDAO(
 
     __mapper_args__ = {
         "polymorphic_identity": "ORMaticScalabilityExperimentResultDAO",
+        "inherit_condition": database_id == ExperimentResultDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class BehaviourQueryDAO(Base, DataAccessObject[experiments.querying.BehaviourQuery]):
+    __tablename__ = "BehaviourQueryDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    question: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+
+class BehaviourQueryResultDAO(
+    ExperimentResultDAO, DataAccessObject[experiments.querying.BehaviourQueryResult]
+):
+    __tablename__ = "BehaviourQueryResultDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(ExperimentResultDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    question: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+    eql_number_of_results: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    eql_duration_ms: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    sql_translation_duration_ms: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+    sql_number_of_results: Mapped[builtins.int] = mapped_column(
+        use_existing_column=True
+    )
+    sql_execution_duration_ms: Mapped[builtins.float] = mapped_column(
+        use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "BehaviourQueryResultDAO",
         "inherit_condition": database_id == ExperimentResultDAO.database_id,
         "polymorphic_load": "selectin",
     }
@@ -10335,6 +10541,19 @@ class MotionStatechartNodeDAO(
         String(255), nullable=False, use_existing_column=True
     )
 
+    plot_specifications_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specifications: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO",
+        uselist=False,
+        foreign_keys=[plot_specifications_id],
+        post_update=True,
+    )
+
     __mapper_args__ = {
         "polymorphic_on": "polymorphic_type",
         "polymorphic_identity": "MotionStatechartNodeDAO",
@@ -10511,6 +10730,16 @@ class CancelMotionDAO(
         use_existing_column=True,
     )
 
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
+
     __mapper_args__ = {
         "polymorphic_identity": "CancelMotionDAO",
         "inherit_condition": database_id == MotionStatechartNodeDAO.database_id,
@@ -10518,8 +10747,39 @@ class CancelMotionDAO(
     }
 
 
-class _CancelBecauseExternalCollisionViolatedDAO(
+class _CancelBecauseCollisionViolatedDAO(
     CancelMotionDAO,
+    DataAccessObject[
+        giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseCollisionViolated
+    ],
+):
+    __tablename__ = "_CancelBecauseCollisionViolatedDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(CancelMotionDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    tasks: Mapped[
+        builtins.list[_CancelBecauseCollisionViolatedDAO_tasks_association]
+    ] = relationship(
+        "_CancelBecauseCollisionViolatedDAO_tasks_association",
+        collection_class=builtins.list,
+        cascade="all, delete-orphan",
+        foreign_keys="[_CancelBecauseCollisionViolatedDAO_tasks_association.source__cancelbecausecollisionviolateddao_id]",
+        lazy="selectin",
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "_CancelBecauseCollisionViolatedDAO",
+        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class _CancelBecauseExternalCollisionViolatedDAO(
+    _CancelBecauseCollisionViolatedDAO,
     DataAccessObject[
         giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseExternalCollisionViolated
     ],
@@ -10527,30 +10787,21 @@ class _CancelBecauseExternalCollisionViolatedDAO(
     __tablename__ = "_CancelBecauseExternalCollisionViolatedDAO"
 
     database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(CancelMotionDAO.database_id),
+        ForeignKey(_CancelBecauseCollisionViolatedDAO.database_id),
         primary_key=True,
         use_existing_column=True,
     )
 
-    tasks: Mapped[
-        builtins.list[_CancelBecauseExternalCollisionViolatedDAO_tasks_association]
-    ] = relationship(
-        "_CancelBecauseExternalCollisionViolatedDAO_tasks_association",
-        collection_class=builtins.list,
-        cascade="all, delete-orphan",
-        foreign_keys="[_CancelBecauseExternalCollisionViolatedDAO_tasks_association.source__cancelbecauseexternalcollisionviolateddao_id]",
-        lazy="selectin",
-    )
-
     __mapper_args__ = {
         "polymorphic_identity": "_CancelBecauseExternalCollisionViolatedDAO",
-        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "inherit_condition": database_id
+        == _CancelBecauseCollisionViolatedDAO.database_id,
         "polymorphic_load": "selectin",
     }
 
 
 class _CancelBecauseSelfCollisionViolatedDAO(
-    CancelMotionDAO,
+    _CancelBecauseCollisionViolatedDAO,
     DataAccessObject[
         giskardpy.motion_statechart.goals.collision_avoidance._CancelBecauseSelfCollisionViolated
     ],
@@ -10558,24 +10809,15 @@ class _CancelBecauseSelfCollisionViolatedDAO(
     __tablename__ = "_CancelBecauseSelfCollisionViolatedDAO"
 
     database_id: Mapped[builtins.int] = mapped_column(
-        ForeignKey(CancelMotionDAO.database_id),
+        ForeignKey(_CancelBecauseCollisionViolatedDAO.database_id),
         primary_key=True,
         use_existing_column=True,
     )
 
-    tasks: Mapped[
-        builtins.list[_CancelBecauseSelfCollisionViolatedDAO_tasks_association]
-    ] = relationship(
-        "_CancelBecauseSelfCollisionViolatedDAO_tasks_association",
-        collection_class=builtins.list,
-        cascade="all, delete-orphan",
-        foreign_keys="[_CancelBecauseSelfCollisionViolatedDAO_tasks_association.source__cancelbecauseselfcollisionviolateddao_id]",
-        lazy="selectin",
-    )
-
     __mapper_args__ = {
         "polymorphic_identity": "_CancelBecauseSelfCollisionViolatedDAO",
-        "inherit_condition": database_id == CancelMotionDAO.database_id,
+        "inherit_condition": database_id
+        == _CancelBecauseCollisionViolatedDAO.database_id,
         "polymorphic_load": "selectin",
     }
 
@@ -10597,6 +10839,16 @@ class EndMotionDAO(
     )
     minimum_threshold: Mapped[builtins.float] = mapped_column(use_existing_column=True)
     maximum_threshold: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "EndMotionDAO",
@@ -10721,12 +10973,20 @@ class SelfCollisionAvoidanceDAO(
         use_existing_column=True
     )
 
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
     robot_id: Mapped[int] = mapped_column(
         ForeignKey("AbstractRobotDAO.database_id", use_alter=True),
         nullable=True,
         use_existing_column=True,
     )
 
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
     robot: Mapped[AbstractRobotDAO] = relationship(
         "AbstractRobotDAO", uselist=False, foreign_keys=[robot_id], post_update=True
     )
@@ -11138,6 +11398,16 @@ class TaskDAO(
     )
 
     weight: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    plot_specs_id: Mapped[int] = mapped_column(
+        ForeignKey("NodePlotSpecDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    plot_specs: Mapped[NodePlotSpecDAO] = relationship(
+        "NodePlotSpecDAO", uselist=False, foreign_keys=[plot_specs_id], post_update=True
+    )
 
     __mapper_args__ = {
         "polymorphic_identity": "TaskDAO",
@@ -12822,6 +13092,7 @@ class NodePlotSpecDAO(
     )
 
     visible: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
+    collapse_children: Mapped[builtins.bool] = mapped_column(use_existing_column=True)
     style: Mapped[builtins.str] = mapped_column(
         sqlalchemy.sql.sqltypes.Text, use_existing_column=True
     )
@@ -23490,6 +23761,40 @@ class RightOfDAO(
     }
 
 
+class CaseReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.reasoner.CaseReasoner]
+):
+    __tablename__ = "CaseReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    model_directory: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+
+class WorldReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.world_reasoner.WorldReasoner]
+):
+    __tablename__ = "WorldReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+
 class RobotPartMixinDAO(
     Base,
     DataAccessObject[semantic_digital_twin.robots.robot_part_mixins.RobotPartMixin],
@@ -24574,6 +24879,63 @@ class BoundingBoxDAO(
     )
 
 
+class BoundsDAO(
+    Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Bounds]
+):
+    __tablename__ = "BoundsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    polymorphic_type: Mapped[str] = mapped_column(
+        String(255), nullable=False, use_existing_column=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_on": "polymorphic_type",
+        "polymorphic_identity": "BoundsDAO",
+    }
+
+
+class PercentageBoundDAO(
+    BoundsDAO, DataAccessObject[experiments.experiment_definitions.PercentageBound]
+):
+    __tablename__ = "PercentageBoundDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(BoundsDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    lower: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    upper: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    __mapper_args__ = {
+        "polymorphic_identity": "PercentageBoundDAO",
+        "inherit_condition": database_id == BoundsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class VolumeBoundDAO(
+    BoundsDAO, DataAccessObject[experiments.experiment_definitions.VolumeBound]
+):
+    __tablename__ = "VolumeBoundDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(BoundsDAO.database_id), primary_key=True, use_existing_column=True
+    )
+
+    lower: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+    upper: Mapped[builtins.float] = mapped_column(use_existing_column=True)
+
+    __mapper_args__ = {
+        "polymorphic_identity": "VolumeBoundDAO",
+        "inherit_condition": database_id == BoundsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
 class ColorDAO(
     Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Color]
 ):
@@ -24763,6 +25125,264 @@ class TextureDAO(
 
     repeat: Mapped[typing.List[builtins.float]] = mapped_column(
         JSON, nullable=False, use_existing_column=True
+    )
+
+
+class GraphOfConvexSetsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.base.GraphOfConvexSets
+    ],
+):
+    __tablename__ = "GraphOfConvexSetsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    polymorphic_type: Mapped[str] = mapped_column(
+        String(255), nullable=False, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    search_space_id: Mapped[typing.Optional[builtins.int]] = mapped_column(
+        ForeignKey("BoundingBoxCollectionDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+    search_space: Mapped[BoundingBoxCollectionDAO] = relationship(
+        "BoundingBoxCollectionDAO",
+        uselist=False,
+        foreign_keys=[search_space_id],
+        post_update=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_on": "polymorphic_type",
+        "polymorphic_identity": "GraphOfConvexSetsDAO",
+    }
+
+
+class GraphOfBoundingBoxesDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.boxes.GraphOfBoundingBoxes
+    ],
+):
+    __tablename__ = "GraphOfBoundingBoxesDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfBoundingBoxesDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class UnboundedSearchSpaceErrorDAO(
+    UsageErrorDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.exceptions.UnboundedSearchSpaceError
+    ],
+):
+    __tablename__ = "UnboundedSearchSpaceErrorDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(UsageErrorDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "UnboundedSearchSpaceErrorDAO",
+        "inherit_condition": database_id == UsageErrorDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class GraphOfConvexPolygonsDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.GraphOfConvexPolygons
+    ],
+):
+    __tablename__ = "GraphOfConvexPolygonsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    obstacles: Mapped[builtins.list[GraphOfConvexPolygonsDAO_obstacles_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_obstacles_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_obstacles_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+    regions: Mapped[builtins.list[GraphOfConvexPolygonsDAO_regions_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_regions_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_regions_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfConvexPolygonsDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class IrisSeedingSettingsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.IrisSeedingSettings
+    ],
+):
+    __tablename__ = "IrisSeedingSettingsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    grid_resolution: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    max_regions: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    iris_options_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedIrisOptionsDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    iris_options: Mapped[_MockedIrisOptionsDAO] = relationship(
+        "_MockedIrisOptionsDAO",
+        uselist=False,
+        foreign_keys=[iris_options_id],
+        post_update=True,
+    )
+
+
+class _MockedConvexSetDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedConvexSet
+    ],
+):
+    __tablename__ = "_MockedConvexSetDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedGcsTrajectoryOptimizationDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedGcsTrajectoryOptimization
+    ],
+):
+    __tablename__ = "_MockedGcsTrajectoryOptimizationDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedHPolyhedronDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedHPolyhedron
+    ],
+):
+    __tablename__ = "_MockedHPolyhedronDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIris
+    ],
+):
+    __tablename__ = "_MockedIrisDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisOptionsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIrisOptions
+    ],
+):
+    __tablename__ = "_MockedIrisOptionsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedPointDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedPoint
+    ],
+):
+    __tablename__ = "_MockedPointDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedSubgraphDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedSubgraph
+    ],
+):
+    __tablename__ = "_MockedSubgraphDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedVPolytopeDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedVPolytope
+    ],
+):
+    __tablename__ = "_MockedVPolytopeDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
     )
 
 

--- a/giskardpy/src/giskardpy/motion_statechart/goals/collision_avoidance.py
+++ b/giskardpy/src/giskardpy/motion_statechart/goals/collision_avoidance.py
@@ -19,6 +19,10 @@ from giskardpy.motion_statechart.graph_node import (
     CancelMotion,
 )
 from giskardpy.motion_statechart.graph_node import Task
+from giskardpy.motion_statechart.plotters.plot_specs import (
+    NodePlotSpec,
+    plot_specification_field,
+)
 from krrood.symbolic_math.symbolic_math import Scalar, FloatVariable
 from semantic_digital_twin.collision_checking.collision_groups import CollisionGroup
 from semantic_digital_twin.collision_checking.collision_matrix import (
@@ -49,30 +53,74 @@ class _CollisionAvoidanceTask(Task):
 
 
 @dataclass(eq=False, repr=False)
+class _CancelBecauseCollisionViolated(CancelMotion):
+    """
+    Cancels the motion when one of the collision avoidance tasks it watches is violated.
+    """
+
+    tasks: list[_CollisionAvoidanceTask] = field(kw_only=True)
+    """
+    The list of collision avoidance tasks to check for collisions.
+    """
+
+    exception: Exception = field(init=False, default=Exception)
+    """
+    Set to init=False, because this class creates its own exception.
+    """
+
+    def build(self, context: MotionStatechartContext) -> NodeArtifacts:
+        self.start_condition = self.create_violation_condition()
+        return NodeArtifacts()
+
+    def create_violation_condition(self) -> Scalar:
+        """
+        :return: An expression that is True as soon as one of :attr:`tasks` observes a
+            violated collision. Without tasks there is nothing to violate, so it stays False.
+        """
+        if len(self.tasks) == 0:
+            return Scalar.const_false()
+        if len(self.tasks) == 1:
+            return sm.trinary_logic_not(self.tasks[0].observation_variable)
+        return sm.trinary_logic_or(
+            *[sm.trinary_logic_not(node.observation_variable) for node in self.tasks]
+        )
+
+
+@dataclass(eq=False, repr=False)
 class _ExternalCollisionAvoidanceNode(_CollisionAvoidanceTask):
     """
-    Avoids external collisions between a collision group and its collision_index-closest object in the environment.
-    Moves `root_T_tip @ tip_P_contact` in `root_T_contact_normal` direction until the distance is larger than buffer_zone.
-    Limits the slack variables to prevent the tip from coming closer than violated_distance.
-    .. warning: Can result in insolvable QPs if multiple of these constraints are violated.
+    Avoids external collisions between a collision group and its collision_index-closest
+    object in the environment.
+
+    Moves `root_T_tip @ tip_P_contact` in `root_T_contact_normal` direction until the
+    distance is larger than buffer_zone. Limits the slack variables to prevent the tip
+    from coming closer than violated_distance.
+
+    .. warning:: Can result in insolvable QPs if multiple of these constraints are
+        violated.
     """
 
     collision_group: CollisionGroup = field(kw_only=True)
     """
     The collision group avoiding external collisions.
     """
+
     max_velocity: float = field(default=0.2, kw_only=True)
     """
     The maximum velocity for the collision avoidance task.
     """
+
     collision_index: int = field(default=0, kw_only=True)
     """
     The index of the closest object in the collision group.
+
     e.g. of collision_index=1 it will avoid the 2. closest contact.
     """
+
     external_collision_manager: ExternalCollisionVariableManager = field(kw_only=True)
     """
-    Reference to the external collision variable manager shared by other external collision avoidance nodes.
+    Reference to the external collision variable manager shared by other external
+    collision avoidance nodes.
     """
 
     @property
@@ -127,10 +175,15 @@ class _ExternalCollisionHasData(_ExternalCollisionAvoidanceNode):
 @dataclass(eq=False, repr=False)
 class _ExternalCollisionAvoidanceTask(_ExternalCollisionAvoidanceNode):
     """
-    Avoids external collisions between a collision group and its collision_index-closest object in the environment.
-    Moves `root_T_tip @ tip_P_contact` in `root_T_contact_normal` direction until the distance is larger than buffer_zone.
-    Limits the slack variables to prevent the tip from coming closer than violated_distance.
-    .. warning: Can result in insolvable QPs if multiple of these constraints are violated.
+    Avoids external collisions between a collision group and its collision_index-closest
+    object in the environment.
+
+    Moves `root_T_tip @ tip_P_contact` in `root_T_contact_normal` direction until the
+    distance is larger than buffer_zone. Limits the slack variables to prevent the tip
+    from coming closer than violated_distance.
+
+    .. warning:: Can result in insolvable QPs if multiple of these constraints are
+        violated.
     """
 
     max_velocity: float = field(default=0.2, kw_only=True)
@@ -144,7 +197,8 @@ class _ExternalCollisionAvoidanceTask(_ExternalCollisionAvoidanceNode):
 
     def create_weight(self, context: MotionStatechartContext) -> sm.Scalar:
         """
-        Creates a weight expression for this task which is scaled by the number of external collisions.
+        Creates a weight expression for this task which is scaled by the number of
+        external collisions.
         """
         max_avoided_bodies = self.collision_group.get_max_avoided_bodies(
             context.collision_manager
@@ -202,33 +256,16 @@ class _ExternalCollisionAvoidanceTask(_ExternalCollisionAvoidanceNode):
 
 
 @dataclass(eq=False, repr=False)
-class _CancelBecauseExternalCollisionViolated(CancelMotion):
+class _CancelBecauseExternalCollisionViolated(_CancelBecauseCollisionViolated):
     """
-    Cancels the motion by raising an exception detailing which external collision tasks were violated.
+    Cancels the motion by raising an exception detailing which external collision tasks
+    were violated.
     """
 
     tasks: list[_ExternalCollisionAvoidanceTask] = field(kw_only=True)
     """
     The list of external collision avoidance tasks to check for collisions.
     """
-    exception: Exception = field(init=False, default=Exception)
-    """
-    Set to init=False, because this class creates its own exception.
-    """
-
-    def build(self, context: MotionStatechartContext) -> NodeArtifacts:
-        if len(self.tasks) == 1:
-            self.start_condition = sm.trinary_logic_not(
-                self.tasks[0].observation_variable
-            )
-        else:
-            self.start_condition = sm.trinary_logic_or(
-                *[
-                    sm.trinary_logic_not(node.observation_variable)
-                    for node in self.tasks
-                ]
-            )
-        return NodeArtifacts()
 
     def on_tick(self, context: MotionStatechartContext) -> Optional[float]:
         violated_tasks = [
@@ -291,7 +328,9 @@ class SetInitialTemporaryCollisionRules(MotionStatechartNode):
     temporary_rules: list[CollisionRule] = field(kw_only=True)
     collision_matrix: CollisionMatrix = field(init=False)
     set_on_build: bool = field(default=True, kw_only=True)
-    """Whether to set the collision matrix on build."""
+    """
+    Whether to set the collision matrix on build.
+    """
 
     def build(self, context: MotionStatechartContext) -> NodeArtifacts:
         artifacts = NodeArtifacts()
@@ -320,23 +359,33 @@ class SetInitialTemporaryCollisionRules(MotionStatechartNode):
 @dataclass(eq=False, repr=False)
 class ExternalCollisionAvoidance(Goal):
     """
-    A goal combining an ExternalCollisionDistanceMonitor and an ExternalCollisionAvoidanceTask.
-    One pair will be added for all collision groups of the robot.
-    The task will only be active if the monitor detects that a collision is close.
+    A goal combining an ExternalCollisionDistanceMonitor and an
+    ExternalCollisionAvoidanceTask. One pair will be added for all collision groups of
+    the robot. The task will only be active if the monitor detects that a collision is
+    close.
+
+    ..note:: This goal expands into one node pair per collision group, so its children are
+        left out of drawings. Set `plot_specs.collapse_children` to False to draw them.
     """
+
+    plot_specifications: NodePlotSpec = plot_specification_field(NodePlotSpec.create_collapsed_goal_style)
 
     robot: AbstractRobot = field(kw_only=True, default=None)
     """
     The robot for which the collision avoidance goal is defined.
     """
+
     max_velocity: float = field(default=0.2, kw_only=True)
     """
     The maximum velocity for the collision avoidance task.
     """
+
     external_collision_manager: ExternalCollisionVariableManager = field(init=False)
     """
-    Reference to the external collision variable manager shared by other external collision avoidance nodes.
+    Reference to the external collision variable manager shared by other external
+    collision avoidance nodes.
     """
+
     cancel_if_collision_violated: bool = field(default=True, kw_only=True)
     """
     If True, the motion will be canceled if a collision is violated.
@@ -399,16 +448,22 @@ class ExternalCollisionAvoidance(Goal):
 @dataclass(eq=False, repr=False)
 class ExternalCollisionDistanceMonitor(MotionStatechartNode):
     """
-    Monitors the distance to the closest external object for a specific collision group of a body.
-    Turns True if the distance falls below a given threshold.
+    Monitors the distance to the closest external object for a specific collision group
+    of a body. Turns True if the distance falls below a given threshold.
 
     .. note:: the input bodies are only used to look up the collision groups.
     """
 
     body: Body = field(kw_only=True)
-    """The robot body to monitor."""
+    """
+    The robot body to monitor.
+    """
+
     threshold: float = field(kw_only=True)
-    """Distance threshold in meters."""
+    """
+    Distance threshold in meters.
+    """
+
     collision_index: int = field(default=0, kw_only=True)
     """Index of the closest collision (0 = closest, 1 = second closest, etc.)."""
 
@@ -435,25 +490,32 @@ class ExternalCollisionDistanceMonitor(MotionStatechartNode):
 class _SelfCollisionAvoidanceNode(_CollisionAvoidanceTask):
     """
     Avoids self collisions between two collision groups.
-    Moves `group_a_P_point_on_a @ group_b_P_point_on_b` in `group_a_T_group_b_contact_normal` direction until the distance is larger than buffer_zone.
-    Limits the slack variables to prevent the tip from coming closer than violated_distance.
+
+    Moves `group_a_P_point_on_a @ group_b_P_point_on_b` in
+    `group_a_T_group_b_contact_normal` direction until the distance is larger than
+    buffer_zone. Limits the slack variables to prevent the tip from coming closer than
+    violated_distance.
     """
 
     collision_group_a: CollisionGroup = field(kw_only=True)
     """
     The first collision group to avoid self collisions with.
     """
+
     collision_group_b: CollisionGroup = field(kw_only=True)
     """
     The second collision group to avoid self collisions with.
     """
+
     max_velocity: float = field(default=0.2, kw_only=True)
     """
     The maximum velocity for the collision avoidance task.
     """
+
     self_collision_manager: SelfCollisionVariableManager = field(kw_only=True)
     """
-    Reference to the self collision variable manager shared by other self collision avoidance nodes.
+    Reference to the self collision variable manager shared by other self collision
+    avoidance nodes.
     """
 
     @property
@@ -516,8 +578,11 @@ class _SelfCollisionHasData(_SelfCollisionAvoidanceNode):
 class _SelfCollisionAvoidanceTask(_SelfCollisionAvoidanceNode):
     """
     Avoids self collisions between two collision groups.
-    Moves `group_a_P_point_on_a @ group_b_P_point_on_b` in `group_a_T_group_b_contact_normal` direction until the distance is larger than buffer_zone.
-    Limits the slack variables to prevent the tip from coming closer than violated_distance.
+
+    Moves `group_a_P_point_on_a @ group_b_P_point_on_b` in
+    `group_a_T_group_b_contact_normal` direction until the distance is larger than
+    buffer_zone. Limits the slack variables to prevent the tip from coming closer than
+    violated_distance.
     """
 
     max_velocity: float = field(default=0.2, kw_only=True)
@@ -560,33 +625,16 @@ class _SelfCollisionAvoidanceTask(_SelfCollisionAvoidanceNode):
 
 
 @dataclass(eq=False, repr=False)
-class _CancelBecauseSelfCollisionViolated(CancelMotion):
+class _CancelBecauseSelfCollisionViolated(_CancelBecauseCollisionViolated):
     """
-    Cancels the motion by raising an exception detailing which self collision tasks were violated.
+    Cancels the motion by raising an exception detailing which self collision tasks were
+    violated.
     """
 
     tasks: list[_SelfCollisionAvoidanceTask] = field(kw_only=True)
     """
     The list of self collision avoidance tasks to check for collisions.
     """
-    exception: Exception = field(init=False, default=Exception)
-    """
-    Set to init=False, because this class creates its own exception.
-    """
-
-    def build(self, context: MotionStatechartContext) -> NodeArtifacts:
-        if len(self.tasks) == 1:
-            self.start_condition = sm.trinary_logic_not(
-                self.tasks[0].observation_variable
-            )
-        else:
-            self.start_condition = sm.trinary_logic_or(
-                *[
-                    sm.trinary_logic_not(node.observation_variable)
-                    for node in self.tasks
-                ]
-            )
-        return NodeArtifacts()
 
     def on_tick(self, context: MotionStatechartContext) -> Optional[float]:
         violated_tasks = [
@@ -611,22 +659,32 @@ class _CancelBecauseSelfCollisionViolated(CancelMotion):
 class SelfCollisionAvoidance(Goal):
     """
     A goal combining a SelfCollisionDistanceMonitor and a SelfCollisionAvoidanceTask.
-    One pair will be added for all collision groups of the robot.
-    The task will only be active if the monitor detects that a collision is close.
+    One pair will be added for all collision groups of the robot. The task will only be
+    active if the monitor detects that a collision is close.
+
+    ..note:: This goal expands into one node pair per checked body combination, so its
+        children are left out of drawings. Set `plot_specs.collapse_children` to False to
+        draw them.
     """
+
+    plot_specs: NodePlotSpec = plot_specification_field(NodePlotSpec.create_collapsed_goal_style)
 
     robot: AbstractRobot = field(kw_only=True, default=None)
     """
     The robot for which the collision avoidance goal is defined.
     """
+
     max_velocity: float = field(default=0.2, kw_only=True)
     """
     The maximum velocity for the collision avoidance task.
     """
+
     self_collision_manager: SelfCollisionVariableManager = field(init=False)
     """
-    Reference to the self collision variable manager shared by other self collision avoidance nodes.
+    Reference to the self collision variable manager shared by other self collision
+    avoidance nodes.
     """
+
     cancel_if_collision_violated: bool = field(default=True, kw_only=True)
     """
     If True, the motion will be canceled if a collision is violated.
@@ -636,8 +694,11 @@ class SelfCollisionAvoidance(Goal):
         self, context: MotionStatechartContext
     ) -> CollisionMatrix:
         """
-        Creates a collision matrix that contains all body combinations except those that are always filtered.
-        We need this because we don't know how the collision matrix might change during the motion
+        Creates a collision matrix that contains all body combinations except those that
+        are always filtered.
+
+        We need this because we don't know how the collision matrix might change during
+        the motion
         """
         collision_matrix = CollisionMatrix()
         avoid_self_collisions = AvoidSelfCollisions(robot=self.robot)
@@ -718,16 +779,25 @@ class SelfCollisionAvoidance(Goal):
 class SelfCollisionDistanceMonitor(MotionStatechartNode):
     """
     Monitors the distance to the closest external object for the group of a body.
+
     Turns True if the distance falls below a given threshold.
     .. note:: the input bodies are only used to look up the collision groups.
     """
 
     body_a: Body = field(kw_only=True)
-    """First robot body to monitor."""
+    """
+    First robot body to monitor.
+    """
+
     body_b: Body = field(kw_only=True)
-    """Second robot body to monitor."""
+    """
+    Second robot body to monitor.
+    """
+
     threshold: float = field(kw_only=True)
-    """Distance threshold in meters."""
+    """
+    Distance threshold in meters.
+    """
 
     def build(self, context: MotionStatechartContext) -> NodeArtifacts:
         manager = context.self_collision_manager

--- a/giskardpy/src/giskardpy/motion_statechart/graph_node.py
+++ b/giskardpy/src/giskardpy/motion_statechart/graph_node.py
@@ -448,6 +448,9 @@ class MotionStatechartNode:
     """
 
     plot_specifications: NodePlotSpec = plot_specification_field(NodePlotSpec.create_monitor_style)
+    """
+    Describes how this node is plotted during a MotionStatechart.draw call or in the MotionStatechartInspector.
+    """
 
     def __post_init__(self):
         if self.name is None:

--- a/giskardpy/src/giskardpy/motion_statechart/graph_node.py
+++ b/giskardpy/src/giskardpy/motion_statechart/graph_node.py
@@ -56,7 +56,10 @@ from giskardpy.motion_statechart.exceptions import (
     NonObservationVariableError,
     NodeAlreadyBelongsToDifferentNodeError,
 )
-from giskardpy.motion_statechart.plotters.plot_specs import NodePlotSpec
+from giskardpy.motion_statechart.plotters.plot_specs import (
+    NodePlotSpec,
+    plot_specification_field,
+)
 from giskardpy.motion_statechart.constraint_builders import GeometricConstraintBuilder
 from giskardpy.qp.constraint_collection import ConstraintCollection
 from giskardpy.utils.utils import string_shortener
@@ -444,9 +447,7 @@ class MotionStatechartNode:
     Decides when this transitions to NOT_STARTED.
     """
 
-    plot_specs: NodePlotSpec = field(
-        default_factory=NodePlotSpec.create_monitor_style, kw_only=True, init=False
-    )
+    plot_specifications: NodePlotSpec = plot_specification_field(NodePlotSpec.create_monitor_style)
 
     def __post_init__(self):
         if self.name is None:
@@ -959,17 +960,13 @@ class Task(MotionStatechartNode):
     )
     """Task priority relative to other tasks."""
 
-    plot_specs: NodePlotSpec = field(
-        default_factory=NodePlotSpec.create_task_style, kw_only=True, init=False
-    )
+    plot_specs: NodePlotSpec = plot_specification_field(NodePlotSpec.create_task_style)
 
 
 @dataclass(eq=False, repr=False)
 class Goal(MotionStatechartNode):
     nodes: List[MotionStatechartNode] = field(default_factory=list, init=False)
-    plot_specs: NodePlotSpec = field(
-        default_factory=NodePlotSpec.create_goal_style, kw_only=True, init=False
-    )
+    plot_specifications: NodePlotSpec = plot_specification_field(NodePlotSpec.create_goal_style)
 
     def expand(self, context: MotionStatechartContext) -> None:
         """
@@ -1077,9 +1074,7 @@ class ThreadPayloadMonitor(MotionStatechartNode, ABC):
 @dataclass(eq=False, repr=False)
 class EndMotion(MotionStatechartNode):
 
-    plot_specs: NodePlotSpec = field(
-        default_factory=NodePlotSpec.create_end_style, kw_only=True, init=False
-    )
+    plot_specs: NodePlotSpec = plot_specification_field(NodePlotSpec.create_end_style)
 
     joint_convergence_threshold: float = field(default=0.01, kw_only=True)
     """
@@ -1163,9 +1158,7 @@ class CancelMotion(MotionStatechartNode):
         default_factory=Scalar.const_true, init=False
     )
 
-    plot_specs: NodePlotSpec = field(
-        default_factory=NodePlotSpec.create_cancel_style, kw_only=True, init=False
-    )
+    plot_specs: NodePlotSpec = plot_specification_field(NodePlotSpec.create_cancel_style)
 
     def build(self, context: MotionStatechartContext) -> NodeArtifacts:
         return NodeArtifacts(observation=Scalar.const_true())

--- a/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
+++ b/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
@@ -458,15 +458,18 @@ class MotionStatechart(SubclassJSONSerializer):
         default_factory=list, init=False, repr=False
     )
     """
-    Cache of all nodes in index order, appended to in :meth:`add_node`. Reading this instead of
-    rebuilding the list from `rx_graph` on every access is what keeps :meth:`tick` cheap.
+    Cache of all nodes in index order, appended to in :meth:`add_node`.
+
+    Reading this instead of rebuilding the list from `rx_graph` on every access is what
+    keeps :meth:`tick` cheap.
     """
 
     _cancel_motion_nodes: List[CancelMotion] = field(
         default_factory=list, init=False, repr=False
     )
     """
-    Cache of all :class:`CancelMotion` nodes, checked every tick in :meth:`_raise_if_cancel_motion`.
+    Cache of all :class:`CancelMotion` nodes, checked every tick in
+    :meth:`_raise_if_cancel_motion`.
     """
 
     _end_motion_nodes: List[EndMotion] = field(
@@ -516,9 +519,10 @@ class MotionStatechart(SubclassJSONSerializer):
                 )
                 child_node_copy.parent_node_index = node.index
                 goal_copy.nodes.append(child_node_copy)
-        # copy conditions
+        # copy conditions and plot specs
         for node in self.nodes:
             node_copy = motion_statechart_copy.get_node_by_index(node.index)
+            node_copy.plot_specifications = deepcopy(node.plot_specifications)
             node_copy.start_condition = node.start_condition
             node_copy.pause_condition = node.pause_condition
             node_copy.end_condition = node.end_condition

--- a/giskardpy/src/giskardpy/motion_statechart/plotters/graphviz.py
+++ b/giskardpy/src/giskardpy/motion_statechart/plotters/graphviz.py
@@ -48,11 +48,25 @@ if TYPE_CHECKING:
 
 
 def extract_node_names_from_condition(condition: str) -> Set[str]:
+    """
+    Collects the node names a condition expression refers to.
+
+    :param condition: The condition expression to scan.
+    :return: The names appearing in quotes inside the expression.
+    """
     matches = re.findall(r'"(.*?)"|\'(.*?)\'', condition)
     return set(match for group in matches for match in group if match)
 
 
 def format_condition(condition: str) -> str:
+    """
+    Rewrites a condition expression for display in an HTML label.
+
+    Logical operators start a new line and trinary constants are spelled out.
+
+    :param condition: The condition expression to rewrite.
+    :return: The expression with graphviz line breaks and readable constants.
+    """
     condition = condition.replace(" and ", "<BR/>       and ")
     condition = condition.replace(" or ", "<BR/>       or ")
     condition = condition.replace("1.0", "True")
@@ -62,14 +76,43 @@ def format_condition(condition: str) -> str:
 
 @dataclass
 class MotionStatechartGraphviz:
+    """
+    Draws a motion statechart as a graphviz graph.
+
+    Every node becomes a labelled box showing its current observation and life cycle
+    state, every :class:`~giskardpy.motion_statechart.graph_node.Goal` becomes a cluster
+    around its children, and every transition becomes a colored edge.
+
+    ..note:: The drawing reflects the state the statechart is in when it is drawn.
+    """
+
     motion_statechart: MotionStatechart
+    """
+    The statechart to draw, including the state it is currently in.
+    """
+
     graph: pydot.Graph = field(init=False)
+    """
+    The graph the statechart is drawn into.
+    """
+
     compact: bool = False
+    """
+    Whether nodes are drawn without their conditions and with tighter spacing.
+    """
+
     _cluster_map: Dict[MotionStatechartNode, pydot.Cluster] = field(
         init=False, default_factory=dict
     )
+    """
+    Maps a goal to the cluster its children are drawn in, with ``None`` mapping to the
+    top level graph.
+    """
 
     def __post_init__(self):
+        """
+        Creates the empty graph the statechart is drawn into.
+        """
         self.graph = pydot.Dot(
             graph_type="digraph",
             graph_name="",
@@ -83,6 +126,11 @@ class MotionStatechartGraphviz:
         self,
         node: MotionStatechartNode,
     ) -> str:
+        """
+        :param node: The node to label.
+        :return: The HTML label showing the node's name, its observation and life cycle
+            state and, outside of compact mode, its conditions.
+        """
         obs_state = self.motion_statechart.observation_state[node]
         life_cycle_state = self.motion_statechart.life_cycle_state[node]
         obs_color = ObservationStateToColor[obs_state]
@@ -122,8 +170,8 @@ class MotionStatechartGraphviz:
 
     def _build_hidden_node_count_block(self, node: MotionStatechartNode) -> str:
         """
-        Builds the label row telling the reader how many descendants of `node` are left
-        out of the drawing.
+        :param node: The node whose descendants are left out of the drawing.
+        :return: The label row stating how many of them are hidden.
         """
         hidden_node_count = self._count_descendants(node)
         plural = "s" if hidden_node_count != 1 else ""
@@ -137,7 +185,8 @@ class MotionStatechartGraphviz:
 
     def _count_descendants(self, node: MotionStatechartNode) -> int:
         """
-        :return: The number of nodes below `node`, nested goals included.
+        :param node: The node to count below.
+        :return: The number of nodes below it, nested goals included.
         """
         if not isinstance(node, Goal):
             return 0
@@ -146,6 +195,16 @@ class MotionStatechartGraphviz:
     def _build_condition_block(
         self, node: MotionStatechartNode, line_color="black"
     ) -> str:
+        """
+        Builds the label rows listing the transition conditions of a node.
+
+        Nodes that terminate the statechart only get their start condition, because the
+        remaining conditions never fire for them.
+
+        :param node: The node whose conditions are listed.
+        :param line_color: The color of the lines separating the rows.
+        :return: The condition rows of the label.
+        """
         start_condition = format_condition(str(node._start_condition))
         pause_condition = format_condition(str(node._pause_condition))
         end_condition = format_condition(str(node._end_condition))
@@ -170,11 +229,20 @@ class MotionStatechartGraphviz:
         return label
 
     def _escape_name(self, name: str) -> str:
+        """
+        :param name: The node name to escape.
+        :return: The name in the quoted form pydot stores it under.
+        """
         return f'"{name}"'
 
     def _get_cluster_of_node(
         self, node_name: str, graph: Union[pydot.Graph, pydot.Cluster]
     ) -> Optional[pydot.Cluster]:
+        """
+        :param node_name: The name of the node to look for.
+        :param graph: The graph whose direct subgraphs are searched.
+        :return: The subgraph holding the node, or ``None`` if none of them does.
+        """
         node_cluster = None
         for cluster in graph.get_subgraphs():
             if (
@@ -190,6 +258,14 @@ class MotionStatechartGraphviz:
         graph: pydot.Graph,
         node: MotionStatechartNode,
     ) -> pydot.Node:
+        """
+        Adds a node to a graph, wrapping it into one nested cluster per extra border
+        style its plot specification asks for.
+
+        :param graph: The graph the node is added to.
+        :param node: The node to draw.
+        :return: The added node.
+        """
         pydot_node = self._create_pydot_node(node)
         if len(node.plot_specifications.extra_border_styles) == 0:
             graph.add_node(pydot_node)
@@ -212,6 +288,11 @@ class MotionStatechartGraphviz:
         return pydot_node
 
     def _create_pydot_node(self, node: MotionStatechartNode) -> pydot.Node:
+        """
+        :param node: The node to draw.
+        :return: A labelled pydot node shaped and styled by the node's plot
+            specification.
+        """
         label = self._format_motion_graph_node(node=node)
         pydot_node = pydot.Node(
             str(node.unique_name),
@@ -228,6 +309,11 @@ class MotionStatechartGraphviz:
         return pydot_node
 
     def to_dot_graph(self) -> pydot.Graph:
+        """
+        Draws every visible node and transition of the statechart.
+
+        :return: The drawn graph.
+        """
         self._cluster_map[None] = self.graph
         top_level_nodes = [
             node for node in self.motion_statechart.nodes if not node.parent_node
@@ -237,6 +323,11 @@ class MotionStatechartGraphviz:
         return self.graph
 
     def to_dot_graph_pdf(self, file_name: str):
+        """
+        Draws the statechart and writes it to a pdf.
+
+        :param file_name: The path of the pdf to write.
+        """
         self.to_dot_graph()
         file_name = file_name
         # create_path(file_name)
@@ -245,14 +336,19 @@ class MotionStatechartGraphviz:
 
     def _is_drawn(self, node: MotionStatechartNode) -> bool:
         """
-        Return False if the node or any of its ancestors is marked invisible in plot
-        specs, or if one of its ancestors collapses its children.
+        :param node: The node to check.
+        :return: Whether the node appears in the drawing, which it does not if it or one
+            of its ancestors is invisible, or if one of its ancestors collapses its
+            children.
         """
         if not node.plot_specifications.visible:
             return False
         current = node.parent_node
         while current is not None:
-            if not current.plot_specifications.visible or current.plot_specifications.collapse_children:
+            if (
+                not current.plot_specifications.visible
+                or current.plot_specifications.collapse_children
+            ):
                 return False
             current = current.parent_node
         return True
@@ -262,13 +358,23 @@ class MotionStatechartGraphviz:
         parent_cluster: Union[pydot.Graph, pydot.Cluster],
         nodes: List[MotionStatechartNode],
     ):
+        """
+        Draws the given nodes, recursing into the children of every goal that does not
+        collapse them.
+
+        :param parent_cluster: The graph or cluster the nodes are drawn in.
+        :param nodes: The nodes to draw.
+        """
         for i, node in enumerate(nodes):
             # Skip invisible nodes entirely, as well as the children of a Goal that is
             # invisible or collapses them.
             if not self._is_drawn(node):
                 continue
 
-            if isinstance(node, Goal) and not node.plot_specifications.collapse_children:
+            if (
+                isinstance(node, Goal)
+                and not node.plot_specifications.collapse_children
+            ):
                 goal_cluster = self._add_cluster(node, parent_cluster)
                 self._add_node(
                     graph=goal_cluster,
@@ -287,6 +393,13 @@ class MotionStatechartGraphviz:
         node: MotionStatechartNode,
         parent_cluster: Union[pydot.Graph, pydot.Cluster],
     ):
+        """
+        Opens the cluster that a goal and its children are drawn in.
+
+        :param node: The goal to draw a border around.
+        :param parent_cluster: The graph or cluster the new cluster is nested in.
+        :return: The new cluster.
+        """
         goal_cluster = pydot.Cluster(
             graph_name=str(node.unique_name),
             fontname=FONT,
@@ -301,6 +414,12 @@ class MotionStatechartGraphviz:
         return goal_cluster
 
     def _add_edges(self):
+        """
+        Draws an edge for every transition whose endpoints are both drawn in the same
+        cluster.
+
+        :raises ValueError: If a transition has a kind that has no edge specification.
+        """
         transition: TrinaryCondition
         for edge_index, (
             parent_node_index,
@@ -328,6 +447,11 @@ class MotionStatechartGraphviz:
     def _are_nodes_in_same_cluster(
         self, parent_node: MotionStatechartNode, child_node: MotionStatechartNode
     ) -> bool:
+        """
+        :param parent_node: The node the transition points to.
+        :param child_node: The node the transition belongs to.
+        :return: Whether both nodes are drawn in the same cluster.
+        """
         parent_node_parent = parent_node.parent_node
         child_node_parent = child_node.parent_node
 
@@ -342,6 +466,16 @@ class MotionStatechartGraphviz:
         src_name: str,
         dst_name: str,
     ) -> Dict[str, object]:
+        """
+        Determines the edge attributes that clip an edge at a cluster border instead of
+        letting it reach into the cluster.
+
+        :param graph: The graph or cluster the edge is drawn in.
+        :param src_name: The name of the node the edge starts at.
+        :param dst_name: The name of the node the edge ends at.
+        :return: The ``ltail`` and ``lhead`` attributes for the endpoints that sit in a
+            cluster.
+        """
         kwargs: Dict[str, object] = {}
         dst_cluster = self._get_cluster_of_node(dst_name, graph)
         src_cluster = self._get_cluster_of_node(src_name, graph)
@@ -357,6 +491,16 @@ class MotionStatechartGraphviz:
         child_node: MotionStatechartNode,
         spec: EdgeSpec,
     ) -> None:
+        """
+        Draws the edge of a single transition.
+
+        Its direction and color come from the edge specification, while its line style
+        reflects the observation state of the node the specification points at.
+
+        :param parent_node: The node the transition points to.
+        :param child_node: The node the transition belongs to.
+        :param spec: The edge specification of the transition kind.
+        """
         graph = self._cluster_map[parent_node.parent_node]
 
         def _select_node(
@@ -364,6 +508,9 @@ class MotionStatechartGraphviz:
             child: MotionStatechartNode,
             selector: StateSelector,
         ) -> MotionStatechartNode:
+            """
+            :return: The node the selector names.
+            """
             return parent if selector == "parent" else child
 
         src_node = _select_node(parent_node, child_node, spec.src_selector)

--- a/giskardpy/src/giskardpy/motion_statechart/plotters/graphviz.py
+++ b/giskardpy/src/giskardpy/motion_statechart/plotters/graphviz.py
@@ -109,6 +109,8 @@ class MotionStatechartGraphviz:
             f"  </TD>"
             f"</TR>"
         )
+        if node.plot_specifications.collapse_children:
+            label += self._build_hidden_node_count_block(node)
         if self.compact:
             label += (
                 f"<TR>" f'  <TD WIDTH="100%" HEIGHT="{LineWidth*2.5}"></TD>' f"</TR>"
@@ -117,6 +119,29 @@ class MotionStatechartGraphviz:
             label += self._build_condition_block(node)
         label += f"</TABLE>>"
         return label
+
+    def _build_hidden_node_count_block(self, node: MotionStatechartNode) -> str:
+        """
+        Builds the label row telling the reader how many descendants of `node` are left
+        out of the drawing.
+        """
+        hidden_node_count = self._count_descendants(node)
+        plural = "s" if hidden_node_count != 1 else ""
+        return (
+            f"<TR>"
+            f'  <TD><FONT FACE="{ConditionFont}">'
+            f"[+] {hidden_node_count} node{plural} hidden"
+            f"</FONT></TD>"
+            f"</TR>"
+        )
+
+    def _count_descendants(self, node: MotionStatechartNode) -> int:
+        """
+        :return: The number of nodes below `node`, nested goals included.
+        """
+        if not isinstance(node, Goal):
+            return 0
+        return sum(1 + self._count_descendants(child_node) for child_node in node.nodes)
 
     def _build_condition_block(
         self, node: MotionStatechartNode, line_color="black"
@@ -166,15 +191,15 @@ class MotionStatechartGraphviz:
         node: MotionStatechartNode,
     ) -> pydot.Node:
         pydot_node = self._create_pydot_node(node)
-        if len(node.plot_specs.extra_border_styles) == 0:
+        if len(node.plot_specifications.extra_border_styles) == 0:
             graph.add_node(pydot_node)
             return pydot_node
         child = pydot_node
-        for index, style in enumerate(node.plot_specs.extra_border_styles):
+        for index, style in enumerate(node.plot_specifications.extra_border_styles):
             c = pydot.Cluster(
                 graph_name=f"{node.unique_name}",
                 penwidth=LineWidth,
-                style=node.plot_specs.extra_border_styles[index],
+                style=node.plot_specifications.extra_border_styles[index],
                 color="black",
             )
             if index == 0:
@@ -182,7 +207,7 @@ class MotionStatechartGraphviz:
             else:
                 c.add_subgraph(child)
             child = c
-        if len(node.plot_specs.extra_border_styles) > 0:
+        if len(node.plot_specifications.extra_border_styles) > 0:
             graph.add_subgraph(c)
         return pydot_node
 
@@ -191,9 +216,9 @@ class MotionStatechartGraphviz:
         pydot_node = pydot.Node(
             str(node.unique_name),
             label=label,
-            shape=node.plot_specs.shape,
+            shape=node.plot_specifications.shape,
             color="black",
-            style=node.plot_specs.style,
+            style=node.plot_specifications.style,
             margin=0,
             fillcolor="white",
             fontname=FONT,
@@ -218,14 +243,16 @@ class MotionStatechartGraphviz:
         self.graph.write_pdf(file_name)
         print(f"Saved task graph at {file_name}.")
 
-    def _is_visible_in_hierarchy(self, node: MotionStatechartNode) -> bool:
+    def _is_drawn(self, node: MotionStatechartNode) -> bool:
         """
         Return False if the node or any of its ancestors is marked invisible in plot
-        specs.
+        specs, or if one of its ancestors collapses its children.
         """
-        current = node
+        if not node.plot_specifications.visible:
+            return False
+        current = node.parent_node
         while current is not None:
-            if not current.plot_specs.visible:
+            if not current.plot_specifications.visible or current.plot_specifications.collapse_children:
                 return False
             current = current.parent_node
         return True
@@ -236,18 +263,19 @@ class MotionStatechartGraphviz:
         nodes: List[MotionStatechartNode],
     ):
         for i, node in enumerate(nodes):
-            # Skip invisible nodes entirely. If a Goal is invisible, skip its children as well.
-            if not self._is_visible_in_hierarchy(node):
+            # Skip invisible nodes entirely, as well as the children of a Goal that is
+            # invisible or collapses them.
+            if not self._is_drawn(node):
                 continue
 
-            if isinstance(node, Goal):
+            if isinstance(node, Goal) and not node.plot_specifications.collapse_children:
                 goal_cluster = self._add_cluster(node, parent_cluster)
                 self._add_node(
                     graph=goal_cluster,
                     node=node,
                 )
-                # Recurse only into visible children; _add_nodes applies visibility filtering
                 self._add_nodes(goal_cluster, node.nodes)
+                continue
 
             self._add_node(
                 parent_cluster,
@@ -284,10 +312,10 @@ class MotionStatechartGraphviz:
             )
             child_node = self.motion_statechart.rx_graph.get_node_data(child_node_index)
 
-            # Skip edges if either endpoint (or one of its ancestors) is invisible
-            if not self._is_visible_in_hierarchy(parent_node):
+            # Skip edges if either endpoint (or one of its ancestors) is not drawn
+            if not self._is_drawn(parent_node):
                 continue
-            if not self._is_visible_in_hierarchy(child_node):
+            if not self._is_drawn(child_node):
                 continue
 
             if not self._are_nodes_in_same_cluster(parent_node, child_node):

--- a/giskardpy/src/giskardpy/motion_statechart/plotters/plot_specs.py
+++ b/giskardpy/src/giskardpy/motion_statechart/plotters/plot_specs.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from typing_extensions import (
+    Any,
+    Callable,
     List,
     Dict,
     Optional,
@@ -11,6 +13,7 @@ from typing_extensions import (
     Self,
 )
 
+from krrood.patterns.field_metadata import JSONMetadata
 from giskardpy.motion_statechart.data_types import TransitionKind
 from giskardpy.motion_statechart.plotters.styles import (
     ConditionColors,
@@ -29,6 +32,13 @@ if TYPE_CHECKING:
 @dataclass
 class NodePlotSpec:
     visible: bool = True
+    collapse_children: bool = False
+    """
+    Whether the descendants of this node are omitted from the drawing.
+
+    Only has an effect on nodes that own children, i.e. goals.
+    """
+
     style: str = "filled, rounded"
     shape: str = "rectangle"
     extra_border_styles: List[str] = field(default_factory=list)
@@ -55,6 +65,15 @@ class NodePlotSpec:
         )
 
     @classmethod
+    def create_collapsed_goal_style(cls) -> Self:
+        """
+        :return: A goal style whose descendants are left out of the drawing.
+        """
+        goal_style = cls.create_goal_style()
+        goal_style.collapse_children = True
+        return goal_style
+
+    @classmethod
     def create_end_style(cls):
         return cls(
             visible=True,
@@ -71,6 +90,21 @@ class NodePlotSpec:
             shape=MonitorShape,
             extra_border_styles=["dashed, rounded"],
         )
+
+
+def plot_specification_field(default_factory: Callable[[], NodePlotSpec]) -> Any:
+    """
+    Declares the plot spec field of a node, styled by `default_factory`.
+
+    Plot specs are not constructor arguments, so they need to be marked as serializable
+    explicitly to survive a JSON round trip.
+    """
+    return field(
+        default_factory=default_factory,
+        kw_only=True,
+        init=False,
+        metadata=JSONMetadata(serialize=True).as_dict(),
+    )
 
 
 SrcSelector = Literal["parent", "child"]

--- a/krrood/src/krrood/symbolic_math/exceptions.py
+++ b/krrood/src/krrood/symbolic_math/exceptions.py
@@ -97,6 +97,16 @@ class NotSquareMatrixError(WrongDimensionsError):
 
 
 @dataclass
+class NotColumnVectorError(WrongDimensionsError):
+    """
+    Raised when data that is expected to describe a vector has more than one column.
+    """
+
+    expected_dimensions: str = field(default="(n, 1)", init=False)
+    actual_dimensions: Tuple[int, int]
+
+
+@dataclass
 class HasFreeVariablesError(SymbolicMathError):
     """
     Raised when an operation can't be performed on an expression with free variables.
@@ -143,6 +153,32 @@ class WrongNumberOfArgsError(ExpressionEvaluationError):
 
     def error_message(self) -> str:
         return f"Expected {self.expected_number_of_args} arguments, but got {self.actual_number_of_args}."
+
+    def suggest_correction(self) -> str:
+        return ""
+
+
+@dataclass
+class NotEnoughArgumentsError(SymbolicMathError):
+    """
+    Raised when an operation is called with fewer arguments than it requires.
+    """
+
+    minimum_number_of_arguments: int
+    """
+    The smallest number of arguments the operation accepts.
+    """
+
+    actual_number_of_arguments: int
+    """
+    The number of arguments the operation was called with.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"Expected at least {self.minimum_number_of_arguments} arguments, "
+            f"but got {self.actual_number_of_arguments}."
+        )
 
     def suggest_correction(self) -> str:
         return ""

--- a/krrood/src/krrood/symbolic_math/symbolic_math.py
+++ b/krrood/src/krrood/symbolic_math/symbolic_math.py
@@ -57,6 +57,8 @@ from krrood.symbolic_math.exceptions import (
     WrongNumberOfArgsError,
     NotSquareMatrixError,
     NotScalerError,
+    NotColumnVectorError,
+    NotEnoughArgumentsError,
     UnsupportedOperationError,
     WrongDimensionsError,
     CannotConvertToStringError,
@@ -1108,7 +1110,8 @@ class Vector(SymbolicMathType):
         """
         if self.shape[0] == 1:
             self._casadi_sx = self._casadi_sx.T
-        assert self.shape[1] == 1 or self.shape == (0, 0)
+        if self.shape[1] != 1 and self.shape != (0, 0):
+            raise NotColumnVectorError(actual_dimensions=self.shape)
 
     @classmethod
     def zeros(cls, size: int) -> Self:
@@ -1527,7 +1530,8 @@ class Matrix(SymbolicMathType):
 
         Only works if the expression is square.
         """
-        assert self.shape[0] == self.shape[1]
+        if not self.is_square():
+            raise NotSquareMatrixError(actual_dimensions=self.shape)
         return Matrix(ca.inv(self.casadi_sx))
 
     def kron(self, other: Matrix) -> Self:
@@ -2047,13 +2051,18 @@ def trinary_logic_not(expression: FloatVariable | Scalar) -> Scalar:
 
 def trinary_logic_and(*args: FloatVariable | Scalar) -> Scalar:
     """
-    AND   |  True   | Unknown | False
-    ------------------+---------+-------
-    True    | True   | Unknown | False
-    Unknown | Unknown | Unknown | False
-    False   |  False  | False  | False.
+    Trinary logic and::
+
+        AND     |  True   | Unknown | False
+        --------+---------+---------+-------
+        True    | True    | Unknown | False
+        Unknown | Unknown | Unknown | False
+        False   | False   | False   | False
     """
-    assert len(args) >= 2, "trinary_logic_and must be called with at least 2 arguments"
+    if len(args) < 2:
+        raise NotEnoughArgumentsError(
+            minimum_number_of_arguments=2, actual_number_of_arguments=len(args)
+        )
     # if there is any False, return False
     if any(x for x in args if x.is_const_false()):
         return Scalar.const_false()
@@ -2071,13 +2080,18 @@ def trinary_logic_and(*args: FloatVariable | Scalar) -> Scalar:
 
 def trinary_logic_or(*args: FloatVariable | Scalar) -> Scalar:
     """
-    OR   |  True   | Unknown | False
-    ------------------+---------+-------
-    True    | True     |  True   | True
-    Unknown |  True   | Unknown | Unknown
-    False   |  True   | Unknown | False.
+    Trinary logic or::
+
+        OR      |  True   | Unknown | False
+        --------+---------+---------+-------
+        True    | True    | True    | True
+        Unknown | True    | Unknown | Unknown
+        False   | True    | Unknown | False
     """
-    assert len(args) >= 2, "trinary_logic_or must be called with at least 2 arguments"
+    if len(args) < 2:
+        raise NotEnoughArgumentsError(
+            minimum_number_of_arguments=2, actual_number_of_arguments=len(args)
+        )
     # if there is any False, return False
     if any(x for x in args if x.is_const_true()):
         return Scalar.const_true()

--- a/krrood/src/krrood/symbolic_math/symbolic_math.py
+++ b/krrood/src/krrood/symbolic_math/symbolic_math.py
@@ -2047,11 +2047,13 @@ def trinary_logic_not(expression: FloatVariable | Scalar) -> Scalar:
 
 def trinary_logic_and(*args: FloatVariable | Scalar) -> Scalar:
     """
-    AND   |  True   | Unknown | False ------------------+---------+------- True    |
-    True   | Unknown | False Unknown | Unknown | Unknown | False False   |  False  |
-    False  | False.
+    AND   |  True   | Unknown | False
+    ------------------+---------+-------
+    True    | True   | Unknown | False
+    Unknown | Unknown | Unknown | False
+    False   |  False  | False  | False.
     """
-    assert len(args) >= 2, "and must be called with at least 2 arguments"
+    assert len(args) >= 2, "trinary_logic_and must be called with at least 2 arguments"
     # if there is any False, return False
     if any(x for x in args if x.is_const_false()):
         return Scalar.const_false()
@@ -2069,11 +2071,13 @@ def trinary_logic_and(*args: FloatVariable | Scalar) -> Scalar:
 
 def trinary_logic_or(*args: FloatVariable | Scalar) -> Scalar:
     """
-    OR   |  True   | Unknown | False ------------------+---------+------- True    | True
-    |  True   | True Unknown |  True   | Unknown | Unknown False   |  True   | Unknown |
-    False.
+    OR   |  True   | Unknown | False
+    ------------------+---------+-------
+    True    | True     |  True   | True
+    Unknown |  True   | Unknown | Unknown
+    False   |  True   | Unknown | False.
     """
-    assert len(args) >= 2, "and must be called with at least 2 arguments"
+    assert len(args) >= 2, "trinary_logic_or must be called with at least 2 arguments"
     # if there is any False, return False
     if any(x for x in args if x.is_const_true()):
         return Scalar.const_true()

--- a/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/orm/ormatic_interface.py
@@ -84,6 +84,8 @@ import semantic_digital_twin.pipeline.mesh_decomposition.coacd
 import semantic_digital_twin.pipeline.mesh_decomposition.vhacd
 import semantic_digital_twin.pipeline.pipeline
 import semantic_digital_twin.reasoning.predicates
+import semantic_digital_twin.reasoning.reasoner
+import semantic_digital_twin.reasoning.world_reasoner
 import semantic_digital_twin.robots.armar7
 import semantic_digital_twin.robots.daisy
 import semantic_digital_twin.robots.garmi
@@ -113,6 +115,10 @@ import semantic_digital_twin.world_description.connection_properties
 import semantic_digital_twin.world_description.connections
 import semantic_digital_twin.world_description.degree_of_freedom
 import semantic_digital_twin.world_description.geometry
+import semantic_digital_twin.world_description.graph_of_convex_sets.base
+import semantic_digital_twin.world_description.graph_of_convex_sets.boxes
+import semantic_digital_twin.world_description.graph_of_convex_sets.exceptions
+import semantic_digital_twin.world_description.graph_of_convex_sets.polygons
 import semantic_digital_twin.world_description.inertial_properties
 import semantic_digital_twin.world_description.shape_collection
 import semantic_digital_twin.world_description.soft_connections
@@ -789,6 +795,44 @@ class WorldModelManagerDAO_model_modification_blocks_association(
     target: Mapped[WorldModelModificationBlockDAO] = relationship(
         "WorldModelModificationBlockDAO",
         foreign_keys=[target_worldmodelmodificationblockdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_obstacles_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_10097511437740384067152589240138880074945231015404257411712969"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedconvexsetdao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedConvexSetDAO.database_id")
+    )
+
+    target: Mapped[_MockedConvexSetDAO] = relationship(
+        "_MockedConvexSetDAO",
+        foreign_keys=[target__mockedconvexsetdao_id],
+        lazy="selectin",
+    )
+
+
+class GraphOfConvexPolygonsDAO_regions_association(Base, AssociationDataAccessObject):
+    __tablename__ = "_21683303155680797721654562863218184758483517575191610116427927"
+
+    database_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    source_graphofconvexpolygonsdao_id: Mapped[int] = mapped_column(
+        ForeignKey("GraphOfConvexPolygonsDAO.database_id")
+    )
+    target__mockedhpolyhedrondao_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedHPolyhedronDAO.database_id")
+    )
+
+    target: Mapped[_MockedHPolyhedronDAO] = relationship(
+        "_MockedHPolyhedronDAO",
+        foreign_keys=[target__mockedhpolyhedrondao_id],
         lazy="selectin",
     )
 
@@ -10611,6 +10655,40 @@ class RightOfDAO(
     }
 
 
+class CaseReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.reasoner.CaseReasoner]
+):
+    __tablename__ = "CaseReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    model_directory: Mapped[builtins.str] = mapped_column(
+        sqlalchemy.sql.sqltypes.Text, use_existing_column=True
+    )
+
+
+class WorldReasonerDAO(
+    Base, DataAccessObject[semantic_digital_twin.reasoning.world_reasoner.WorldReasoner]
+):
+    __tablename__ = "WorldReasonerDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+
+
 class RobotPartMixinDAO(
     Base,
     DataAccessObject[semantic_digital_twin.robots.robot_part_mixins.RobotPartMixin],
@@ -11642,6 +11720,16 @@ class BoundingBoxDAO(
     )
 
 
+class BoundsDAO(
+    Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Bounds]
+):
+    __tablename__ = "BoundsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
 class ColorDAO(
     Base, DataAccessObject[semantic_digital_twin.world_description.geometry.Color]
 ):
@@ -11831,6 +11919,264 @@ class TextureDAO(
 
     repeat: Mapped[typing.List[builtins.float]] = mapped_column(
         JSON, nullable=False, use_existing_column=True
+    )
+
+
+class GraphOfConvexSetsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.base.GraphOfConvexSets
+    ],
+):
+    __tablename__ = "GraphOfConvexSetsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    polymorphic_type: Mapped[str] = mapped_column(
+        String(255), nullable=False, use_existing_column=True
+    )
+
+    world_id: Mapped[int] = mapped_column(
+        ForeignKey("WorldMappingDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+    search_space_id: Mapped[typing.Optional[builtins.int]] = mapped_column(
+        ForeignKey("BoundingBoxCollectionDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    world: Mapped[WorldMappingDAO] = relationship(
+        "WorldMappingDAO", uselist=False, foreign_keys=[world_id], post_update=True
+    )
+    search_space: Mapped[BoundingBoxCollectionDAO] = relationship(
+        "BoundingBoxCollectionDAO",
+        uselist=False,
+        foreign_keys=[search_space_id],
+        post_update=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_on": "polymorphic_type",
+        "polymorphic_identity": "GraphOfConvexSetsDAO",
+    }
+
+
+class GraphOfBoundingBoxesDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.boxes.GraphOfBoundingBoxes
+    ],
+):
+    __tablename__ = "GraphOfBoundingBoxesDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfBoundingBoxesDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class UnboundedSearchSpaceErrorDAO(
+    UsageErrorDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.exceptions.UnboundedSearchSpaceError
+    ],
+):
+    __tablename__ = "UnboundedSearchSpaceErrorDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(UsageErrorDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "UnboundedSearchSpaceErrorDAO",
+        "inherit_condition": database_id == UsageErrorDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class GraphOfConvexPolygonsDAO(
+    GraphOfConvexSetsDAO,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.GraphOfConvexPolygons
+    ],
+):
+    __tablename__ = "GraphOfConvexPolygonsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        ForeignKey(GraphOfConvexSetsDAO.database_id),
+        primary_key=True,
+        use_existing_column=True,
+    )
+
+    obstacles: Mapped[builtins.list[GraphOfConvexPolygonsDAO_obstacles_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_obstacles_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_obstacles_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+    regions: Mapped[builtins.list[GraphOfConvexPolygonsDAO_regions_association]] = (
+        relationship(
+            "GraphOfConvexPolygonsDAO_regions_association",
+            collection_class=builtins.list,
+            cascade="all, delete-orphan",
+            foreign_keys="[GraphOfConvexPolygonsDAO_regions_association.source_graphofconvexpolygonsdao_id]",
+            lazy="selectin",
+        )
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "GraphOfConvexPolygonsDAO",
+        "inherit_condition": database_id == GraphOfConvexSetsDAO.database_id,
+        "polymorphic_load": "selectin",
+    }
+
+
+class IrisSeedingSettingsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons.IrisSeedingSettings
+    ],
+):
+    __tablename__ = "IrisSeedingSettingsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+    grid_resolution: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+    max_regions: Mapped[builtins.int] = mapped_column(use_existing_column=True)
+
+    iris_options_id: Mapped[int] = mapped_column(
+        ForeignKey("_MockedIrisOptionsDAO.database_id", use_alter=True),
+        nullable=True,
+        use_existing_column=True,
+    )
+
+    iris_options: Mapped[_MockedIrisOptionsDAO] = relationship(
+        "_MockedIrisOptionsDAO",
+        uselist=False,
+        foreign_keys=[iris_options_id],
+        post_update=True,
+    )
+
+
+class _MockedConvexSetDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedConvexSet
+    ],
+):
+    __tablename__ = "_MockedConvexSetDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedGcsTrajectoryOptimizationDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedGcsTrajectoryOptimization
+    ],
+):
+    __tablename__ = "_MockedGcsTrajectoryOptimizationDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedHPolyhedronDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedHPolyhedron
+    ],
+):
+    __tablename__ = "_MockedHPolyhedronDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIris
+    ],
+):
+    __tablename__ = "_MockedIrisDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedIrisOptionsDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedIrisOptions
+    ],
+):
+    __tablename__ = "_MockedIrisOptionsDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedPointDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedPoint
+    ],
+):
+    __tablename__ = "_MockedPointDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedSubgraphDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedSubgraph
+    ],
+):
+    __tablename__ = "_MockedSubgraphDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
+    )
+
+
+class _MockedVPolytopeDAO(
+    Base,
+    DataAccessObject[
+        semantic_digital_twin.world_description.graph_of_convex_sets.polygons._MockedVPolytope
+    ],
+):
+    __tablename__ = "_MockedVPolytopeDAO"
+
+    database_id: Mapped[builtins.int] = mapped_column(
+        Integer, primary_key=True, use_existing_column=True
     )
 
 

--- a/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
+++ b/test/giskardpy_test/test_motion_statechart/test_collision_avoidance_tasks.py
@@ -13,6 +13,7 @@ from giskardpy.motion_statechart.data_types import (
 )
 from giskardpy.motion_statechart.exceptions import CollisionViolatedError
 from giskardpy.motion_statechart.goals.collision_avoidance import (
+    _CancelBecauseSelfCollisionViolated,
     ExternalCollisionAvoidance,
     SelfCollisionAvoidance,
     ExternalCollisionDistanceMonitor,
@@ -507,6 +508,36 @@ def test_multiple_external_collision_avoidance_motions(cylinder_bot_world: World
     # Second motion
     run_motion(0.5)
     assert len(cylinder_bot_world.collision_manager.collision_consumers) == 0
+
+
+def test_cancel_node_without_tasks_never_starts():
+    msc = MotionStatechart()
+    msc.add_node(cancel := _CancelBecauseSelfCollisionViolated(name="cancel", tasks=[]))
+
+    cancel.build(MotionStatechartContext.empty())
+
+    assert cancel.start_condition.is_const_false()
+
+
+def test_self_collision_avoidance_without_checked_body_combinations(
+    cylinder_bot_world: World,
+):
+    robot = cylinder_bot_world.get_semantic_annotations_by_type(AbstractRobot)[0]
+
+    msc = MotionStatechart()
+    msc.add_nodes(
+        [
+            goal := SelfCollisionAvoidance(robot=robot),
+            local_min := LocalMinimumReached(),
+        ]
+    )
+    msc.add_node(EndMotion.when_true(local_min))
+
+    Executor(MotionStatechartContext(world=cylinder_bot_world)).compile(
+        motion_statechart=msc
+    )
+
+    assert goal.nodes == msc.get_nodes_by_type(CancelMotion)
 
 
 def test_self_collision_avoidance(self_collision_bot_world: World):

--- a/test/giskardpy_test/test_motion_statechart/test_graphviz_plotter.py
+++ b/test/giskardpy_test/test_motion_statechart/test_graphviz_plotter.py
@@ -1,0 +1,187 @@
+import pydot
+from typing_extensions import Optional, Set, Union
+
+from giskardpy.motion_statechart.context import MotionStatechartContext
+from giskardpy.motion_statechart.goals.collision_avoidance import (
+    ExternalCollisionAvoidance,
+    SelfCollisionAvoidance,
+)
+from giskardpy.motion_statechart.graph_node import (
+    EndMotion,
+    Goal,
+    MotionStatechartNode,
+)
+from giskardpy.motion_statechart.motion_statechart import MotionStatechart
+from giskardpy.motion_statechart.nodes_for_testing.nodes_for_testing import (
+    TestGoal,
+    TestNestedGoal,
+)
+from giskardpy.motion_statechart.plotters.graphviz import MotionStatechartGraphviz
+
+# %% helpers
+
+
+def build_motion_statechart(goal: Goal) -> MotionStatechart:
+    """
+    Creates a motion statechart holding `goal` and an end motion, expanded far enough to
+    be drawn.
+    """
+    motion_statechart = MotionStatechart()
+    motion_statechart.add_node(goal)
+    motion_statechart.add_node(EndMotion.when_true(goal))
+    motion_statechart._expand_goals(MotionStatechartContext.empty())
+    motion_statechart._add_transitions()
+    return motion_statechart
+
+
+def draw(motion_statechart: MotionStatechart) -> pydot.Graph:
+    """
+    :return: The dot graph of `motion_statechart`.
+    """
+    return MotionStatechartGraphviz(motion_statechart).to_dot_graph()
+
+
+def direct_node_names(graph: Union[pydot.Graph, pydot.Cluster]) -> Set[str]:
+    """
+    :return: The names of the nodes declared on `graph` itself, ignoring its subgraphs.
+    """
+    return {node.get_name().strip('"') for node in graph.get_nodes()}
+
+
+def all_node_names(graph: Union[pydot.Graph, pydot.Cluster]) -> Set[str]:
+    """
+    :return: The names of the nodes declared anywhere in `graph`, subgraphs included.
+    """
+    names = direct_node_names(graph)
+    for subgraph in graph.get_subgraphs():
+        names |= all_node_names(subgraph)
+    return names
+
+
+def all_edge_endpoints(graph: Union[pydot.Graph, pydot.Cluster]) -> Set[str]:
+    """
+    :return: The source and destination names of every edge in `graph`, subgraphs included.
+    """
+    endpoints = set()
+    for edge in graph.get_edges():
+        endpoints.add(edge.get_source().strip('"'))
+        endpoints.add(edge.get_destination().strip('"'))
+    for subgraph in graph.get_subgraphs():
+        endpoints |= all_edge_endpoints(subgraph)
+    return endpoints
+
+
+def find_cluster_of(
+    graph: pydot.Graph, node: MotionStatechartNode
+) -> Optional[pydot.Cluster]:
+    """
+    :return: The cluster `node` owns as a goal, or None if it has none.
+    """
+    for subgraph in graph.get_subgraphs():
+        if subgraph.get_name().strip('"') == f"cluster_{node.unique_name}":
+            return subgraph
+    return None
+
+
+def find_node(graph: pydot.Graph, node: MotionStatechartNode) -> pydot.Node:
+    """
+    :return: The pydot node drawn for `node`.
+    """
+    for candidate in graph.get_nodes():
+        if candidate.get_name().strip('"') == node.unique_name:
+            return candidate
+    raise AssertionError(f"{node.unique_name} was not drawn in {graph.get_name()}")
+
+
+# %% expanded goals
+
+
+def test_expanded_goal_draws_children_in_its_cluster():
+    goal = TestGoal(name="goal")
+    motion_statechart = build_motion_statechart(goal)
+
+    cluster = find_cluster_of(draw(motion_statechart), goal)
+
+    assert direct_node_names(cluster) == {
+        goal.unique_name,
+        goal.sub_node1.unique_name,
+        goal.sub_node2.unique_name,
+    }
+
+
+def test_expanded_goal_node_is_declared_only_in_its_cluster():
+    goal = TestGoal(name="goal")
+    motion_statechart = build_motion_statechart(goal)
+
+    graph = draw(motion_statechart)
+
+    assert goal.unique_name not in direct_node_names(graph)
+
+
+# %% collapsed goals
+
+
+def test_collapsed_goal_hides_children_and_their_edges():
+    goal = TestGoal(name="goal")
+    goal.plot_specifications.collapse_children = True
+    motion_statechart = build_motion_statechart(goal)
+
+    graph = draw(motion_statechart)
+
+    assert find_cluster_of(graph, goal) is None
+    assert goal.unique_name in direct_node_names(graph)
+    hidden_names = {goal.sub_node1.unique_name, goal.sub_node2.unique_name}
+    assert all_node_names(graph) & hidden_names == set()
+    assert all_edge_endpoints(graph) & hidden_names == set()
+
+
+def test_collapsed_goal_reports_hidden_node_count():
+    goal = TestGoal(name="goal")
+    goal.plot_specifications.collapse_children = True
+    motion_statechart = build_motion_statechart(goal)
+
+    label = find_node(draw(motion_statechart), goal).get_label()
+
+    assert "2 nodes hidden" in label
+
+
+def test_collapsed_goal_counts_hidden_nodes_of_nested_goals():
+    goal = TestNestedGoal(name="goal")
+    goal.plot_specifications.collapse_children = True
+    motion_statechart = build_motion_statechart(goal)
+
+    label = find_node(draw(motion_statechart), goal).get_label()
+
+    # the inner goal plus the two nodes it expands into
+    assert "3 nodes hidden" in label
+
+
+def test_expanded_goal_reports_no_hidden_node_count():
+    goal = TestGoal(name="goal")
+    motion_statechart = build_motion_statechart(goal)
+
+    cluster = find_cluster_of(draw(motion_statechart), goal)
+
+    assert "hidden" not in find_node(cluster, goal).get_label()
+
+
+# %% collision avoidance defaults
+
+
+def test_collision_avoidance_goals_collapse_their_children():
+    assert ExternalCollisionAvoidance().plot_specifications.collapse_children
+    assert SelfCollisionAvoidance().plot_specs.collapse_children
+
+
+# %% structure copies
+
+
+def test_structure_copy_keeps_plot_specs():
+    goal = TestGoal(name="goal")
+    goal.plot_specifications.collapse_children = True
+    motion_statechart = build_motion_statechart(goal)
+
+    goal_copy = motion_statechart.create_structure_copy().get_node_by_index(goal.index)
+
+    assert goal_copy.plot_specifications.collapse_children
+    assert goal_copy.plot_specifications is not goal.plot_specifications

--- a/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
+++ b/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
@@ -330,6 +330,22 @@ def test_nested_goals(tmp_path):
             assert node_copy.parent_node_index is None
 
 
+def test_collapsed_goal_survives_json_round_trip():
+    msc = MotionStatechart()
+    msc.add_node(goal := TestNestedGoal())
+    goal.plot_specifications.collapse_children = True
+    msc.add_node(EndMotion.when_true(goal))
+
+    msc._expand_goals(MotionStatechartContext.empty())
+    json_data = msc.create_structure_copy().to_json()
+    json_str = json.dumps(json_data)
+    new_json_data = json.loads(json_str)
+
+    msc_copy = MotionStatechart.from_json(new_json_data)
+
+    assert msc_copy.get_node_by_index(goal.index).plot_specifications.collapse_children
+
+
 def test_cancel_motion():
     msc = MotionStatechart()
     msc.add_node(node := ConstTrueNode())

--- a/test/giskardpy_test/test_motion_statechart/test_motion_statechart.py
+++ b/test/giskardpy_test/test_motion_statechart/test_motion_statechart.py
@@ -219,9 +219,9 @@ def test_draw_with_invisible_node(tmp_path):
     )
     msc.add_node(EndMotion.when_all_true(msc.nodes))
 
-    sequence.plot_specs.visible = False
-    s1n2.plot_specs.visible = False
-    s2n2.plot_specs.visible = False
+    sequence.plot_specifications.visible = False
+    s1n2.plot_specifications.visible = False
+    s2n2.plot_specifications.visible = False
 
     kin_sim = Executor(MotionStatechartContext(world=World()))
     kin_sim.compile(motion_statechart=msc)

--- a/test/krrood_test/test_symbolic_math/test_symbolic_math.py
+++ b/test/krrood_test/test_symbolic_math/test_symbolic_math.py
@@ -9,6 +9,8 @@ import scipy.sparse as sp
 import krrood.symbolic_math.symbolic_math as sm
 from krrood.symbolic_math.exceptions import (
     HasFreeVariablesError,
+    NotColumnVectorError,
+    NotEnoughArgumentsError,
     NotSquareMatrixError,
 )
 from krrood.symbolic_math.symbolic_math import VariableParameters
@@ -111,6 +113,18 @@ class TestLogic3:
                 assert expected == float(
                     actual
                 ), f"a={i}, b={j}, expected {expected}, actual {actual}"
+
+    def test_and3_with_too_few_arguments(self):
+        with pytest.raises(NotEnoughArgumentsError) as error:
+            sm.trinary_logic_and(sm.Scalar(TrinaryTrue))
+        assert error.value.minimum_number_of_arguments == 2
+        assert error.value.actual_number_of_arguments == 1
+
+    def test_or3_with_too_few_arguments(self):
+        with pytest.raises(NotEnoughArgumentsError) as error:
+            sm.trinary_logic_or(sm.Scalar(TrinaryTrue))
+        assert error.value.minimum_number_of_arguments == 2
+        assert error.value.actual_number_of_arguments == 1
 
     def test_not3(self):
         for i in self.values:
@@ -919,6 +933,11 @@ class TestVector:
         v = sm.Vector(data)
         assert v.to_list() == data.tolist()
 
+    def test_vector_from_multi_column_data(self):
+        with pytest.raises(NotColumnVectorError) as error:
+            sm.Vector(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        assert error.value.actual_dimensions == (2, 2)
+
     def test_to_list_raises_on_variables(self):
         v = sm.Vector(vec := [sm.FloatVariable(name="a"), 2.0])
         with pytest.raises(HasFreeVariablesError):
@@ -1221,6 +1240,11 @@ class TestMatrix:
         mat = sm.Matrix(np_arr).reshape((2, 8))
         assert mat.shape == (2, 8)
         assert np.allclose(mat.to_np(), np_arr.reshape((2, 8)))
+
+    def test_inverse_of_non_square_matrix(self):
+        with pytest.raises(NotSquareMatrixError) as error:
+            sm.Matrix(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])).inverse()
+        assert error.value.actual_dimensions == (2, 3)
 
     def test_trace(self):
         m = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])


### PR DESCRIPTION
If needed, it can be turned off in the plot specifications of a node. Only collision avoidance goals are collapsed by default 

before:
[muh.pdf](https://github.com/user-attachments/files/30794651/muh.pdf)


after:

[muh_after.pdf](https://github.com/user-attachments/files/30794437/muh_after.pdf)
