### PR TITLE
[KRROOD] Fix ORMatic mapping a tuple-valued many-to-many relationship

### DIFF
--- a/krrood/src/krrood/ormatic/data_access_objects/dao.py
+++ b/krrood/src/krrood/ormatic/data_access_objects/dao.py
@@ -465,6 +465,19 @@ def _get_set_field_names(clazz: Type) -> Tuple[str, ...]:
     )
 
 
+@lru_cache(maxsize=None)
+def _get_tuple_field_names(clazz: Type) -> Tuple[str, ...]:
+    """
+    :param clazz: The domain class to inspect.
+    :return: The names of all fields annotated as tuples.
+    """
+    return tuple(
+        attr_name
+        for attr_name, hint in _get_type_hints_cached(clazz).items()
+        if get_origin(hint) is tuple or hint is tuple
+    )
+
+
 class DataAccessObject(HasGeneric[T]):
     """
     Base class for Data Access Objects (DAOs) providing bidirectional conversion between
@@ -727,7 +740,14 @@ class DataAccessObject(HasGeneric[T]):
                     for item in source_collection
                 ]
 
-            setattr(self, relationship.key, type(source_collection)(dao_collection))
+            # The instrumented DAO attribute expects an iterable duck-typed as its own
+            # collection class; an immutable domain container (tuple) is held as a
+            # list at the ORM layer (see WrappedTable.create_many_to_many_relationship),
+            # so it must be assigned as one here too.
+            assignable_container_type = (
+                list if type(source_collection) is tuple else type(source_collection)
+            )
+            setattr(self, relationship.key, assignable_container_type(dao_collection))
 
     def _get_or_queue_dao(
         self,
@@ -918,13 +938,18 @@ class DataAccessObject(HasGeneric[T]):
     @staticmethod
     def _finalize_object_containers(domain_object: Any) -> None:
         """
-        Convert lists to sets based on type hints.
+        Convert lists to sets or tuples based on type hints.
         """
         for attr_name in _get_set_field_names(type(domain_object)):
             value = getattr(domain_object, attr_name, None)
             if isinstance(value, list):
                 # object.__setattr__ (not setattr) so this also works on frozen dataclasses.
                 object.__setattr__(domain_object, attr_name, set(value))
+        for attr_name in _get_tuple_field_names(type(domain_object)):
+            value = getattr(domain_object, attr_name, None)
+            if isinstance(value, list):
+                # object.__setattr__ (not setattr) so this also works on frozen dataclasses.
+                object.__setattr__(domain_object, attr_name, tuple(value))
 
     def _call_post_inits(
         self,

--- a/krrood/src/krrood/ormatic/wrapped_table.py
+++ b/krrood/src/krrood/ormatic/wrapped_table.py
@@ -791,11 +791,20 @@ class WrappedTable:
         # create a relationship
         rel_name = f"{wrapped_field.field.name}"
 
-        # Use the actual container type from the domain model (e.g., list)
-        container_name = module_and_class_name(wrapped_field.container_type)
+        # SQLAlchemy instruments a collection class in place (it needs an appender
+        # method), which an immutable domain container such as tuple cannot provide.
+        # The relationship is therefore held as a list at the ORM layer; from_dao
+        # restores the domain field's own tuple type once its object is populated
+        # (see DataAccessObject._finalize_object_containers).
+        collection_class_type = (
+            list
+            if wrapped_field.container_type is tuple
+            else wrapped_field.container_type
+        )
+        container_name = module_and_class_name(collection_class_type)
 
         # Association Object pattern
-        rel_type = f"Mapped[{module_and_class_name(wrapped_field.container_type)}[{association_table.name}]]"
+        rel_type = f"Mapped[{container_name}[{association_table.name}]]"
         rel_constructor = (
             f"relationship('{association_table.name}', "
             f"collection_class={container_name}, "

--- a/test/krrood_test/dataset/tuple_collection_classes.py
+++ b/test/krrood_test/dataset/tuple_collection_classes.py
@@ -1,0 +1,34 @@
+"""
+Classes used to verify that ORMatic can persist and reconstruct a ``tuple``-valued many-
+to-many relationship (a field typed as ``tuple[SomeMappedClass, ...]``).
+
+Kept in their own module so the generated interface can import them by name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TupleCollectionMember:
+    """
+    A flat value object referenced from a tuple-valued collection field.
+    """
+
+    label: str
+    """
+    The label of the member.
+    """
+
+
+@dataclass
+class TupleCollectionOwner:
+    """
+    An object whose collection of mapped members is a ``tuple`` rather than a ``list``.
+    """
+
+    members: tuple[TupleCollectionMember, ...]
+    """
+    The members of the owner, in a fixed order.
+    """

