### PR TITLE
fix CartesianPositionStraight

### DIFF
--- a/giskardpy/src/giskardpy/motion_statechart/tasks/cartesian_tasks.py
+++ b/giskardpy/src/giskardpy/motion_statechart/tasks/cartesian_tasks.py
@@ -39,7 +39,6 @@ from krrood.symbolic_math.symbolic_math import (
 )
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.spatial_types import (
-    Vector3,
     Point3,
     RotationMatrix,
     HomogeneousTransformationMatrix,
@@ -482,94 +481,96 @@ class CartesianPositionStraight(CartesianTask):
     threshold: float = field(default=0.01, kw_only=True)
     """Distance threshold for goal achievement in meters."""
 
+    _line_start_binding: ForwardKinematicsBinding = field(init=False)
+    """Binding for the tip pose the line starts at."""
+
+    LATERAL_WEIGHT_FACTOR: ClassVar[float] = 2
+    """How much more expensive leaving the line is than falling behind on it."""
+
     @property
     def goal_reference_frame(self) -> KinematicStructureEntity:
         return self.goal_point.reference_frame
+
+    def build(self, context: MotionStatechartContext) -> NodeArtifacts:
+        """
+        Bind the pose the line starts at before the constraints are described against it.
+        """
+        self._line_start_binding = ForwardKinematicsBinding(
+            name=PrefixedName("root_T_line_start", str(self.name)),
+            root=self.root_link,
+            tip=self.tip_link,
+            float_variable_data=context.float_variable_data,
+        )
+        self._line_start_binding.bind(context.world)
+        return super().build(context)
+
+    def on_start(self, context: MotionStatechartContext) -> None:
+        """
+        Start the line at the pose the tip has now.
+
+        A line starts where the tip is when the motion begins, no matter how much earlier
+        the statechart was built, and independently of :attr:`binding_policy`, which only
+        decides when the goal is computed.
+        """
+        super().on_start(context)
+        self._line_start_binding.bind(context.world)
 
     def build_artifacts(self, context: MotionStatechartContext) -> NodeArtifacts:
         """
         Build motion constraints for reaching the goal along a straight line.
 
-        Creates a virtual coordinate frame aligned with the straight-line path and
-        constrains motion to stay on that line.
+        The tip is driven along the line from the pose the motion starts at to the goal,
+        and back onto that line whenever it strays.
 
         :param context: Provides access to world model and kinematic expressions.
         :return: The artifacts of this task, whose error is the distance between the tip and the goal point.
         """
         artifacts = NodeArtifacts()
         root_P_goal = self.root_T_goal_reference_frame @ self.goal_point
-
-        # Get current tip position and transformations
+        root_P_line_start = self._line_start_binding.root_T_tip.to_position()
         root_P_tip = context.world.compose_forward_kinematics_expression(
             self.root_link, self.tip_link
         ).to_position()
-        tip_T_root = context.world.compose_forward_kinematics_expression(
-            self.tip_link, self.root_link
-        )
-        tip_P_goal = tip_T_root.dot(root_P_goal)
 
-        # Create coordinate frame aligned with straight-line path
-        # x-axis points from current position towards goal
-        tip_V_error = Vector3.from_iterable(tip_P_goal)
-        trans_error = tip_V_error.norm()
-        tip_V_intermediate_error = tip_V_error.safe_division(trans_error)
+        root_V_line = root_P_goal - root_P_line_start
+        # scale normalizes in place, so the length has to be read before it
+        line_length = root_V_line.norm()
+        root_V_line.scale(1)
+        root_R_line = RotationMatrix.from_x_axis(root_V_line)
+        line_V_travelled = root_R_line.inverse() @ (root_P_tip - root_P_line_start)
 
-        # Create orthogonal y and z axes. Crossing the path direction with a world axis degenerates
-        # when the two are parallel, so deterministically pick whichever of the X/Y axes yields the
-        # better-conditioned (longer) cross product instead of sampling a random helper vector.
-        tip_V_cross_x = tip_V_intermediate_error.cross(Vector3.X())
-        tip_V_cross_y = tip_V_intermediate_error.cross(Vector3.Y())
-        tip_V_helper = Vector3.from_iterable(
-            [
-                sm.if_greater(
-                    tip_V_cross_x.norm(),
-                    tip_V_cross_y.norm(),
-                    tip_V_cross_x[i],
-                    tip_V_cross_y[i],
-                )
-                for i in range(3)
-            ]
+        lateral_weight = (
+            DefaultWeights.WEIGHT_ABOVE_COLLISION_AVOIDANCE * self.LATERAL_WEIGHT_FACTOR
         )
-        y = tip_V_intermediate_error.cross(tip_V_helper)
-        z = tip_V_intermediate_error.cross(y)
-        tip_R_aligned = RotationMatrix.from_vectors(
-            x=tip_V_intermediate_error, y=-z, z=y
+        artifacts.geometry.add_position_constraint(
+            expression_current=line_V_travelled[0],
+            expression_goal=line_length,
+            reference_velocity=self.reference_velocity,
+            quadratic_weight=DefaultWeights.WEIGHT_ABOVE_COLLISION_AVOIDANCE,
+            name="line/progress",
         )
-
-        # Transform tip kinematics into aligned frame
-        tip_T_root_evaluated = context.world.compute_forward_kinematics(
-            self.tip_link, self.root_link
+        artifacts.geometry.add_position_constraint(
+            expression_current=line_V_travelled[1],
+            expression_goal=0,
+            reference_velocity=self.reference_velocity,
+            quadratic_weight=lateral_weight,
+            name="line/y",
         )
-        root_T_tip = context.world.compose_forward_kinematics_expression(
-            self.root_link, self.tip_link
+        artifacts.geometry.add_position_constraint(
+            expression_current=line_V_travelled[2],
+            expression_goal=0,
+            reference_velocity=self.reference_velocity,
+            quadratic_weight=lateral_weight,
+            name="line/z",
         )
-        aligned_T_tip = tip_R_aligned.inverse() @ tip_T_root_evaluated @ root_T_tip
-
-        expr_p = aligned_T_tip.to_position()
-        dist = (root_P_goal - root_P_tip).norm()
-
-        # Constrain motion: x-axis moves towards goal, y and z stay at zero
-        for i, (name, bound, weight_mult) in enumerate(
-            [
-                ("line/x", dist, 1),
-                ("line/y", 0, 2),
-                ("line/z", 0, 2),
-            ]
-        ):
-            artifacts.constraints.add_equality_constraint(
-                name=name,
-                reference_velocity=self.reference_velocity,
-                equality_bound=bound,
-                quadratic_weight=DefaultWeights.WEIGHT_ABOVE_COLLISION_AVOIDANCE
-                * weight_mult,
-                task_expression=expr_p[i],
-            )
 
         self.add_goal_and_current_debug_expressions(
             artifacts, goal=root_P_goal, current=root_P_tip
         )
 
-        artifacts.error = SymbolicErrorSignal(dist)
+        artifacts.error = SymbolicErrorSignal(
+            root_P_goal.euclidean_distance(root_P_tip)
+        )
         return artifacts
 
 

--- a/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
@@ -788,6 +788,35 @@ class RotationMatrix(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
         return R
 
     @classmethod
+    def from_x_axis(
+        cls,
+        x: Vector3,
+        reference_frame: Optional[KinematicStructureEntity] = None,
+    ) -> RotationMatrix:
+        """
+        Create a rotation matrix from the direction its x-axis points along.
+
+        The y- and z-axis only complete the frame and are otherwise arbitrary.
+        """
+        # Crossing a direction with a world axis degenerates when the two are parallel, so
+        # pick whichever of the X/Y axes yields the better-conditioned (longer) cross
+        # product.
+        frame_V_cross_x = x.cross(Vector3.X())
+        frame_V_cross_y = x.cross(Vector3.Y())
+        y = Vector3.from_iterable(
+            [
+                sm.if_greater(
+                    frame_V_cross_x.norm(),
+                    frame_V_cross_y.norm(),
+                    frame_V_cross_x[i],
+                    frame_V_cross_y[i],
+                )
+                for i in range(3)
+            ]
+        )
+        return cls.from_vectors(x=x, y=y, reference_frame=reference_frame)
+
+    @classmethod
     def from_rpy(
         cls,
         roll: Optional[sm.ScalarData] = None,

--- a/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
@@ -797,6 +797,10 @@ class RotationMatrix(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
         Create a rotation matrix from the direction its x-axis points along.
 
         The y- and z-axis only complete the frame and are otherwise arbitrary.
+
+        :param x: the direction the x-axis should point along
+        :param reference_frame: the frame the resulting rotation matrix is expressed in
+        :return: a rotation matrix whose x-axis points along ``x``
         """
         # Crossing a direction with a world axis degenerates when the two are parallel, so
         # pick whichever of the X/Y axes yields the better-conditioned (longer) cross

--- a/test/giskardpy_test/test_motion_statechart/test_cartesian_tasks.py
+++ b/test/giskardpy_test/test_motion_statechart/test_cartesian_tasks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 import pytest
 
@@ -9,6 +11,7 @@ from giskardpy.motion_statechart.context import MotionStatechartContext
 from giskardpy.motion_statechart.data_types import (
     ObservationStateValues,
     DefaultWeights,
+    LifeCycleValues,
 )
 from giskardpy.motion_statechart.goals.cartesian_goals import (
     DifferentialDriveBaseGoal,
@@ -18,6 +21,7 @@ from giskardpy.motion_statechart.goals.templates import Sequence, Parallel
 from giskardpy.motion_statechart.graph_node import (
     EndMotion,
     CancelMotion,
+    MotionStatechartNode,
 )
 from giskardpy.motion_statechart.monitors.overwrite_state_monitors import (
     SetSeedConfiguration,
@@ -74,6 +78,80 @@ from test.giskardpy_test.test_motion_statechart.debug_expression_helpers import 
     debug_expression_by_name,
 )
 from semantic_digital_twin.robots.pr2 import PR2Joint
+
+# %% straight line paths
+
+STRAIGHT_LINE_TOLERANCE = 0.02
+"""
+How far the tip may stray from the line it is supposed to travel along, in meters.
+
+Some deviation is unavoidable: the controller has to accelerate out of the pose the
+motion starts at, and it can only correct a lateral offset on the tick after it appeared.
+"""
+
+
+@dataclass
+class StraightLine:
+    """
+    The line a straight Cartesian motion is supposed to travel along.
+    """
+
+    start: np.ndarray
+    """Position the motion starts at."""
+
+    end: np.ndarray
+    """Position the motion ends at."""
+
+    def distance_from(self, position: np.ndarray) -> float:
+        """
+        :return: Distance between `position` and this line.
+        """
+        direction = self.end - self.start
+        direction = direction / np.linalg.norm(direction)
+        offset = position - self.start
+        return float(np.linalg.norm(offset - np.dot(offset, direction) * direction))
+
+    def maximum_distance_from(self, positions: list[np.ndarray]) -> float:
+        """
+        :return: Distance of the position that strayed furthest from this line.
+        """
+        return max(self.distance_from(position) for position in positions)
+
+
+def record_tip_path(
+    executor: Executor,
+    task: MotionStatechartNode,
+    root_link: KinematicStructureEntity,
+    tip_link: KinematicStructureEntity,
+    maximum_ticks: int = 2000,
+) -> list[np.ndarray]:
+    """
+    Tick until the motion ends and collect where the tip was while `task` was running.
+
+    The first entry is the position the tip had when `task` started, which is where a
+    straight motion is supposed to begin.
+
+    :raises TimeoutError: if the motion does not end within `maximum_ticks`.
+    """
+    world = executor.context.world
+    life_cycle_state = executor.motion_statechart.life_cycle_state
+
+    def tip_position() -> np.ndarray:
+        return world.compute_forward_kinematics_np(root_link, tip_link)[:3, 3].copy()
+
+    path = []
+    if life_cycle_state[task] == LifeCycleValues.RUNNING:
+        path.append(tip_position())
+    for _ in range(maximum_ticks):
+        position_before_tick = tip_position()
+        executor.tick()
+        if not path and life_cycle_state[task] == LifeCycleValues.RUNNING:
+            path.append(position_before_tick)
+        if path:
+            path.append(tip_position())
+        if executor.motion_statechart.is_end_motion():
+            return path
+    raise TimeoutError(f"{task.name} did not finish within {maximum_ticks} ticks")
 
 
 class TestCartesianPositionTrajectory:
@@ -1054,6 +1132,93 @@ class TestCartesianTasks:
         assert np.allclose(
             cart_straight.goal_pose.to_np(), goal_pose.to_np(), atol=0.015
         )
+
+    def test_straight_path_while_the_orientation_changes(
+        self, pr2_world_state_reset: World
+    ):
+        """
+        The tip must stay on the line to the goal while the very same goal rotates it.
+
+        The orientation half of :class:`CartesianPoseStraight` runs in parallel with the
+        position half, so a goal that also reorients the tip turns the tip frame while
+        the straight line motion is under way.
+        """
+        tip = pr2_world_state_reset.get_kinematic_structure_entity_by_name(
+            "r_gripper_tool_frame"
+        )
+        root = pr2_world_state_reset.get_kinematic_structure_entity_by_name(
+            "odom_combined"
+        )
+        start = pr2_world_state_reset.compute_forward_kinematics_np(root, tip)[:3, 3]
+        goal_pose = Pose.from_xyz_rpy(
+            x=start[0] + 0.3,
+            y=start[1],
+            z=start[2],
+            pitch=np.pi / 2,
+            reference_frame=root,
+        )
+
+        motion_statechart = MotionStatechart()
+        goal = CartesianPoseStraight(
+            root_link=root,
+            tip_link=tip,
+            goal_pose=goal_pose,
+        )
+        motion_statechart.add_node(goal)
+        motion_statechart.add_node(EndMotion.when_true(goal))
+
+        executor = Executor(MotionStatechartContext(world=pr2_world_state_reset))
+        executor.compile(motion_statechart=motion_statechart)
+        straight = next(
+            node for node in goal.nodes if isinstance(node, CartesianPositionStraight)
+        )
+        path = record_tip_path(executor, straight, root, tip)
+
+        line = StraightLine(start=path[0], end=goal_pose.to_np()[:3, 3])
+        assert line.maximum_distance_from(path) <= STRAIGHT_LINE_TOLERANCE
+
+    def test_straight_line_starts_where_the_task_starts(
+        self, pr2_world_state_reset: World
+    ):
+        """
+        The line must start at the pose the tip has when the task starts running, not at
+        the pose it had when the statechart was compiled.
+
+        Every node is built during compilation, while a task that waits for another one
+        starts after that motion has moved the tip somewhere else.
+        """
+        tip = pr2_world_state_reset.get_kinematic_structure_entity_by_name(
+            "r_gripper_tool_frame"
+        )
+        root = pr2_world_state_reset.get_kinematic_structure_entity_by_name(
+            "odom_combined"
+        )
+        start = pr2_world_state_reset.compute_forward_kinematics_np(root, tip)[:3, 3]
+        goal_point = Point3(start[0] + 0.2, start[1], start[2], reference_frame=root)
+
+        motion_statechart = MotionStatechart()
+        wrist_goal = JointPositionList(
+            goal_state=JointState.from_str_dict(
+                {PR2Joint.RIGHT_WRIST_FLEX: -np.pi / 2},
+                world=pr2_world_state_reset,
+            )
+        )
+        straight = CartesianPositionStraight(
+            root_link=root,
+            tip_link=tip,
+            goal_point=goal_point,
+        )
+        motion_statechart.add_nodes([wrist_goal, straight])
+        wrist_goal.end_condition = wrist_goal.observation_variable
+        straight.start_condition = wrist_goal.observation_variable
+        motion_statechart.add_node(EndMotion.when_true(straight))
+
+        executor = Executor(MotionStatechartContext(world=pr2_world_state_reset))
+        executor.compile(motion_statechart=motion_statechart)
+        path = record_tip_path(executor, straight, root, tip)
+
+        line = StraightLine(start=path[0], end=goal_point.to_np()[:3])
+        assert line.maximum_distance_from(path) <= STRAIGHT_LINE_TOLERANCE
 
     def test_soft_trunk_cartesian_position(self):
         """

--- a/test/semantic_digital_twin_test/test_spatial_types/test_spatial_types.py
+++ b/test/semantic_digital_twin_test/test_spatial_types/test_spatial_types.py
@@ -154,6 +154,33 @@ class TestRotationMatrix:
             RotationMatrix.from_vectors(x=x_unit, y=y_unit, z=z_unit), R_ref
         )
 
+    @pytest.mark.parametrize(
+        "direction",
+        [
+            np.array([1.0, 2, 3]),
+            np.array([1.0, 0, 0]),
+            np.array([0.0, 1, 0]),
+            np.array([0.0, 0, 1]),
+            np.array([1.0, 1, 0]),
+            np.array([0.0, 0, -5]),
+        ],
+    )
+    def test_from_x_axis(self, direction):
+        """
+        The x-axis of the result points along the given direction, whatever the
+        direction is, and the two axes completing the frame turn it into a proper
+        rotation matrix.
+        """
+        expected_x_axis = direction / np.linalg.norm(direction)
+
+        result = RotationMatrix.from_x_axis(Vector3.from_iterable(direction)).to_np()[
+            :3, :3
+        ]
+
+        assert np.allclose(result[:, 0], expected_x_axis)
+        assert np.allclose(result.T @ result, np.eye(3))
+        assert np.isclose(np.linalg.det(result), 1)
+
     @pytest.mark.parametrize("q", quaternions)
     def test_from_quaternion(self, q):
         actual = RotationMatrix.from_quaternion(Quaternion.from_iterable(q))


### PR DESCRIPTION
test(cartesian_tasks): add tests for straight-line motion constraints and improve artifacts logic

- Introduced `StraightLine` class and tests for validating straight-line motion during Cartesian tasks.
- Enhanced `CartesianPositionStraight` task with start pose binding and improved motion constraints logic.
- Added `RotationMatrix.from_x_axis` method and corresponding tests.