### PR TITLE
[MultiSim] Fix lost world→sim pose writes that made test_world_sim_state_sync flaky

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
@@ -2929,6 +2929,18 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         ``sync_rate_hz`` wall-clock Hz. The sibling state-change callback is
         paused across the write so our own ``notify_state_change`` does not
         echo back into :meth:`_on_state_change`.
+
+        The whole pull runs under ``World._world_lock``. ``WorldState`` takes
+        that lock per accessor, so holding it only for the individual writes
+        would let a writer thread land in the middle of this pull: the pose it
+        just wrote gets overwritten here with the pre-write qpos values, and
+        the notification that would have pushed that pose into MuJoCo is
+        swallowed by the ``pause()`` below. The write is then lost without a
+        trace, because the closing ``update_previous_world_state`` rebases the
+        diff baseline onto what this pull just wrote. ``_world_lock`` is the
+        outermost lock in the codebase -- ``modify_world`` takes it before the
+        simulator's ``_model_lock`` -- so acquiring it here preserves that
+        order.
         """
         if self.sync_rate_hz <= 0:
             return
@@ -2937,34 +2949,43 @@ class MujocoSynchronizer(MultiSimSynchronizer):
             return
         self._last_sync_time = now
 
-        changed = False
-        self._state_callback.pause()
+        with self._world._world_lock:
+            changed = False
+            self._state_callback.pause()
+            try:
+                # Read qpos under the model lock so the whole pull sees one
+                # coherent post-step state rather than a mixture of poses from
+                # either side of an ``mj_step`` running on another thread.
+                with self.simulator._model_lock:
+                    for connection in self._world.connections:
+                        if isinstance(connection, FixedConnection):
+                            continue
+                        qpos_adr = self._resolve_qpos_adr(connection)
+                        if qpos_adr is None:
+                            continue
 
-        for connection in self._world.connections:
-            if isinstance(connection, FixedConnection):
-                continue
-            qpos_adr = self._resolve_qpos_adr(connection)
-            if qpos_adr is None:
-                continue
+                        if isinstance(connection, Connection6DoF):
+                            self._read_6dof_from_qpos(connection, qpos_adr)
+                            changed = True
+                        elif isinstance(connection, ActiveConnection1DOF):
+                            self._read_1dof_from_qpos(connection, qpos_adr)
+                            changed = True
+                        else:
+                            logger.warning(
+                                "sim→world sync: unsupported connection type %s "
+                                "for joint %s; skipping",
+                                type(connection).__name__,
+                                connection.name.name,
+                            )
 
-            if isinstance(connection, Connection6DoF):
-                self._read_6dof_from_qpos(connection, qpos_adr)
-                changed = True
-            elif isinstance(connection, ActiveConnection1DOF):
-                self._read_1dof_from_qpos(connection, qpos_adr)
-                changed = True
-            else:
-                logger.warning(
-                    "sim→world sync: unsupported connection type %s for "
-                    "joint %s; skipping",
-                    type(connection).__name__,
-                    connection.name.name,
-                )
-
-        if changed:
-            self._world.notify_state_change()
-            self._state_callback.update_previous_world_state()
-        self._state_callback.resume()
+                if changed:
+                    self._world.notify_state_change()
+                    self._state_callback.update_previous_world_state()
+            finally:
+                # Always resume: a callback left paused by an exception would
+                # silently disable the world -> sim direction for the rest of
+                # the run.
+                self._state_callback.resume()
 
     def _write_6dof_to_qpos(
         self,
@@ -3036,51 +3057,67 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         Push ``world.state`` into ``_mj_data.qpos`` for every connection whose
         DoF values changed since the last notification. Only non-fixed
         connections that resolve to a MuJoCo joint are pushed.
+
+        Runs under ``World._world_lock`` so the diff against
+        ``previous_world_state_data`` and the qpos writes it produces cannot be
+        interleaved with :meth:`_sim_to_world` on the physics thread. Callers
+        that mutate ``world.state`` already hold the lock, and it is reentrant,
+        so this is free on that path.
         """
-        positions = self._world.state.positions
-        previous_positions = self._state_callback.previous_world_state_data
+        with self._world._world_lock:
+            positions = self._world.state.positions
+            previous_positions = self._state_callback.previous_world_state_data
 
-        if len(positions) != len(previous_positions):
-            # Model shape changed since the last notification (e.g. a spawn
-            # just added DoFs). The spawner already wrote the initial qpos
-            # for the new entities; just rebase the diff and return.
+            if len(positions) != len(previous_positions):
+                # Model shape changed since the last notification (e.g. a spawn
+                # just added DoFs). The spawner already wrote the initial qpos
+                # for the new entities; just rebase the diff and return.
+                self._state_callback.update_previous_world_state()
+                return
+
+            state_index = self._world.state._index
+
+            # ``_model_lock`` is what serialises access to ``_mj_data`` against
+            # the physics thread. Writing qpos without it is not just a torn
+            # read: the model integrates with RK4, and ``mj_step`` writes the
+            # integrated qpos back from state it saved at the top of the step,
+            # so a write that lands mid-step is overwritten and vanishes. The
+            # body then simply carries on from its old pose, with nothing
+            # raised anywhere. Acquired inside ``_world_lock`` to match the
+            # order ``modify_world`` already establishes.
+            with self.simulator._model_lock:
+                for connection in self._world.connections:
+                    if isinstance(connection, FixedConnection):
+                        continue
+                    qpos_adr = self._resolve_qpos_adr(connection)
+                    if qpos_adr is None:
+                        continue
+
+                    if isinstance(connection, Connection6DoF):
+                        self._write_6dof_to_qpos(
+                            connection,
+                            qpos_adr,
+                            positions,
+                            previous_positions,
+                            state_index,
+                        )
+                    elif isinstance(connection, ActiveConnection1DOF):
+                        self._write_1dof_to_qpos(
+                            connection,
+                            qpos_adr,
+                            positions,
+                            previous_positions,
+                            state_index,
+                        )
+                    else:
+                        logger.warning(
+                            "world→sim sync: unsupported connection type %s for "
+                            "joint %s; skipping",
+                            type(connection).__name__,
+                            connection.name.name,
+                        )
+
             self._state_callback.update_previous_world_state()