--- a/test/krrood_test/test_ormatic/test_tuple_collection_relationship.py
+++ b/test/krrood_test/test_ormatic/test_tuple_collection_relationship.py
@@ -1,0 +1,86 @@
+"""
+ORMatic-specific check that a many-to-many relationship declared as ``tuple[X, ...]``
+(rather than ``list[X]`` or ``Set[X]``) can be mapped and round-tripped.
+
+SQLAlchemy requires a collection class it can instrument in place (an appender method),
+which a ``tuple`` cannot provide, so the generated relationship must use an
+instrumentable collection at the ORM layer while still handing the domain object back
+its declared ``tuple``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from sqlalchemy import select
+from sqlalchemy.orm import configure_mappers, sessionmaker
+
+from krrood.class_diagrams.class_diagram import ClassDiagram
+from krrood.ormatic.data_access_objects.helper import to_dao
+from krrood.ormatic.helper import get_classes_of_ormatic_interface
+from krrood.ormatic.ormatic import ORMatic
+from krrood.ormatic.utils import create_engine
+from ..dataset.tuple_collection_classes import (
+    TupleCollectionMember,
+    TupleCollectionOwner,
+)
+
+
+def _generate_interface(tmp_path):
+    """
+    Generate and import an ORMatic SQLAlchemy interface for the tuple-collection
+    classes.
+    """
+    class_diagram = ClassDiagram([TupleCollectionOwner, TupleCollectionMember])
+    instance = ORMatic(class_diagram)
+    instance.make_all_tables()
+
+    interface_file = tmp_path / "tuple_collection_interface.py"
+    with open(interface_file, "w") as f:
+        instance.to_sqlalchemy_file(f)
+
+    spec = importlib.util.spec_from_file_location(
+        "tuple_collection_interface", interface_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ormatic_configures_a_tuple_valued_many_to_many_relationship(tmp_path):
+    """
+    Configuring the mappers of a ``tuple[X, ...]``-valued relationship must not raise,
+    since SQLAlchemy cannot instrument ``tuple`` itself as a collection class.
+    """
+    module = _generate_interface(tmp_path)
+    get_classes_of_ormatic_interface(module)
+
+    configure_mappers()
+
+
+def test_ormatic_round_trips_a_tuple_valued_many_to_many_relationship(tmp_path):
+    module = _generate_interface(tmp_path)
+    get_classes_of_ormatic_interface(module)
+    configure_mappers()
+
+    engine = create_engine("sqlite:///:memory:")
+    module.Base.metadata.create_all(engine)
+    session = sessionmaker(engine)()
+
+    original = TupleCollectionOwner(
+        members=(
+            TupleCollectionMember(label="a"),
+            TupleCollectionMember(label="b"),
+        )
+    )
+
+    dao = to_dao(original)
+    session.add(dao)
+    session.commit()
+
+    reconstructed = session.scalars(select(type(dao))).one().from_dao()
+
+    assert isinstance(reconstructed.members, tuple)
+    assert reconstructed == original


### PR DESCRIPTION
## Summary
- A dataclass field typed `tuple[SomeMappedClass, ...]` made ORMatic generate a SQLAlchemy relationship with `collection_class=tuple`. SQLAlchemy needs a collection class it can instrument in place (an appender method), which an immutable `tuple` can't provide, so `configure_mappers()` raised `ArgumentError: Type tuple must elect an appender method to be a collection class`. Since mapper configuration is global, this broke *any* query in the process, not just one touching the offending class.
- The relationship is now held as a `list` at the ORM layer instead (`wrapped_table.py::create_many_to_many_relationship`); the domain object gets its declared `tuple` back once `from_dao` finishes populating it, reusing the same list→container finalization step already in place for `set` fields (`dao.py::_finalize_object_containers`).
- `to_dao`'s collection assignment (`_fill_relationships_from_plan`) is adjusted the same way, since SQLAlchemy's collection assignment duck-types the incoming iterable against its own `collection_class` and rejects a bare tuple there too.

## Test plan
- [x] Added `test/krrood_test/dataset/tuple_collection_classes.py` (mimic dataclasses: one holding `tuple[Other, ...]`) and `test/krrood_test/test_ormatic/test_tuple_collection_relationship.py`, which reproduce the `ArgumentError` on `main` and pass with this fix.
- [x] Full `test/krrood_test/test_ormatic/` suite passes (134 tests).
- [x] Broader `test/krrood_test/` suite passes (2002 tests; a couple of pre-existing, unrelated collection errors aside).

Made with the help of Claude.