### PR TITLE
Fix ProcTHOR precompute scripts and the documented connection URI

### DIFF
--- a/semantic_digital_twin/examples/persistence_of_annotated_worlds.md
+++ b/semantic_digital_twin/examples/persistence_of_annotated_worlds.md
@@ -102,5 +102,9 @@ This tutorial used an in memory database for the purpose of demonstration.
 If you want to permanently store worlds, you have to
 - Install an RDBMS that is supported by SQLAlchemy. (I recommend [PostgreSQL](https://www.postgresql.org/download/))
 - Create a user and database in your RDBMS, for instance with [this script](https://github.com/cram2/cognitive_robot_abstract_machine/blob/main/semantic_digital_twin/scripts/create_postgres_database_and_user_if_not_exists.sql). The script contains the documentation on how to run itself.
-- Set the environment variable `SEMANTIC_DIGITAL_TWIN_DATABASE_URI` to the connection string of your RDBMS, for instance by adding `export SEMANTIC_DIGITAL_TWIN_DATABASE_URI=postgresql://semantic_digital_twin:a_very_strong_password_here@localhost:5432/semantic_digital_twin` to your bashrc.
+- Set the environment variable `SEMANTIC_DIGITAL_TWIN_DATABASE_URI` to the connection string of your RDBMS, for instance by adding `export SEMANTIC_DIGITAL_TWIN_DATABASE_URI=postgresql+psycopg://semantic_digital_twin:a_very_strong_password_here@localhost:5432/semantic_digital_twin` to your bashrc.
+  Note the `+psycopg`: it selects the psycopg 3 driver, which is what this
+  project depends on. A bare `postgresql://` URI makes SQLAlchemy default to
+  psycopg2 instead, which is not installed, so connecting fails with
+  `ModuleNotFoundError: No module named 'psycopg2'`.
 - Create a session for database interaction, for instance with `semantic_digital_twin_sessionmaker()()`

--- a/semantic_digital_twin/scripts/fetch_and_safe_to_db.py
+++ b/semantic_digital_twin/scripts/fetch_and_safe_to_db.py
@@ -4,7 +4,7 @@ import time
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
 
-from krrood.ormatic.dao import to_dao
+from krrood.ormatic.data_access_objects.helper import to_dao
 from krrood.ormatic.utils import drop_database
 from semantic_digital_twin.adapters.ros.world_fetcher import fetch_world_from_service
 from semantic_digital_twin.orm.ormatic_interface import Base

--- a/semantic_digital_twin/scripts/parse_procthor_files_and_save_to_database.py
+++ b/semantic_digital_twin/scripts/parse_procthor_files_and_save_to_database.py
@@ -9,7 +9,7 @@ import tqdm
 from sqlalchemy.orm import Session
 
 from krrood.symbol_graph.symbol_graph import SymbolGraph
-from krrood.ormatic.dao import to_dao
+from krrood.ormatic.data_access_objects.helper import to_dao
 from krrood.ormatic.utils import drop_database, create_engine
 from krrood.utils import recursive_subclasses
 from semantic_digital_twin.world import World
@@ -119,7 +119,7 @@ def parse_fbx_file_to_world_mapping_daos(fbx_file_path: str) -> List[WorldMappin
         resolved = resolver.resolve(world.name)
         if resolved:
             with world.modify_world():
-                world.add_semantic_annotation(resolved(body=world.root))
+                world.add_semantic_annotation(resolved(root=world.root))
 
     return [to_dao(world) for world in worlds]
 


### PR DESCRIPTION
Both scripts in `semantic_digital_twin/scripts/` are unrunnable as shipped on `main`, and the persistence example hands readers a connection URI that cannot connect. I hit all three while standing up a shared, precomputed world database, where the ProcTHOR import is the first step.

## Three bugs

**1. `krrood.ormatic.dao` no longer exists.**

`to_dao` now lives in `krrood.ormatic.data_access_objects.helper`. Both `parse_procthor_files_and_save_to_database.py` and `fetch_and_safe_to_db.py` still import the old path and die before doing any work:

```
ModuleNotFoundError: No module named 'krrood.ormatic.dao'
```

**2. The semantic annotation is constructed with the wrong keyword.**

With the import fixed, `parse_procthor_files_and_save_to_database.py` then fails on *every* FBX file. It calls `resolved(body=world.root)`, but `HasRootBody` subclasses take a `kw_only` field named `root` — see `HasRootKinematicStructureEntity.root` in `semantic_annotations/mixins.py`, and the `Table(root=...)` example in `examples/persistence_of_annotated_worlds.md`.

```
TypeError: Dresser.__init__() got an unexpected keyword argument 'body'
TypeError: PartNetChairLeg.__init__() got an unexpected keyword argument 'body'
TypeError: SoapBottle.__init__() got an unexpected keyword argument 'body'
```

Because the failure is per-file inside the loop, the script still exits 0 having stored nothing — which is how this stayed quiet.

**3. The documented connection URI selects a driver that is not installed.**

`examples/persistence_of_annotated_worlds.md` tells readers to export a bare `postgresql://…` URI. SQLAlchemy maps that scheme to psycopg2, but `semantic_digital_twin/requirements.txt` pins `psycopg` (v3) and psycopg2 appears nowhere in the repo, so following the tutorial verbatim fails at connect time:

```
ModuleNotFoundError: No module named 'psycopg2'
```

Fixed to `postgresql+psycopg://…`, with a short note on why — the error names psycopg2 and gives no hint that the URI *scheme* is the problem.

## Verification

Run against a checkout of the AI2-THOR asset tree (`131` `*_grp.fbx` files after the script's own exclusion list).

Before: 0 of 131 files parsed — every one raised `TypeError`.

After:

| file | worlds |
|---|---|
| `dressers_grp.fbx` | 18 |
| `chairs_grp.fbx` | 19 |
| `soap_bottles_grp.fbx` | 30 |

Names come out as expected for the stage-2 lookup (`dresser_205`, `chair_1`, `soap_bottle_1`, …).

The corrected URI is what the resulting `WorldMappingDAO`s were round-tripped through: stored to PostgreSQL 17, re-queried in a fresh session, and reconstructed with an unchanged body count. The bare `postgresql://` form was confirmed to fail against the same server.

## Notes

Draft because I have not added a regression test. These are scripts rather than library code and nothing under `test/` covers them today, so I would like a steer on whether you want a smoke test here (and where it belongs) before I add one.