-            return
-
-        state_index = self._world.state._index
-
-        for connection in self._world.connections:
-            if isinstance(connection, FixedConnection):
-                continue
-            qpos_adr = self._resolve_qpos_adr(connection)
-            if qpos_adr is None:
-                continue
-
-            if isinstance(connection, Connection6DoF):
-                self._write_6dof_to_qpos(
-                    connection,
-                    qpos_adr,
-                    positions,
-                    previous_positions,
-                    state_index,
-                )
-            elif isinstance(connection, ActiveConnection1DOF):
-                self._write_1dof_to_qpos(
-                    connection,
-                    qpos_adr,
-                    positions,
-                    previous_positions,
-                    state_index,
-                )
-            else:
-                logger.warning(
-                    "world→sim sync: unsupported connection type %s for "
-                    "joint %s; skipping",
-                    type(connection).__name__,
-                    connection.name.name,
-                )
-
-        self._state_callback.update_previous_world_state()
 
     def stop(self):
         if "read_data_from_simulator" in self.simulator.__dict__:

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
@@ -13,7 +13,16 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum
 from types import NoneType
-from typing_extensions import Dict, List, Any, ClassVar, Type, Optional, Union
+from typing_extensions import (
+    Dict,
+    List,
+    Any,
+    ClassVar,
+    Iterator,
+    Type,
+    Optional,
+    Union,
+)
 
 import numpy
 import mujoco
@@ -2883,6 +2892,101 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         quat_xyzw = Rotation.from_matrix(pose[:3, :3]).as_quat()
         return xyz, quat_xyzw
 
+    def _joint_backed_connections(self) -> Iterator[Tuple[Connection, int]]:
+        """
+        Yield every connection that a MuJoCo joint can be synced with, paired
+        with the qpos address of that joint.
+
+        Fixed connections carry no DoFs, and a connection that does not resolve
+        to a joint is not in the compiled model, so neither has anything to
+        sync. Both sync directions walk the same set, so they share this.
+        """
+        for connection in self._world.connections:
+            if isinstance(connection, FixedConnection):
+                continue
+            qpos_adr = self._resolve_qpos_adr(connection)
+            if qpos_adr is None:
+                continue
+            yield connection, qpos_adr
+
+    @staticmethod
+    def _warn_unsupported_connection(direction: str, connection: Connection) -> None:
+        """
+        Report a connection that has a MuJoCo joint but no sync implementation.
+        """
+        logger.warning(
+            "%s sync: unsupported connection type %s for joint %s; skipping",
+            direction,
+            type(connection).__name__,
+            connection.name.name,
+        )
+
+    def _read_connections_from_qpos(self) -> bool:
+        """
+        Copy ``_mj_data.qpos`` into ``world.state`` for every joint-backed
+        connection.
+
+        Held under ``_model_lock`` so the whole pull sees one coherent
+        post-step state rather than a mixture of poses from either side of an
+        ``mj_step`` running on the physics thread.
+
+        :return: Whether any connection was read.
+        """
+        changed = False
+        with self.simulator._model_lock:
+            for connection, qpos_adr in self._joint_backed_connections():
+                if isinstance(connection, Connection6DoF):
+                    self._read_6dof_from_qpos(connection, qpos_adr)
+                elif isinstance(connection, ActiveConnection1DOF):
+                    self._read_1dof_from_qpos(connection, qpos_adr)
+                else:
+                    self._warn_unsupported_connection("sim→world", connection)
+                    continue
+                changed = True
+        return changed
+
+    def _write_connections_to_qpos(
+        self, positions: numpy.ndarray, previous_positions: numpy.ndarray
+    ) -> None:
+        """
+        Push ``world.state`` into ``_mj_data.qpos`` for every joint-backed
+        connection whose DoF values differ from ``previous_positions``.
+
+        ``_model_lock`` is what serialises access to ``_mj_data`` against the
+        physics thread, and holding it here is not just about torn reads: the
+        model integrates with RK4, and ``mj_step`` writes the integrated qpos
+        back from state it saved at the top of the step, so a write that lands
+        mid-step is overwritten and vanishes. The body then simply carries on
+        from its old pose, with nothing raised anywhere. Acquired inside
+        ``_world_lock`` to match the order ``modify_world`` already
+        establishes.
+
+        :param positions: The current ``world.state`` positions.
+        :param previous_positions: The positions as of the last notification,
+            used to find what changed. Must be the same length as ``positions``.
+        """
+        state_index = self._world.state._index
+        with self.simulator._model_lock:
+            for connection, qpos_adr in self._joint_backed_connections():
+                if isinstance(connection, Connection6DoF):
+                    self._write_6dof_to_qpos(
+                        connection,
+                        qpos_adr,
+                        positions,
+                        previous_positions,
+                        state_index,
+                    )
+                elif isinstance(connection, ActiveConnection1DOF):
+                    self._write_1dof_to_qpos(
+                        connection,
+                        qpos_adr,
+                        positions,
+                        previous_positions,
+                        state_index,
+                    )
+                else:
+                    self._warn_unsupported_connection("world→sim", connection)
+
     def _read_6dof_from_qpos(self, connection: Connection6DoF, qpos_adr: int) -> None:
         """
         Copy a 6DoF MuJoCo free-joint qpos block into ``world.state`` for
@@ -2950,35 +3054,9 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         self._last_sync_time = now
 
         with self._world._world_lock:
-            changed = False
             self._state_callback.pause()
             try:
-                # Read qpos under the model lock so the whole pull sees one
-                # coherent post-step state rather than a mixture of poses from
-                # either side of an ``mj_step`` running on another thread.
-                with self.simulator._model_lock:
-                    for connection in self._world.connections:
-                        if isinstance(connection, FixedConnection):
-                            continue
-                        qpos_adr = self._resolve_qpos_adr(connection)
-                        if qpos_adr is None:
-                            continue
-
-                        if isinstance(connection, Connection6DoF):
-                            self._read_6dof_from_qpos(connection, qpos_adr)
-                            changed = True
-                        elif isinstance(connection, ActiveConnection1DOF):
-                            self._read_1dof_from_qpos(connection, qpos_adr)
-                            changed = True
-                        else:
-                            logger.warning(
-                                "sim→world sync: unsupported connection type %s "
-                                "for joint %s; skipping",
-                                type(connection).__name__,
-                                connection.name.name,
-                            )
-
-                if changed:
+                if self._read_connections_from_qpos():
                     self._world.notify_state_change()
                     self._state_callback.update_previous_world_state()
             finally:
@@ -3075,48 +3153,7 @@ class MujocoSynchronizer(MultiSimSynchronizer):
                 self._state_callback.update_previous_world_state()
                 return
 
-            state_index = self._world.state._index
-
-            # ``_model_lock`` is what serialises access to ``_mj_data`` against
-            # the physics thread. Writing qpos without it is not just a torn
-            # read: the model integrates with RK4, and ``mj_step`` writes the
-            # integrated qpos back from state it saved at the top of the step,
-            # so a write that lands mid-step is overwritten and vanishes. The
-            # body then simply carries on from its old pose, with nothing
-            # raised anywhere. Acquired inside ``_world_lock`` to match the
-            # order ``modify_world`` already establishes.
-            with self.simulator._model_lock:
-                for connection in self._world.connections:
-                    if isinstance(connection, FixedConnection):
-                        continue
-                    qpos_adr = self._resolve_qpos_adr(connection)
-                    if qpos_adr is None:
-                        continue
-
-                    if isinstance(connection, Connection6DoF):
-                        self._write_6dof_to_qpos(
-                            connection,
-                            qpos_adr,
-                            positions,
-                            previous_positions,
-                            state_index,
-                        )
-                    elif isinstance(connection, ActiveConnection1DOF):
-                        self._write_1dof_to_qpos(
-                            connection,
-                            qpos_adr,
-                            positions,
-                            previous_positions,
-                            state_index,
-                        )
-                    else:
-                        logger.warning(
-                            "world→sim sync: unsupported connection type %s for "
-                            "joint %s; skipping",
-                            type(connection).__name__,
-                            connection.name.name,
-                        )
-
+            self._write_connections_to_qpos(positions, previous_positions)
             self._state_callback.update_previous_world_state()
 
     def stop(self):

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
@@ -2818,6 +2818,27 @@ class MultiSimSynchronizer(ModelChangeCallback, ABC):
         raise NotImplementedError
 
 
+@dataclass
+class JointBackedConnection:
+    """
+    A connection paired with the MuJoCo joint that backs it.
+
+    Resolving a connection to its joint costs a name lookup, so the two sync
+    directions carry the resolved address alongside the connection rather than
+    each looking it up again.
+    """
+
+    connection: Connection
+    """
+    The connection in the world.
+    """
+
+    qpos_address: int
+    """
+    Index at which this joint's values start in ``_mj_data.qpos``.
+    """
+
+
 @dataclass(eq=False)
 class MujocoSynchronizer(MultiSimSynchronizer):
     simulator: MujocoSimulator
@@ -2892,7 +2913,7 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         quat_xyzw = Rotation.from_matrix(pose[:3, :3]).as_quat()
         return xyz, quat_xyzw
 
-    def _joint_backed_connections(self) -> Iterator[Tuple[Connection, int]]:
+    def _joint_backed_connections(self) -> Iterator[JointBackedConnection]:
         """
         Yield every connection that a MuJoCo joint can be synced with, paired
         with the qpos address of that joint.
@@ -2907,12 +2928,17 @@ class MujocoSynchronizer(MultiSimSynchronizer):
             qpos_address = self._resolve_qpos_address(connection)
             if qpos_address is None:
                 continue
-            yield connection, qpos_address
+            yield JointBackedConnection(
+                connection=connection, qpos_address=qpos_address
+            )
 
     @staticmethod
     def _warn_unsupported_connection(direction: str, connection: Connection) -> None:
         """
         Report a connection that has a MuJoCo joint but no sync implementation.
+
+        :param direction: Which way the sync was going, for the message.
+        :param connection: The connection that could not be synced.
         """
         logger.warning(
             "%s sync: unsupported connection type %s for joint %s; skipping",
@@ -2934,15 +2960,21 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         """
         changed = False
         with self.simulator._model_lock:
-            for connection, qpos_address in self._joint_backed_connections():
-                if isinstance(connection, Connection6DoF):
-                    self._read_6dof_from_qpos(connection, qpos_address)
-                elif isinstance(connection, ActiveConnection1DOF):
-                    self._read_1dof_from_qpos(connection, qpos_address)
-                else:
-                    self._warn_unsupported_connection("sim→world", connection)
-                    continue
-                changed = True
+            for joint_backed in self._joint_backed_connections():
+                connection = joint_backed.connection
+                match connection:
+                    case Connection6DoF():
+                        self._read_6dof_from_qpos(
+                            connection, joint_backed.qpos_address
+                        )
+                        changed = True
+                    case ActiveConnection1DOF():
+                        self._read_1dof_from_qpos(
+                            connection, joint_backed.qpos_address
+                        )
+                        changed = True
+                    case _:
+                        self._warn_unsupported_connection("sim→world", connection)
         return changed
 
     def _write_connections_to_qpos(
@@ -2967,30 +2999,35 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         """
         state_index = self._world.state._index
         with self.simulator._model_lock:
-            for connection, qpos_address in self._joint_backed_connections():
-                if isinstance(connection, Connection6DoF):
-                    self._write_6dof_to_qpos(
-                        connection,
-                        qpos_address,
-                        positions,
-                        previous_positions,
-                        state_index,
-                    )
-                elif isinstance(connection, ActiveConnection1DOF):
-                    self._write_1dof_to_qpos(
-                        connection,
-                        qpos_address,
-                        positions,
-                        previous_positions,
-                        state_index,
-                    )
-                else:
-                    self._warn_unsupported_connection("world→sim", connection)
+            for joint_backed in self._joint_backed_connections():
+                connection = joint_backed.connection
+                match connection:
+                    case Connection6DoF():
+                        self._write_6dof_to_qpos(
+                            connection,
+                            joint_backed.qpos_address,
+                            positions,
+                            previous_positions,
+                            state_index,
+                        )
+                    case ActiveConnection1DOF():
+                        self._write_1dof_to_qpos(
+                            connection,
+                            joint_backed.qpos_address,
+                            positions,
+                            previous_positions,
+                            state_index,
+                        )
+                    case _:
+                        self._warn_unsupported_connection("world→sim", connection)
 
     def _read_6dof_from_qpos(self, connection: Connection6DoF, qpos_address: int) -> None:
         """
         Copy a 6DoF MuJoCo free-joint qpos block into ``world.state`` for
         ``connection``.
+
+        :param connection: The 6DoF connection whose DoFs are written.
+        :param qpos_address: Index of the free joint's 7-value qpos block.
         """
         mj_data = self.simulator._mj_data
         state = self._world.state
@@ -3019,6 +3056,9 @@ class MujocoSynchronizer(MultiSimSynchronizer):
     ) -> None:
         """
         Copy a single MuJoCo qpos slot into ``world.state`` for ``connection``.
+
+        :param connection: The 1DoF connection whose DoF is written.
+        :param qpos_address: Index of the joint's single qpos slot.
         """
         self._world.state[connection.raw_dof.id].position = float(
             self.simulator._mj_data.qpos[qpos_address]
@@ -3077,6 +3117,13 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         Push the 6DoF world state for ``connection`` into the MuJoCo qpos
         block at ``qpos_address``. No-op if the DoF values match the previous
         snapshot within tolerance.
+
+        :param connection: The 6DoF connection whose pose is pushed.
+        :param qpos_address: Index of the free joint's 7-value qpos block.
+        :param positions: The current ``world.state`` positions.
+        :param previous_positions: The positions as of the last notification,
+            compared against ``positions`` to decide whether to write.
+        :param state_index: Maps a DoF id to its column in those two arrays.
         """
         ix = state_index[connection.x.id]
         iy = state_index[connection.y.id]
@@ -3124,6 +3171,13 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         """
         Push the 1DoF world state for ``connection`` into the MuJoCo qpos slot
         at ``qpos_address``. No-op if the DoF value is unchanged.
+
+        :param connection: The 1DoF connection whose value is pushed.
+        :param qpos_address: Index of the joint's single qpos slot.
+        :param positions: The current ``world.state`` positions.
+        :param previous_positions: The positions as of the last notification,
+            compared against ``positions`` to decide whether to write.
+        :param state_index: Maps a DoF id to its column in those two arrays.
         """
         idx = state_index[connection.raw_dof.id]
         if positions[idx] == previous_positions[idx]:

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/multi_sim.py
@@ -2855,7 +2855,7 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         super().__post_init__()
         self.simulator.read_data_from_simulator = self._sim_to_world
 
-    def _resolve_qpos_adr(self, connection: Connection) -> Optional[int]:
+    def _resolve_qpos_address(self, connection: Connection) -> Optional[int]:
         """
         Resolve the qpos address for the MuJoCo joint backing ``connection``,
         or ``None`` if the joint is not present in the model.
@@ -2904,10 +2904,10 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         for connection in self._world.connections:
             if isinstance(connection, FixedConnection):
                 continue
-            qpos_adr = self._resolve_qpos_adr(connection)
-            if qpos_adr is None:
+            qpos_address = self._resolve_qpos_address(connection)
+            if qpos_address is None:
                 continue
-            yield connection, qpos_adr
+            yield connection, qpos_address
 
     @staticmethod
     def _warn_unsupported_connection(direction: str, connection: Connection) -> None:
@@ -2934,11 +2934,11 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         """
         changed = False
         with self.simulator._model_lock:
-            for connection, qpos_adr in self._joint_backed_connections():
+            for connection, qpos_address in self._joint_backed_connections():
                 if isinstance(connection, Connection6DoF):
-                    self._read_6dof_from_qpos(connection, qpos_adr)
+                    self._read_6dof_from_qpos(connection, qpos_address)
                 elif isinstance(connection, ActiveConnection1DOF):
-                    self._read_1dof_from_qpos(connection, qpos_adr)
+                    self._read_1dof_from_qpos(connection, qpos_address)
                 else:
                     self._warn_unsupported_connection("sim→world", connection)
                     continue
@@ -2967,11 +2967,11 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         """
         state_index = self._world.state._index
         with self.simulator._model_lock:
-            for connection, qpos_adr in self._joint_backed_connections():
+            for connection, qpos_address in self._joint_backed_connections():
                 if isinstance(connection, Connection6DoF):
                     self._write_6dof_to_qpos(
                         connection,
-                        qpos_adr,
+                        qpos_address,
                         positions,
                         previous_positions,
                         state_index,
@@ -2979,7 +2979,7 @@ class MujocoSynchronizer(MultiSimSynchronizer):
                 elif isinstance(connection, ActiveConnection1DOF):
                     self._write_1dof_to_qpos(
                         connection,
-                        qpos_adr,
+                        qpos_address,
                         positions,
                         previous_positions,
                         state_index,
@@ -2987,7 +2987,7 @@ class MujocoSynchronizer(MultiSimSynchronizer):
                 else:
                     self._warn_unsupported_connection("world→sim", connection)
 
-    def _read_6dof_from_qpos(self, connection: Connection6DoF, qpos_adr: int) -> None:
+    def _read_6dof_from_qpos(self, connection: Connection6DoF, qpos_address: int) -> None:
         """
         Copy a 6DoF MuJoCo free-joint qpos block into ``world.state`` for
         ``connection``.
@@ -2995,8 +2995,8 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         mj_data = self.simulator._mj_data
         state = self._world.state
 
-        xyz = mj_data.qpos[qpos_adr : qpos_adr + 3]
-        qwxyz = mj_data.qpos[qpos_adr + 3 : qpos_adr + 7]
+        xyz = mj_data.qpos[qpos_address : qpos_address + 3]
+        qwxyz = mj_data.qpos[qpos_address + 3 : qpos_address + 7]
 
         mj_T_world = self._make_pose_matrix(
             xyz,
@@ -3015,13 +3015,13 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         state[connection.qz.id].position = float(dof_quat_xyzw[2])
 
     def _read_1dof_from_qpos(
-        self, connection: ActiveConnection1DOF, qpos_adr: int
+        self, connection: ActiveConnection1DOF, qpos_address: int
     ) -> None:
         """
         Copy a single MuJoCo qpos slot into ``world.state`` for ``connection``.
         """
         self._world.state[connection.raw_dof.id].position = float(
-            self.simulator._mj_data.qpos[qpos_adr]
+            self.simulator._mj_data.qpos[qpos_address]
         )
 
     def _sim_to_world(self) -> None:
@@ -3068,14 +3068,14 @@ class MujocoSynchronizer(MultiSimSynchronizer):
     def _write_6dof_to_qpos(
         self,
         connection: Connection6DoF,
-        qpos_adr: int,
+        qpos_address: int,
         positions: numpy.ndarray,
         previous_positions: numpy.ndarray,
         state_index: Dict[Any, int],
     ) -> None:
         """
         Push the 6DoF world state for ``connection`` into the MuJoCo qpos
-        block at ``qpos_adr``. No-op if the DoF values match the previous
+        block at ``qpos_address``. No-op if the DoF values match the previous
         snapshot within tolerance.
         """
         ix = state_index[connection.x.id]
@@ -3105,30 +3105,30 @@ class MujocoSynchronizer(MultiSimSynchronizer):
         mj_xyz, mj_quat_xyzw = self._decompose_pose_matrix(parent_T_conn @ conn_T_child)
 
         mj_data = self.simulator._mj_data
-        mj_data.qpos[qpos_adr + 0] = mj_xyz[0]
-        mj_data.qpos[qpos_adr + 1] = mj_xyz[1]
-        mj_data.qpos[qpos_adr + 2] = mj_xyz[2]
-        mj_data.qpos[qpos_adr + 3] = mj_quat_xyzw[3]
-        mj_data.qpos[qpos_adr + 4] = mj_quat_xyzw[0]
-        mj_data.qpos[qpos_adr + 5] = mj_quat_xyzw[1]
-        mj_data.qpos[qpos_adr + 6] = mj_quat_xyzw[2]
+        mj_data.qpos[qpos_address + 0] = mj_xyz[0]
+        mj_data.qpos[qpos_address + 1] = mj_xyz[1]
+        mj_data.qpos[qpos_address + 2] = mj_xyz[2]
+        mj_data.qpos[qpos_address + 3] = mj_quat_xyzw[3]
+        mj_data.qpos[qpos_address + 4] = mj_quat_xyzw[0]
+        mj_data.qpos[qpos_address + 5] = mj_quat_xyzw[1]
+        mj_data.qpos[qpos_address + 6] = mj_quat_xyzw[2]
 
     def _write_1dof_to_qpos(
         self,
         connection: ActiveConnection1DOF,
-        qpos_adr: int,
+        qpos_address: int,
         positions: numpy.ndarray,
         previous_positions: numpy.ndarray,
         state_index: Dict[Any, int],
     ) -> None:
         """
         Push the 1DoF world state for ``connection`` into the MuJoCo qpos slot
-        at ``qpos_adr``. No-op if the DoF value is unchanged.
+        at ``qpos_address``. No-op if the DoF value is unchanged.
         """
         idx = state_index[connection.raw_dof.id]
         if positions[idx] == previous_positions[idx]:
             return
-        self.simulator._mj_data.qpos[qpos_adr] = positions[idx]
+        self.simulator._mj_data.qpos[qpos_address] = positions[idx]
 
     def _on_state_change(self) -> None:
         """

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/connections.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/connections.py
@@ -734,6 +734,13 @@ class Connection6DoF(Connection):
         find the DOF state that makes the *resulting* origin equal ``transformation``,
         rather than writing ``transformation`` in as ``_kinematics`` directly.
 
+        The degree-of-freedom writes and the notification they trigger are held
+        together under ``World._world_lock``. They form one logical pose
+        change, and an observer that reads or writes the state between them --
+        such as a running physics simulator syncing its own values back into
+        the world -- would otherwise see, and be able to overwrite, a pose that
+        is only half applied.
+
         :param transformation: The desired parent-to-child origin. Must carry a
             reference frame (:meth:`World.transform` raises
             :class:`~semantic_digital_twin.exceptions.MissingReferenceFrameError`
@@ -749,14 +756,15 @@ class Connection6DoF(Connection):
         )
         position = local_kinematics.to_position()
         orientation = local_kinematics.to_rotation_matrix().to_quaternion()
-        self._world.state[self.x.id].position = position[0]
-        self._world.state[self.y.id].position = position[1]
-        self._world.state[self.z.id].position = position[2]
-        self._world.state[self.qx.id].position = orientation[0]
-        self._world.state[self.qy.id].position = orientation[1]
-        self._world.state[self.qz.id].position = orientation[2]
-        self._world.state[self.qw.id].position = orientation[3]
-        self._world.notify_state_change()
+        with self._world._world_lock:
+            self._world.state[self.x.id].position = position[0]
+            self._world.state[self.y.id].position = position[1]
+            self._world.state[self.z.id].position = position[2]
+            self._world.state[self.qx.id].position = orientation[0]
+            self._world.state[self.qy.id].position = orientation[1]
+            self._world.state[self.qz.id].position = orientation[2]
+            self._world.state[self.qw.id].position = orientation[3]
+            self._world.notify_state_change()
 
     def copy_for_world(self, world: World) -> Connection6DoF:
         """
@@ -1041,16 +1049,25 @@ class OmniDrive(WheeledDrive):
         Overwrites the origin of the connection.
 
         .. warning:: Ignores z position, pitch, and yaw values.
+
+        The degree-of-freedom writes and the notification they trigger are held
+        together under ``World._world_lock``. They form one logical pose
+        change, and an observer that reads or writes the state between them --
+        such as a running physics simulator syncing its own values back into
+        the world -- would otherwise see, and be able to overwrite, a pose that
+        is only half applied.
+
         :param parent_T_child:
         """
         if isinstance(transformation, np.ndarray):
             transformation = HomogeneousTransformationMatrix(data=transformation)
         position = transformation.to_position()
         roll, pitch, yaw = transformation.to_rotation_matrix().to_rpy()
-        self._world.state[self.x.id].position = position.x
-        self._world.state[self.y.id].position = position.y
-        self._world.state[self.yaw.id].position = yaw
-        self._world.notify_state_change()
+        with self._world._world_lock:
+            self._world.state[self.x.id].position = position.x
+            self._world.state[self.y.id].position = position.y
+            self._world.state[self.yaw.id].position = yaw
+            self._world.notify_state_change()
 
     def get_free_variable_names(self) -> list[UUID]:
         return [self.x.id, self.y.id, self.yaw.id]
@@ -1303,16 +1320,25 @@ class DifferentialDrive(WheeledDrive):
         Overwrites the origin of the connection.
 
         .. warning:: Ignores z position, pitch, and yaw values.
+
+        The degree-of-freedom writes and the notification they trigger are held
+        together under ``World._world_lock``. They form one logical pose
+        change, and an observer that reads or writes the state between them --
+        such as a running physics simulator syncing its own values back into
+        the world -- would otherwise see, and be able to overwrite, a pose that
+        is only half applied.
+
         :param parent_T_child:
         """
         if isinstance(transformation, np.ndarray):
             transformation = HomogeneousTransformationMatrix(data=transformation)
         position = transformation.to_position()
         roll, pitch, yaw = transformation.to_rotation_matrix().to_rpy()
-        self._world.state[self.x.id].position = position.x
-        self._world.state[self.y.id].position = position.y
-        self._world.state[self.yaw.id].position = yaw
-        self._world.notify_state_change()
+        with self._world._world_lock:
+            self._world.state[self.x.id].position = position.x
+            self._world.state[self.y.id].position = position.y
+            self._world.state[self.yaw.id].position = yaw
+            self._world.notify_state_change()
 
     def get_free_variable_names(self) -> list[UUID]:
         return [self.x.id, self.y.id, self.yaw.id]

--- a/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
@@ -2,6 +2,7 @@ import logging
 import os
 import threading
 import time
+from dataclasses import dataclass
 
 import mujoco
 import pytest
@@ -852,10 +853,35 @@ def test_world_sim_state_sync():
         stop_multisim_if_running(multi_sim)
 
 
-def _build_box_on_plane_world() -> tuple[World, Body, Connection6DoF]:
+@dataclass
+class BoxOnPlaneWorld:
     """
-    A ground plane plus a single free-floating box, authored directly into a
-    :class:`World` so a simulator can be built from it without spawning.
+    A world holding a ground plane and one free-floating box, together with the
+    pieces of it a test needs to address afterwards.
+    """
+
+    world: World
+    """
+    The world itself, ready for a simulator to be built from it.
+    """
+
+    box: Body
+    """
+    The free-floating box, used as the reference frame for poses written to it.
+    """
+
+    box_connection: Connection6DoF
+    """
+    The box's 6DoF connection to the world root, whose origin the tests set.
+    """
+
+
+def _build_box_on_plane_world() -> BoxOnPlaneWorld:
+    """
+    Build a ground plane plus a single free-floating box, authored directly
+    into a :class:`World` so a simulator can be built from it without spawning.
+
+    :return: The world and the box handles the caller needs.
     """
     world = World()
     root = Body(name=PrefixedName("world"))
@@ -894,7 +920,7 @@ def _build_box_on_plane_world() -> tuple[World, Body, Connection6DoF]:
             world=world, parent=root, child=box
         )
         world.add_connection(box_connection)
-    return world, box, box_connection
+    return BoxOnPlaneWorld(world=world, box=box, box_connection=box_connection)
 
 
 def test_pose_written_during_sim_to_world_pull_reaches_the_simulator():
@@ -916,8 +942,9 @@ def test_pose_written_during_sim_to_world_pull_reaches_the_simulator():
     """
     target_xyz = numpy.array([0.4, -0.3, 1.25])
 
-    world, box, box_connection = _build_box_on_plane_world()
-    multi_sim = MujocoSim(world=world, headless=headless, step_size=STEP_SIZE)
+    scene = _build_box_on_plane_world()
+    box, box_connection = scene.box, scene.box_connection
+    multi_sim = MujocoSim(world=scene.world, headless=headless, step_size=STEP_SIZE)
     synchronizer = multi_sim.synchronizer
     # The pull is wall-clock throttled; this test calls it explicitly and must
     # not have the call skipped.
@@ -1003,8 +1030,9 @@ def test_pose_write_waits_for_the_running_physics_step():
     """
     target_xyz = numpy.array([-0.25, 0.45, 1.75])
 
-    world, box, box_connection = _build_box_on_plane_world()
-    multi_sim = MujocoSim(world=world, headless=headless, step_size=STEP_SIZE)
+    scene = _build_box_on_plane_world()
+    box, box_connection = scene.box, scene.box_connection
+    multi_sim = MujocoSim(world=scene.world, headless=headless, step_size=STEP_SIZE)
     synchronizer = multi_sim.synchronizer
 
     model_lock_held = threading.Event()

--- a/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 import time
 
 import mujoco
@@ -44,6 +45,7 @@ from semantic_digital_twin.adapters.multi_sim import (
     MujocoActuator,
     MujocoBuilder,
     MujocoLight,
+    MujocoSynchronizer,
 )
 
 urdf_dir = os.path.join(
@@ -756,7 +758,6 @@ def test_body_frame_excludes_joint_state_at_build_time():
         stop_multisim_if_running(multi_sim)
 
 
-@pytest.mark.flaky
 def test_world_sim_state_sync():
     plane_half_thickness = 0.05
     box_half_size = 0.1
@@ -849,6 +850,218 @@ def test_world_sim_state_sync():
         )
     finally:
         stop_multisim_if_running(multi_sim)
+
+
+def _build_box_on_plane_world() -> tuple[World, Body, Connection6DoF]:
+    """
+    A ground plane plus a single free-floating box, authored directly into a
+    :class:`World` so a simulator can be built from it without spawning.
+    """
+    world = World()
+    root = Body(name=PrefixedName("world"))
+    with world.modify_world():
+        world.add_body(root)
+
+        ground_plane = Body(name=PrefixedName("ground_plane"))
+        ground_plane.collision = ShapeCollection(
+            [
+                Box(
+                    origin=HomogeneousTransformationMatrix.from_xyz_rpy(
+                        reference_frame=ground_plane
+                    ),
+                    scale=Scale(2.0, 2.0, 0.1),
+                    color=Color(1.0, 1.0, 0.0, 1.0),
+                )
+            ],
+            reference_frame=ground_plane,
+        )
+        world.add_connection(FixedConnection(parent=root, child=ground_plane))
+
+        box = Body(name=PrefixedName("free_box"))
+        box.collision = ShapeCollection(
+            [
+                Box(
+                    origin=HomogeneousTransformationMatrix.from_xyz_rpy(
+                        reference_frame=box
+                    ),
+                    scale=Scale(0.2, 0.2, 0.2),
+                    color=Color(1.0, 0.0, 0.0, 1.0),
+                )
+            ],
+            reference_frame=box,
+        )
+        box_connection = Connection6DoF.create_with_dofs(
+            world=world, parent=root, child=box
+        )
+        world.add_connection(box_connection)
+    return world, box, box_connection
+
+
+def test_pose_written_during_sim_to_world_pull_reaches_the_simulator():
+    """
+    A pose written from another thread while the physics thread is inside its
+    *sim → world* pull must still reach MuJoCo.
+
+    The pull overwrites ``world.state`` from ``qpos`` and pauses the sibling
+    state-change callback while it does so. A write that lands inside that
+    window is therefore overwritten with the pre-write pose *and* has its
+    notification swallowed by the pause, so it never reaches ``qpos`` and no
+    error is raised anywhere -- the pose is simply lost. Under load this is
+    what made ``test_world_sim_state_sync`` fail, with the box settling at the
+    origin instead of the pose it was teleported to.
+
+    Rather than wait for that interleaving to happen by chance, this drives it:
+    the pull is held open inside ``_read_6dof_from_qpos`` while a second thread
+    writes a new pose.
+    """
+    target_xyz = numpy.array([0.4, -0.3, 1.25])
+
+    world, box, box_connection = _build_box_on_plane_world()
+    multi_sim = MujocoSim(world=world, headless=headless, step_size=STEP_SIZE)
+    synchronizer = multi_sim.synchronizer
+    # The pull is wall-clock throttled; this test calls it explicitly and must
+    # not have the call skipped.
+    synchronizer.sync_rate_hz = MujocoSynchronizer.UNTHROTTLED_SYNC_RATE_HZ
+
+    pull_is_inside = threading.Event()
+    let_pull_finish = threading.Event()
+    original_read = synchronizer._read_6dof_from_qpos
+
+    def blocking_read(connection, qpos_adr):
+        pull_is_inside.set()
+        assert let_pull_finish.wait(
+            timeout=10
+        ), "test did not release the sim → world pull"
+        return original_read(connection, qpos_adr)
+
+    write_failed = []
+
+    def write_new_pose():
+        try:
+            box_connection.origin = HomogeneousTransformationMatrix.from_xyz_rpy(
+                x=float(target_xyz[0]),
+                y=float(target_xyz[1]),
+                z=float(target_xyz[2]),
+                reference_frame=box,
+            )
+        except BaseException as error:  # surfaced on the main thread below
+            write_failed.append(error)
+
+    try:
+        synchronizer._read_6dof_from_qpos = blocking_read
+
+        # The physics thread is never started: _sim_to_world is what the
+        # physics thread would call after each mj_step, and calling it directly
+        # keeps the interleaving deterministic.
+        puller = threading.Thread(target=synchronizer._sim_to_world, daemon=True)
+        puller.start()
+        assert pull_is_inside.wait(timeout=10), "sim → world pull never started"
+
+        writer = threading.Thread(target=write_new_pose, daemon=True)
+        writer.start()
+        # Give the writer every chance to slip into the middle of the pull.
+        time.sleep(0.2)
+
+        let_pull_finish.set()
+        puller.join(timeout=10)
+        writer.join(timeout=10)
+        assert not puller.is_alive(), "sim → world pull did not finish"
+        assert not writer.is_alive(), "pose write did not finish"
+        assert not write_failed, f"pose write raised: {write_failed[0]!r}"
+
+        qpos_adr = synchronizer._resolve_qpos_adr(box_connection)
+        assert qpos_adr is not None, "free joint is missing from the MuJoCo model"
+        written_xyz = numpy.asarray(
+            multi_sim.simulator._mj_data.qpos[qpos_adr : qpos_adr + 3], dtype=float
+        )
+        assert numpy.allclose(written_xyz, target_xyz, atol=1e-6), (
+            "pose written during the sim → world pull never reached MuJoCo: "
+            f"qpos={written_xyz}, expected={target_xyz}"
+        )
+    finally:
+        synchronizer._read_6dof_from_qpos = original_read
+        let_pull_finish.set()
+        synchronizer.stop()
+
+
+def test_pose_write_waits_for_the_running_physics_step():
+    """
+    The *world → sim* push must write ``qpos`` under the simulator's model
+    lock, the same lock :meth:`MujocoSimulator.step_callback` holds across
+    ``mj_step``.
+
+    The scene integrates with RK4, which saves the state at the top of the step
+    and writes the integrated ``qpos`` back at the end. A pose written into
+    ``qpos`` while a step is in flight is therefore overwritten by that final
+    write and disappears -- the body carries on from its old pose and nothing
+    reports an error. Under CI load the physics thread spends most of its wall
+    time inside ``mj_step``, which is what made ``test_world_sim_state_sync``
+    fail there while passing on an idle machine.
+
+    Holding the model lock from another thread stands in for a step in flight:
+    the push must block until it is released, and must land afterwards.
+    """
+    target_xyz = numpy.array([-0.25, 0.45, 1.75])
+
+    world, box, box_connection = _build_box_on_plane_world()
+    multi_sim = MujocoSim(world=world, headless=headless, step_size=STEP_SIZE)
+    synchronizer = multi_sim.synchronizer
+
+    model_lock_held = threading.Event()
+    release_model_lock = threading.Event()
+    write_returned = threading.Event()
+    write_failed = []
+
+    def hold_model_lock():
+        with multi_sim.simulator._model_lock:
+            model_lock_held.set()
+            release_model_lock.wait(timeout=10)
+
+    def write_new_pose():
+        try:
+            box_connection.origin = HomogeneousTransformationMatrix.from_xyz_rpy(
+                x=float(target_xyz[0]),
+                y=float(target_xyz[1]),
+                z=float(target_xyz[2]),
+                reference_frame=box,
+            )
+        except BaseException as error:  # surfaced on the main thread below
+            write_failed.append(error)
+        finally:
+            write_returned.set()
+
+    try:
+        holder = threading.Thread(target=hold_model_lock, daemon=True)
+        holder.start()
+        assert model_lock_held.wait(timeout=10), "could not take the model lock"
+
+        writer = threading.Thread(target=write_new_pose, daemon=True)
+        writer.start()
+
+        assert not write_returned.wait(timeout=1.0), (
+            "the world → sim push completed while another thread held the "
+            "model lock, so it can also run in the middle of an mj_step, "
+            "where RK4 overwrites the pose it just wrote"
+        )
+
+        release_model_lock.set()
+        writer.join(timeout=10)
+        holder.join(timeout=10)
+        assert write_returned.is_set(), "pose write never finished"
+        assert not write_failed, f"pose write raised: {write_failed[0]!r}"
+
+        qpos_adr = synchronizer._resolve_qpos_adr(box_connection)
+        assert qpos_adr is not None, "free joint is missing from the MuJoCo model"
+        written_xyz = numpy.asarray(
+            multi_sim.simulator._mj_data.qpos[qpos_adr : qpos_adr + 3], dtype=float
+        )
+        assert numpy.allclose(written_xyz, target_xyz, atol=1e-6), (
+            "pose never reached MuJoCo once the model lock was free: "
+            f"qpos={written_xyz}, expected={target_xyz}"
+        )
+    finally:
+        release_model_lock.set()
+        synchronizer.stop()
 
 
 def test_prebuilt_world_multiple_free_bodies_start_at_authored_poses():

--- a/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_multi_sim.py
@@ -927,12 +927,12 @@ def test_pose_written_during_sim_to_world_pull_reaches_the_simulator():
     let_pull_finish = threading.Event()
     original_read = synchronizer._read_6dof_from_qpos
 
-    def blocking_read(connection, qpos_adr):
+    def blocking_read(connection, qpos_address):
         pull_is_inside.set()
         assert let_pull_finish.wait(
             timeout=10
         ), "test did not release the sim → world pull"
-        return original_read(connection, qpos_adr)
+        return original_read(connection, qpos_address)
 
     write_failed = []
 
@@ -969,10 +969,10 @@ def test_pose_written_during_sim_to_world_pull_reaches_the_simulator():
         assert not writer.is_alive(), "pose write did not finish"
         assert not write_failed, f"pose write raised: {write_failed[0]!r}"
 
-        qpos_adr = synchronizer._resolve_qpos_adr(box_connection)
-        assert qpos_adr is not None, "free joint is missing from the MuJoCo model"
+        qpos_address = synchronizer._resolve_qpos_address(box_connection)
+        assert qpos_address is not None, "free joint is missing from the MuJoCo model"
         written_xyz = numpy.asarray(
-            multi_sim.simulator._mj_data.qpos[qpos_adr : qpos_adr + 3], dtype=float
+            multi_sim.simulator._mj_data.qpos[qpos_address : qpos_address + 3], dtype=float
         )
         assert numpy.allclose(written_xyz, target_xyz, atol=1e-6), (
             "pose written during the sim → world pull never reached MuJoCo: "
@@ -1050,10 +1050,10 @@ def test_pose_write_waits_for_the_running_physics_step():
         assert write_returned.is_set(), "pose write never finished"
         assert not write_failed, f"pose write raised: {write_failed[0]!r}"
 
-        qpos_adr = synchronizer._resolve_qpos_adr(box_connection)
-        assert qpos_adr is not None, "free joint is missing from the MuJoCo model"
+        qpos_address = synchronizer._resolve_qpos_address(box_connection)
+        assert qpos_address is not None, "free joint is missing from the MuJoCo model"
         written_xyz = numpy.asarray(
-            multi_sim.simulator._mj_data.qpos[qpos_adr : qpos_adr + 3], dtype=float
+            multi_sim.simulator._mj_data.qpos[qpos_address : qpos_address + 3], dtype=float
         )
         assert numpy.allclose(written_xyz, target_xyz, atol=1e-6), (
             "pose never reached MuJoCo once the model lock was free: "


### PR DESCRIPTION
## Problem

`test_world_sim_state_sync` fails intermittently in CI:

```
FAILED test_multi_sim.py::test_world_sim_state_sync - AssertionError: Box did not settle at target:
final_pos=[-2.83720686e-18  7.66259388e-15  1.49892245e-01], expected≈[0.3  0.2  0.15]
```

This is not a CI hardware-resource problem. The `z` coordinate in the failure is **correct** — the box did have time to fall and settle. It settled at the *origin* because the teleport to `(0.3, 0.2, 5.0)` was silently lost.

Reproduced by pinning to 2 cores with competing CPU load: **7 failures in 12 runs**, same signature. Tracing every `qpos` access in a failing run shows the write landing and then vanishing, with no write in between:

```
write6 MainThread before=[0.0, 0.0, 0.34] after=[0.3, 0.2, 5.0]   <- teleport written to qpos
read6  Thread-1   before=[-0.0, -0.0, 0.1392]                      <- gone, nothing wrote in between
```

## Cause

Two unsynchronised paths in `MujocoSynchronizer`, both of which drop a `world → sim` pose write without raising anything.

**1. `qpos` writes race `mj_step` (dominant).** `_on_state_change` writes `_mj_data.qpos` without taking the simulator's `_model_lock` — the lock `step_callback` holds across `mj_step`. The scene integrates with RK4, which saves the state at the top of the step and writes the integrated `qpos` back at the end, so a pose written while a step is in flight is overwritten and disappears; the body simply carries on from its old pose.

On an idle machine a step is short and the write almost always lands between steps. On a loaded runner the physics thread is descheduled mid-step and spends most of its wall time there, so the write lands inside a step often enough to fail the test. **The CPU shortage exposes the race rather than causing the failure** — which is why this only shows up in CI.

**2. Pose writes are not atomic against the `sim → world` pull.** `WorldState` takes `_world_lock` per accessor, so the seven degree-of-freedom writes in `Connection6DoF.origin` and the notification that pushes them are not one unit. A pull landing between them overwrites the new pose with the pre-write `qpos` values and — because it pauses the sibling state-change callback while it does so — swallows the notification that would have pushed the pose into MuJoCo. The closing `update_previous_world_state` then rebases the diff baseline, so no later notification sees the change either.

## Fix

- Hold `_world_lock` across the whole pull and the whole push, and across the writes plus notification in the three `origin` setters that have this shape (`Connection6DoF`, `OmniDrive`, `DifferentialDrive`).
- Take `_model_lock` around every `qpos` access, so pushes and pulls are serialised against `mj_step`.
- `_world_lock` stays the outer lock, matching the order `modify_world` already establishes (`_world_lock` → `_model_lock`), so no new lock ordering is introduced.
- The pull now resumes its callback in a `finally` block. An exception previously left it paused, silently disabling the `world → sim` direction for the rest of the run.

The test is **not** skipped and **not** marked flaky. The existing `@pytest.mark.flaky` is removed — it was inert, since no flaky plugin is installed and pytest only warned about an unknown mark.

## Tests

Two regression tests that drive each interleaving directly rather than waiting for it to happen under load, so they are deterministic:

- `test_pose_written_during_sim_to_world_pull_reaches_the_simulator` — holds the pull open inside `_read_6dof_from_qpos` while another thread writes a pose.
- `test_pose_write_waits_for_the_running_physics_step` — holds `_model_lock` from another thread, standing in for a step in flight, and asserts the push blocks until it is released and then lands.

Both **fail on the unfixed code** and pass with the fix.

## Verification

Run in a container built from `cram:latest` with the workspace re-synced (`uv sync --extra dev --active`).

| Check | Result |
|---|---|
| Starvation harness (2 cores + load), before | 7/12 failed |
| Starvation harness, after | **0/25 failed** |
| `test_multi_sim.py` | 18 passed |
| Full `semantic_digital_twin` suite, `-n 4` on 4 cores | **1048 passed, 0 failed**, 284.5s |
| Same suite on unpatched `main` (baseline) | 1046 passed, 282.6s |

No measurable cost from the added locking (284.5s vs 282.6s).

Note: 4 `ERROR collecting test_worlds/__init__.py - No module named 'pydrake'` appear in both the patched and baseline local runs — drake is installed by a separate CI step and is absent from the local container. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
