### PR TITLE
Keep NygaInduction extreme-point widening from overlapping a sibling leaf

### DIFF
--- a/probabilistic_model/src/probabilistic_model/learning/jpt/jpt.py
+++ b/probabilistic_model/src/probabilistic_model/learning/jpt/jpt.py
@@ -8,7 +8,7 @@ import pandas as pd
 from jpt.learning.impurity import Impurity
 
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
-from random_events.interval import closed, singleton, Interval
+from random_events.interval import closed, Bound, SimpleInterval
 from random_events.product_algebra import VariableMap
 from random_events.variable import Variable, Continuous, Integer, Symbolic
 from typing_extensions import Self
@@ -313,40 +313,42 @@ class JointProbabilityTree(SubclassJSONSerializer):
         self.c45queue.append((data, start + split_pos + 1, end, new_depth))
 
     @staticmethod
-    def reserved_neighbor_region(
-        own_values: np.ndarray, other_values: np.ndarray
-    ) -> Interval:
+    def leaf_support(
+        own_values: np.ndarray, other_values: np.ndarray, tolerance_at_extremes: float
+    ) -> SimpleInterval:
         """
-        The nearest values in `other_values` immediately below and above the range of
-        `own_values`, as a region of one or two singleton points.
+        The largest span around the range of `own_values` that stays clear of
+        `other_values`, widened by at most `tolerance_at_extremes` on each side.
 
-        Passed as the `forbidden_region` to :meth:`NygaInduction.fit` for a leaf, so
-        that widening that leaf's support for a variable to account for float
+        Passed as the `support` of the :class:`NygaInduction` fit for a leaf, so that
+        widening that leaf's support for a variable to account for float
         instabilities cannot cross into a sibling leaf's raw data for the same
         variable - which would break the determinism of the tree the leaves are
-        mounted into. Considering only the two nearest points, rather than every
-        point in `other_values`, is sufficient because the widening is bounded by
-        :attr:`NygaInduction.tolerance_at_extremes`, which cannot reach past them.
+        mounted into. Considering only the nearest point on each side, rather than
+        every point in `other_values`, is sufficient because the widening cannot
+        reach further than `tolerance_at_extremes` in the first place.
 
         :param own_values: The values of one continuous variable, for the rows of the
             leaf under construction.
         :param other_values: The values of that variable, for every row outside that
             leaf.
-        :return: The reserved region, empty if `other_values` is empty.
+        :param tolerance_at_extremes: The widening to apply where `other_values`
+            leaves enough room for it.
+        :return: The allowed support.
         """
-        region = Interval.from_simple_sets()
-        if len(other_values) == 0:
-            return region
+        own_lower, own_upper = own_values.min(), own_values.max()
 
-        below = other_values[other_values < own_values.min()]
-        if len(below) > 0:
-            region = region.union_with(singleton(float(below.max())))
+        lower, left = own_lower - tolerance_at_extremes, Bound.CLOSED
+        below = other_values[other_values < own_lower]
+        if len(below) > 0 and below.max() > lower:
+            lower, left = float(below.max()), Bound.OPEN
 
-        above = other_values[other_values > own_values.max()]
-        if len(above) > 0:
-            region = region.union_with(singleton(float(above.min())))
+        upper, right = own_upper + tolerance_at_extremes, Bound.CLOSED
+        above = other_values[other_values > own_upper]
+        if len(above) > 0 and above.min() < upper:
+            upper, right = float(above.min()), Bound.OPEN
 
-        return region
+        return SimpleInterval.from_data(lower, upper, left, right)
 
     def create_leaf_node(
         self, data: np.ndarray, other_data: Optional[np.ndarray] = None
@@ -371,14 +373,13 @@ class JointProbabilityTree(SubclassJSONSerializer):
                     min_likelihood_improvement=annotated_variable.min_likelihood_improvement,
                     min_samples_per_quantile=annotated_variable.min_samples_per_quantile,
                 )
-                forbidden_region = (
-                    self.reserved_neighbor_region(data[:, index], other_data[:, index])
-                    if other_data is not None
-                    else None
-                )
-                distribution = distribution.fit(
-                    data[:, index], forbidden_region=forbidden_region
-                )
+                if other_data is not None:
+                    distribution.support = self.leaf_support(
+                        data[:, index],
+                        other_data[:, index],
+                        distribution.tolerance_at_extremes,
+                    )
+                distribution = distribution.fit(data[:, index])
 
                 if isinstance(
                     distribution.root, UnivariateContinuousLeaf

--- a/probabilistic_model/src/probabilistic_model/learning/jpt/jpt.py
+++ b/probabilistic_model/src/probabilistic_model/learning/jpt/jpt.py
@@ -8,7 +8,7 @@ import pandas as pd
 from jpt.learning.impurity import Impurity
 
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
-from random_events.interval import closed
+from random_events.interval import closed, singleton, Interval
 from random_events.product_algebra import VariableMap
 from random_events.variable import Variable, Continuous, Integer, Symbolic
 from typing_extensions import Self
@@ -289,7 +289,10 @@ class JointProbabilityTree(SubclassJSONSerializer):
         if max_gain <= self.min_impurity_improvement:
 
             # create decomposable product node
-            leaf_node = self.create_leaf_node(data[self.indices[start:end]])
+            other_rows = np.concatenate([self.indices[:start], self.indices[end:]])
+            leaf_node = self.create_leaf_node(
+                data[self.indices[start:end]], data[other_rows]
+            )
             weight = number_of_samples / len(data)
             self.root.add_subcircuit(leaf_node, np.log(weight))
 
@@ -309,11 +312,53 @@ class JointProbabilityTree(SubclassJSONSerializer):
         self.c45queue.append((data, start, start + split_pos + 1, new_depth))
         self.c45queue.append((data, start + split_pos + 1, end, new_depth))
 
-    def create_leaf_node(self, data: np.ndarray) -> ProductUnit:
+    @staticmethod
+    def reserved_neighbor_region(
+        own_values: np.ndarray, other_values: np.ndarray
+    ) -> Interval:
+        """
+        The nearest values in `other_values` immediately below and above the range of
+        `own_values`, as a region of one or two singleton points.
+
+        Passed as the `forbidden_region` to :meth:`NygaInduction.fit` for a leaf, so
+        that widening that leaf's support for a variable to account for float
+        instabilities cannot cross into a sibling leaf's raw data for the same
+        variable - which would break the determinism of the tree the leaves are
+        mounted into. Considering only the two nearest points, rather than every
+        point in `other_values`, is sufficient because the widening is bounded by
+        :attr:`NygaInduction.tolerance_at_extremes`, which cannot reach past them.
+
+        :param own_values: The values of one continuous variable, for the rows of the
+            leaf under construction.
+        :param other_values: The values of that variable, for every row outside that
+            leaf.
+        :return: The reserved region, empty if `other_values` is empty.
+        """
+        region = Interval.from_simple_sets()
+        if len(other_values) == 0:
+            return region
+
+        below = other_values[other_values < own_values.min()]
+        if len(below) > 0:
+            region = region.union_with(singleton(float(below.max())))
+
+        above = other_values[other_values > own_values.max()]
+        if len(above) > 0:
+            region = region.union_with(singleton(float(above.min())))
+
+        return region
+
+    def create_leaf_node(
+        self, data: np.ndarray, other_data: Optional[np.ndarray] = None
+    ) -> ProductUnit:
         """
         Create a fully decomposable product node from a 2D data array.
 
-        :param data: The preprocessed data to use for training
+        :param data: The preprocessed data to use for training.
+        :param other_data: The preprocessed data of every row that does not belong to
+            this leaf, used to keep continuous variables' fitted supports from
+            overlapping a sibling leaf's data. If not given, no such reservation is
+            made.
         :return: The leaf node.
         """
         result = ProductUnit(probabilistic_circuit=self.probabilistic_circuit)
@@ -326,7 +371,14 @@ class JointProbabilityTree(SubclassJSONSerializer):
                     min_likelihood_improvement=annotated_variable.min_likelihood_improvement,
                     min_samples_per_quantile=annotated_variable.min_samples_per_quantile,
                 )
-                distribution = distribution.fit(data[:, index])
+                forbidden_region = (
+                    self.reserved_neighbor_region(data[:, index], other_data[:, index])
+                    if other_data is not None
+                    else None
+                )
+                distribution = distribution.fit(
+                    data[:, index], forbidden_region=forbidden_region
+                )
 
                 if isinstance(
                     distribution.root, UnivariateContinuousLeaf

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Deque, Tuple, Dict, Any
 import numpy as np
 import numpy.typing as npt
 import random_events
-from random_events.interval import closed, closed_open, SimpleInterval, Bound
+from random_events.interval import closed, closed_open, Interval, SimpleInterval, Bound
 from random_events.product_algebra import SimpleEvent, Event
 from random_events.variable import Continuous
 from typing_extensions import Self
@@ -419,13 +419,21 @@ class NygaInduction:
     """
 
     def fit(
-        self, data: np.ndarray, weights: Optional[np.ndarray] = None
+        self,
+        data: np.ndarray,
+        weights: Optional[np.ndarray] = None,
+        forbidden_region: Optional[Interval] = None,
     ) -> ProbabilisticCircuit:
         """
         Fit the distribution to the data.
 
         :param data: The data to fit the distribution to.
         :param weights: The optional log_weights of the data points.
+        :param forbidden_region: Space that the fitted support must not overlap, for
+            example the already-fitted support of a sibling distribution for the same
+            variable elsewhere in a larger circuit. Only constrains
+            :meth:`adjust_extreme_points`; the induced quantiles themselves are
+            unaffected.
 
         :return: The fitted distribution.
         """
@@ -483,12 +491,18 @@ class NygaInduction:
             induction_steps.extend(new_induction_steps)
 
         self.probabilistic_circuit.normalize()
-        self.adjust_extreme_points()
+        self.adjust_extreme_points(forbidden_region)
         return self.probabilistic_circuit
 
-    def adjust_extreme_points(self):
+    def adjust_extreme_points(self, forbidden_region: Optional[Interval] = None):
         """
-        Applies `epsilon_at_extremes` to the support of the distribution.
+        Applies `tolerance_at_extremes` to the support of the distribution.
+
+        The widening is shrunk wherever it would otherwise enter `forbidden_region`,
+        so that a dense dataset near a boundary shared with another leaf cannot make
+        the two supports overlap and destroy the determinism of the mixture.
+
+        :param forbidden_region: Space this distribution's support must not overlap.
         """
         # skip if this distribution is a dirac delta distribution
         if len(self.probabilistic_circuit.nodes()) == 1:
@@ -499,15 +513,58 @@ class NygaInduction:
             self.probabilistic_circuit.leaves,
             key=lambda leaf: leaf.distribution.interval.lower,
         )
-
-        lowest_leaf.distribution.interval.lower -= self.tolerance_at_extremes
+        lower, touches_forbidden_region = self.safe_extreme_point(
+            lowest_leaf.distribution.interval.lower, -1, forbidden_region
+        )
+        lowest_leaf.distribution.interval.lower = lower
+        if touches_forbidden_region:
+            lowest_leaf.distribution.interval.left = Bound.OPEN
 
         highest_leaf = max(
             self.probabilistic_circuit.leaves,
             key=lambda leaf: leaf.distribution.interval.upper,
         )
+        upper, touches_forbidden_region = self.safe_extreme_point(
+            highest_leaf.distribution.interval.upper, 1, forbidden_region
+        )
+        highest_leaf.distribution.interval.upper = upper
+        if touches_forbidden_region:
+            highest_leaf.distribution.interval.right = Bound.OPEN
 
-        highest_leaf.distribution.interval.upper += self.tolerance_at_extremes
+    def safe_extreme_point(
+        self, boundary: float, direction: int, forbidden_region: Optional[Interval]
+    ) -> Tuple[float, bool]:
+        """
+        Compute how far `boundary` may move by `tolerance_at_extremes` without the
+        swept-over region entering `forbidden_region`.
+
+        :param boundary: The extreme point to widen.
+        :param direction: -1 to shrink the boundary (a lower bound), +1 to grow it
+            (an upper bound).
+        :param forbidden_region: Space the swept-over region must not overlap.
+
+        :return: The new boundary, and whether it had to be clipped exactly onto the
+            edge of `forbidden_region` (in which case the corresponding side of the
+            interval must be opened to avoid a single-point overlap).
+        """
+        unclipped = boundary + direction * self.tolerance_at_extremes
+        if forbidden_region is None or forbidden_region.is_empty():
+            return unclipped, False
+
+        swept_region = (
+            closed(unclipped, boundary)
+            if direction < 0
+            else closed(boundary, unclipped)
+        )
+        intrusion = swept_region.intersection_with(forbidden_region)
+        if intrusion.is_empty():
+            return unclipped, False
+
+        if direction < 0:
+            edge = max(simple_set.upper for simple_set in intrusion.simple_sets)
+        else:
+            edge = min(simple_set.lower for simple_set in intrusion.simple_sets)
+        return edge, True
 
     def empty_copy(self) -> Self:
         return self.__class__(

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Deque, Tuple, Dict, Any
 import numpy as np
 import numpy.typing as npt
 import random_events
-from random_events.interval import closed, closed_open, Interval, SimpleInterval, Bound
+from random_events.interval import closed, closed_open, SimpleInterval, Bound
 from random_events.product_algebra import SimpleEvent, Event
 from random_events.variable import Continuous
 from typing_extensions import Self
@@ -155,23 +155,37 @@ class InductionStep:
         """
         Create a uniform distribution from the datapoint at `begin_index` to the datapoint at `end_index`.
 
+        The piece touching the globally first or last datapoint of the induction is
+        built unbounded on that side and then intersected with
+        :attr:`NygaInduction.support`, so that widening the support to absorb float
+        instabilities - or narrowing it to stay clear of a sibling distribution
+        elsewhere in a larger circuit - is expressed entirely through that one
+        interval rather than through a separate adjustment step. If no support is
+        set, the piece keeps the exact bounds implied by the data, unchanged.
+
         :param begin_index: The index of the first datapoint.
         :param end_index: The index of the last datapoint.
         """
-        if end_index == len(self.data):
-            interval = SimpleInterval.from_data(
-                self.left_connecting_point_from_index(begin_index),
-                self.right_connecting_point(),
-                Bound.CLOSED,
-                Bound.CLOSED,
-            )
-        else:
-            interval = SimpleInterval.from_data(
-                self.left_connecting_point_from_index(begin_index),
-                self.right_connecting_point_from_index(end_index),
-                Bound.CLOSED,
-                Bound.OPEN,
-            )
+        is_last_piece = end_index == len(self.data)
+        support = self.nyga_induction.support
+
+        lower = self.left_connecting_point_from_index(begin_index)
+        upper = (
+            self.right_connecting_point()
+            if is_last_piece
+            else self.right_connecting_point_from_index(end_index)
+        )
+        if support is not None:
+            if begin_index == 0:
+                lower = -float("inf")
+            if is_last_piece:
+                upper = float("inf")
+
+        interval = SimpleInterval.from_data(
+            lower, upper, Bound.CLOSED, Bound.CLOSED if is_last_piece else Bound.OPEN
+        )
+        if support is not None:
+            interval = interval.intersection_with(support)
         return UniformDistribution(variable=self.variable, interval=interval)
 
     def sum_weights_from_indices(self, begin_index: int, end_index: int) -> float:
@@ -411,6 +425,18 @@ class NygaInduction:
     float precision.
     """
 
+    support: Optional[SimpleInterval] = None
+    """
+    The allowed span of the distribution's support. Every uniform piece the induction
+    creates is intersected with this interval, so a sibling distribution for the same
+    variable elsewhere in a larger circuit (e.g. another leaf of a
+    :class:`~probabilistic_model.learning.jpt.jpt.JointProbabilityTree`) can be kept
+    from being overlapped by simply narrowing this interval instead of it.
+
+    If left as `None`, :meth:`fit` sets it to the data's own range widened by
+    `tolerance_at_extremes` on both sides.
+    """
+
     probabilistic_circuit: ProbabilisticCircuit = field(
         init=False, default_factory=ProbabilisticCircuit, compare=False
     )
@@ -419,21 +445,13 @@ class NygaInduction:
     """
 
     def fit(
-        self,
-        data: np.ndarray,
-        weights: Optional[np.ndarray] = None,
-        forbidden_region: Optional[Interval] = None,
+        self, data: np.ndarray, weights: Optional[np.ndarray] = None
     ) -> ProbabilisticCircuit:
         """
         Fit the distribution to the data.
 
         :param data: The data to fit the distribution to.
         :param weights: The optional log_weights of the data points.
-        :param forbidden_region: Space that the fitted support must not overlap, for
-            example the already-fitted support of a sibling distribution for the same
-            variable elsewhere in a larger circuit. Only constrains
-            :meth:`adjust_extreme_points`; the induced quantiles themselves are
-            unaffected.
 
         :return: The fitted distribution.
         """
@@ -454,6 +472,15 @@ class NygaInduction:
             )
 
             return self.probabilistic_circuit
+
+        # default the support to the data's own range widened by tolerance_at_extremes
+        if self.support is None:
+            self.support = SimpleInterval.from_data(
+                sorted_unique_data[0] - self.tolerance_at_extremes,
+                sorted_unique_data[-1] + self.tolerance_at_extremes,
+                Bound.CLOSED,
+                Bound.CLOSED,
+            )
 
         # if the log_weights are not given
         if weights is None:
@@ -491,80 +518,7 @@ class NygaInduction:
             induction_steps.extend(new_induction_steps)
 
         self.probabilistic_circuit.normalize()
-        self.adjust_extreme_points(forbidden_region)
         return self.probabilistic_circuit
-
-    def adjust_extreme_points(self, forbidden_region: Optional[Interval] = None):
-        """
-        Applies `tolerance_at_extremes` to the support of the distribution.
-
-        The widening is shrunk wherever it would otherwise enter `forbidden_region`,
-        so that a dense dataset near a boundary shared with another leaf cannot make
-        the two supports overlap and destroy the determinism of the mixture.
-
-        :param forbidden_region: Space this distribution's support must not overlap.
-        """
-        # skip if this distribution is a dirac delta distribution
-        if len(self.probabilistic_circuit.nodes()) == 1:
-            return
-
-        # get the left most side of the distribution
-        lowest_leaf = min(
-            self.probabilistic_circuit.leaves,
-            key=lambda leaf: leaf.distribution.interval.lower,
-        )
-        lower, touches_forbidden_region = self.safe_extreme_point(
-            lowest_leaf.distribution.interval.lower, -1, forbidden_region
-        )
-        lowest_leaf.distribution.interval.lower = lower
-        if touches_forbidden_region:
-            lowest_leaf.distribution.interval.left = Bound.OPEN
-
-        highest_leaf = max(
-            self.probabilistic_circuit.leaves,
-            key=lambda leaf: leaf.distribution.interval.upper,
-        )
-        upper, touches_forbidden_region = self.safe_extreme_point(
-            highest_leaf.distribution.interval.upper, 1, forbidden_region
-        )
-        highest_leaf.distribution.interval.upper = upper
-        if touches_forbidden_region:
-            highest_leaf.distribution.interval.right = Bound.OPEN
-
-    def safe_extreme_point(
-        self, boundary: float, direction: int, forbidden_region: Optional[Interval]
-    ) -> Tuple[float, bool]:
-        """
-        Compute how far `boundary` may move by `tolerance_at_extremes` without the
-        swept-over region entering `forbidden_region`.
-
-        :param boundary: The extreme point to widen.
-        :param direction: -1 to shrink the boundary (a lower bound), +1 to grow it
-            (an upper bound).
-        :param forbidden_region: Space the swept-over region must not overlap.
-
-        :return: The new boundary, and whether it had to be clipped exactly onto the
-            edge of `forbidden_region` (in which case the corresponding side of the
-            interval must be opened to avoid a single-point overlap).
-        """
-        unclipped = boundary + direction * self.tolerance_at_extremes
-        if forbidden_region is None or forbidden_region.is_empty():
-            return unclipped, False
-
-        swept_region = (
-            closed(unclipped, boundary)
-            if direction < 0
-            else closed(boundary, unclipped)
-        )
-        intrusion = swept_region.intersection_with(forbidden_region)
-        if intrusion.is_empty():
-            return unclipped, False
-
-        if direction < 0:
-            edge = max(simple_set.upper for simple_set in intrusion.simple_sets)
-        else:
-            edge = min(simple_set.lower for simple_set in intrusion.simple_sets)
-        return edge, True
 
     def empty_copy(self) -> Self:
         return self.__class__(

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Deque, Tuple, Dict, Any
 import numpy as np
 import numpy.typing as npt
 import random_events
-from random_events.interval import closed, closed_open, SimpleInterval, Bound
+from random_events.interval import closed, closed_open, reals, SimpleInterval, Bound
 from random_events.product_algebra import SimpleEvent, Event
 from random_events.variable import Continuous
 from typing_extensions import Self
@@ -160,32 +160,28 @@ class InductionStep:
         :attr:`NygaInduction.support`, so that widening the support to absorb float
         instabilities - or narrowing it to stay clear of a sibling distribution
         elsewhere in a larger circuit - is expressed entirely through that one
-        interval rather than through a separate adjustment step. If no support is
-        set, the piece keeps the exact bounds implied by the data, unchanged.
+        interval rather than through a separate adjustment step.
 
         :param begin_index: The index of the first datapoint.
         :param end_index: The index of the last datapoint.
         """
         is_last_piece = end_index == len(self.data)
-        support = self.nyga_induction.support
 
-        lower = self.left_connecting_point_from_index(begin_index)
+        lower = (
+            -float("inf")
+            if begin_index == 0
+            else self.left_connecting_point_from_index(begin_index)
+        )
         upper = (
-            self.right_connecting_point()
+            float("inf")
             if is_last_piece
             else self.right_connecting_point_from_index(end_index)
         )
-        if support is not None:
-            if begin_index == 0:
-                lower = -float("inf")
-            if is_last_piece:
-                upper = float("inf")
 
         interval = SimpleInterval.from_data(
             lower, upper, Bound.CLOSED, Bound.CLOSED if is_last_piece else Bound.OPEN
         )
-        if support is not None:
-            interval = interval.intersection_with(support)
+        interval = interval.intersection_with(self.nyga_induction.support)
         return UniformDistribution(variable=self.variable, interval=interval)
 
     def sum_weights_from_indices(self, begin_index: int, end_index: int) -> float:
@@ -425,7 +421,7 @@ class NygaInduction:
     float precision.
     """
 
-    support: Optional[SimpleInterval] = None
+    support: SimpleInterval = field(default_factory=lambda: reals().simple_sets[0])
     """
     The allowed span of the distribution's support. Every uniform piece the induction
     creates is intersected with this interval, so a sibling distribution for the same
@@ -433,8 +429,8 @@ class NygaInduction:
     :class:`~probabilistic_model.learning.jpt.jpt.JointProbabilityTree`) can be kept
     from being overlapped by simply narrowing this interval instead of it.
 
-    If left as `None`, :meth:`fit` sets it to the data's own range widened by
-    `tolerance_at_extremes` on both sides.
+    Defaults to the entire real line; :meth:`fit` always narrows it further to at
+    most the data's own range widened by `tolerance_at_extremes` on both sides.
     """
 
     probabilistic_circuit: ProbabilisticCircuit = field(
@@ -473,14 +469,15 @@ class NygaInduction:
 
             return self.probabilistic_circuit
 
-        # default the support to the data's own range widened by tolerance_at_extremes
-        if self.support is None:
-            self.support = SimpleInterval.from_data(
+        # narrow the support to at most the data's own range widened by tolerance_at_extremes
+        self.support = self.support.intersection_with(
+            SimpleInterval.from_data(
                 sorted_unique_data[0] - self.tolerance_at_extremes,
                 sorted_unique_data[-1] + self.tolerance_at_extremes,
                 Bound.CLOSED,
                 Bound.CLOSED,
             )
+        )
 
         # if the log_weights are not given
         if weights is None:

--- a/random_events/src/random_events/interval.py
+++ b/random_events/src/random_events/interval.py
@@ -86,7 +86,7 @@ class SimpleInterval(sigma_algebra.AbstractSimpleSet):
 
     @left.setter
     def left(self, value: Bound):
-        self.cpp_object.left = value.value
+        self.cpp_object.left = rl.BorderType(value.value)
 
     @property
     def right(self) -> Bound:
@@ -97,7 +97,7 @@ class SimpleInterval(sigma_algebra.AbstractSimpleSet):
 
     @right.setter
     def right(self, value: Bound):
-        self.cpp_object.right = value.value
+        self.cpp_object.right = rl.BorderType(value.value)
 
     @classmethod
     def _from_cpp(cls, cpp_object: rl.SimpleInterval) -> Self:

--- a/test/probabilistic_model_test/test_jpts/test_jpt.py
+++ b/test/probabilistic_model_test/test_jpts/test_jpt.py
@@ -241,6 +241,37 @@ class JPTTestCase(unittest.TestCase):
         self.assertEqual(self.model, deserialized)
 
 
+class DenseBoundaryDeterminismTestCase(unittest.TestCase):
+    """
+    Regression test for leaves whose data sits closer to a decision boundary than
+    `NygaInduction.tolerance_at_extremes`. Widening each leaf's support independently
+    would let the two supports overlap and break the tree's determinism; this checks
+    that leaf construction reserves the neighboring leaf's data instead.
+    """
+
+    def test_leaves_stay_deterministic_when_data_is_denser_than_tolerance(self):
+        # smaller than 2 * the default NygaInduction.tolerance_at_extremes (1e-6), so
+        # widening both sides by the full tolerance would make them overlap
+        gap = 2e-7
+        left_data = np.linspace(0.0, 5.0 - gap / 2, 50)
+        right_data = np.linspace(5.0 + gap / 2, 10.0, 50)
+        data = pd.DataFrame({"x": np.concatenate([left_data, right_data])})
+
+        (variable,) = infer_variables_from_dataframe(data)
+        model = JointProbabilityTree(annotated_variables=[variable])
+        preprocessed = model.preprocess_data(data)
+
+        left_data_rows, right_data_rows = preprocessed[:50], preprocessed[50:]
+        left_leaf = model.create_leaf_node(left_data_rows, right_data_rows)
+        right_leaf = model.create_leaf_node(right_data_rows, left_data_rows)
+
+        model.root = SumUnit(probabilistic_circuit=model.probabilistic_circuit)
+        model.root.add_subcircuit(left_leaf, 0.0)
+        model.root.add_subcircuit(right_leaf, 0.0)
+
+        self.assertTrue(model.probabilistic_circuit.is_deterministic())
+
+
 class BreastCancerTestCase(unittest.TestCase):
     data: pd.DataFrame
     model: JointProbabilityTree

--- a/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
+++ b/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
@@ -1,9 +1,10 @@
 import unittest
+from typing import Optional
 
 import numpy as np
 import plotly.graph_objects as go
 from numpy import testing
-from random_events.interval import closed, closed_open, Bound
+from random_events.interval import closed, closed_open, Bound, SimpleInterval
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
 from random_events.variable import Continuous
 from scipy.special import logsumexp
@@ -325,92 +326,106 @@ class FittedNygaDistributionTestCase(unittest.TestCase):
         self.assertGreater(likelihood.min(), -np.inf)
 
 
-class SafeExtremePointTestCase(unittest.TestCase):
+class SupportedUniformDistributionTestCase(unittest.TestCase):
     """
-    Tests for `NygaInduction.safe_extreme_point`, which bounds how far an extreme point
-    of a Nyga distribution's support may be widened by `tolerance_at_extremes` without
-    entering a given forbidden region.
-    """
-
-    variable: Continuous = Continuous("x")
-    model: NygaInduction
-
-    def setUp(self) -> None:
-        self.model = NygaInduction(self.variable)
-
-    def test_lower_bound_uses_full_tolerance_when_no_forbidden_region(self):
-        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
-            5.0, -1, None
-        )
-        self.assertEqual(new_bound, 5.0 - self.model.tolerance_at_extremes)
-        self.assertFalse(touches_forbidden_region)
-
-    def test_upper_bound_uses_full_tolerance_when_clear_of_forbidden_region(self):
-        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
-            5.0, 1, closed(10.0, 20.0)
-        )
-        self.assertEqual(new_bound, 5.0 + self.model.tolerance_at_extremes)
-        self.assertFalse(touches_forbidden_region)
-
-    def test_lower_bound_clips_exactly_onto_forbidden_region_edge(self):
-        # unclipped would be 5.0000005 - 1e-6 = 4.9999995, inside the forbidden region
-        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
-            5.0000005, -1, closed(0.0, 5.0)
-        )
-        self.assertEqual(new_bound, 5.0)
-        self.assertTrue(touches_forbidden_region)
-
-    def test_upper_bound_clips_exactly_onto_forbidden_region_edge(self):
-        # unclipped would be 4.9999995 + 1e-6 = 5.0000005, inside the forbidden region
-        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
-            4.9999995, 1, closed(5.0, 10.0)
-        )
-        self.assertEqual(new_bound, 5.0)
-        self.assertTrue(touches_forbidden_region)
-
-
-class AdjustExtremePointsTestCase(unittest.TestCase):
-    """
-    Tests for `NygaInduction.adjust_extreme_points`, which widens a Nyga
-    distribution's support without letting it overlap a given forbidden region - the
-    support already claimed by another leaf for the same variable elsewhere in a
-    larger circuit, as happens when :class:`JointProbabilityTree` mounts one
-    independently fitted distribution per decision-tree leaf.
+    Tests for how `InductionStep.create_uniform_distribution_from_indices` uses
+    `NygaInduction.support`: the piece touching the globally first or last datapoint is
+    intersected with it, which is what lets a leaf's tolerance widening be capped
+    without a separate adjustment step.
     """
 
     variable: Continuous = Continuous("x")
+    sorted_data: np.array = np.array([1, 2, 3, 4, 7, 9])
 
-    def model_with_single_piece(self, lower: float, upper: float) -> NygaInduction:
-        model = NygaInduction(self.variable)
-        root = SumUnit(probabilistic_circuit=model.probabilistic_circuit)
-        leaf_node = leaf(
+    def induction_step_with_support(
+        self, support: Optional[SimpleInterval]
+    ) -> InductionStep:
+        nyga_distribution = NygaInduction(
+            self.variable, min_samples_per_quantile=1, support=support
+        )
+        weights = np.ones((len(self.sorted_data),))
+        cumulative_weights = np.append(0, np.cumsum(weights))
+        cumulative_log_weights = np.append(0, np.cumsum(np.log(weights)))
+        return InductionStep(
+            self.sorted_data,
+            cumulative_weights,
+            cumulative_log_weights,
+            0,
+            len(self.sorted_data),
+            nyga_distribution,
+        )
+
+    def test_edge_piece_uses_exact_data_bounds_without_a_support(self):
+        distribution = self.induction_step_with_support(
+            None
+        ).create_uniform_distribution()
+        self.assertEqual(
+            distribution,
             UniformDistribution(
-                variable=self.variable, interval=closed(lower, upper).simple_sets[0]
+                variable=self.variable, interval=closed(1, 9).simple_sets[0]
             ),
-            model.probabilistic_circuit,
         )
-        root.add_subcircuit(leaf_node, 0.0)
-        return model
 
-    def test_widens_by_full_tolerance_without_forbidden_region(self):
-        model = self.model_with_single_piece(0.0, 5.0)
-        model.adjust_extreme_points()
-        widened = model.probabilistic_circuit.leaves[0].distribution.interval
-        self.assertEqual(widened.lower, -model.tolerance_at_extremes)
-        self.assertEqual(widened.upper, 5.0 + model.tolerance_at_extremes)
+    def test_edge_piece_is_clipped_to_a_given_support(self):
+        support = closed(0.0, 5.0).simple_sets[0]
+        distribution = self.induction_step_with_support(
+            support
+        ).create_uniform_distribution()
+        self.assertEqual(distribution.interval, support)
 
-    def test_clips_upper_bound_to_avoid_overlapping_forbidden_region(self):
-        # the raw leaf already sits closer to the neighbor than tolerance_at_extremes
-        model = self.model_with_single_piece(0.0, 4.9999995)
-        forbidden_region = closed(5.0, 10.0)
-        model.adjust_extreme_points(forbidden_region)
-        widened = model.probabilistic_circuit.leaves[0].distribution.interval
-
-        self.assertEqual(widened.upper, 5.0)
-        self.assertEqual(widened.right, Bound.OPEN)
-        self.assertTrue(
-            widened.as_composite_set().intersection_with(forbidden_region).is_empty()
+    def test_internal_piece_is_unaffected_by_a_wider_support(self):
+        induction_step = self.induction_step_with_support(
+            closed(-10.0, 20.0).simple_sets[0]
         )
+        distribution = induction_step.create_uniform_distribution_from_indices(3, 5)
+        self.assertEqual(
+            distribution,
+            UniformDistribution(
+                variable=self.variable, interval=closed_open(3.5, 8.0).simple_sets[0]
+            ),
+        )
+
+
+class NygaInductionSupportTestCase(unittest.TestCase):
+    """
+    Tests for how `NygaInduction.fit` establishes `support` when none is given, and
+    respects one that is - the mechanism that lets a sibling leaf's data (e.g.
+    another leaf of a :class:`JointProbabilityTree`) keep this distribution's support
+    from overlapping it.
+    """
+
+    variable: Continuous = Continuous("x")
+
+    def test_fit_defaults_support_to_data_range_widened_by_tolerance(self):
+        model = NygaInduction(
+            self.variable, min_samples_per_quantile=1, min_likelihood_improvement=0
+        )
+        model.fit([1.0, 2.0, 3.0])
+        # SimpleInterval stores its bounds as single-precision floats, so the exact
+        # value picks up rounding noise around the scale of tolerance_at_extremes itself
+        self.assertAlmostEqual(
+            model.support.lower, 1.0 - model.tolerance_at_extremes, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            model.support.upper, 3.0 + model.tolerance_at_extremes, delta=1e-5
+        )
+
+    def test_fit_keeps_a_given_support(self):
+        given_support = closed(0.0, 10.0).simple_sets[0]
+        model = NygaInduction(
+            self.variable,
+            support=given_support,
+            min_samples_per_quantile=1,
+            min_likelihood_improvement=0,
+        )
+        model.fit([1.0, 2.0, 3.0])
+
+        self.assertEqual(model.support, given_support)
+        widest_leaf = max(
+            model.probabilistic_circuit.leaves,
+            key=lambda leaf: leaf.distribution.interval.upper,
+        )
+        self.assertEqual(widest_leaf.distribution.interval.upper, 10.0)
 
 
 if __name__ == "__main__":

--- a/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
+++ b/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import plotly.graph_objects as go
 from numpy import testing
-from random_events.interval import closed, closed_open
+from random_events.interval import closed, closed_open, Bound
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
 from random_events.variable import Continuous
 from scipy.special import logsumexp
@@ -323,6 +323,94 @@ class FittedNygaDistributionTestCase(unittest.TestCase):
         )
         self.assertEqual(likelihood.shape, (1000,))
         self.assertGreater(likelihood.min(), -np.inf)
+
+
+class SafeExtremePointTestCase(unittest.TestCase):
+    """
+    Tests for `NygaInduction.safe_extreme_point`, which bounds how far an extreme point
+    of a Nyga distribution's support may be widened by `tolerance_at_extremes` without
+    entering a given forbidden region.
+    """
+
+    variable: Continuous = Continuous("x")
+    model: NygaInduction
+
+    def setUp(self) -> None:
+        self.model = NygaInduction(self.variable)
+
+    def test_lower_bound_uses_full_tolerance_when_no_forbidden_region(self):
+        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
+            5.0, -1, None
+        )
+        self.assertEqual(new_bound, 5.0 - self.model.tolerance_at_extremes)
+        self.assertFalse(touches_forbidden_region)
+
+    def test_upper_bound_uses_full_tolerance_when_clear_of_forbidden_region(self):
+        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
+            5.0, 1, closed(10.0, 20.0)
+        )
+        self.assertEqual(new_bound, 5.0 + self.model.tolerance_at_extremes)
+        self.assertFalse(touches_forbidden_region)
+
+    def test_lower_bound_clips_exactly_onto_forbidden_region_edge(self):
+        # unclipped would be 5.0000005 - 1e-6 = 4.9999995, inside the forbidden region
+        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
+            5.0000005, -1, closed(0.0, 5.0)
+        )
+        self.assertEqual(new_bound, 5.0)
+        self.assertTrue(touches_forbidden_region)
+
+    def test_upper_bound_clips_exactly_onto_forbidden_region_edge(self):
+        # unclipped would be 4.9999995 + 1e-6 = 5.0000005, inside the forbidden region
+        new_bound, touches_forbidden_region = self.model.safe_extreme_point(
+            4.9999995, 1, closed(5.0, 10.0)
+        )
+        self.assertEqual(new_bound, 5.0)
+        self.assertTrue(touches_forbidden_region)
+
+
+class AdjustExtremePointsTestCase(unittest.TestCase):
+    """
+    Tests for `NygaInduction.adjust_extreme_points`, which widens a Nyga
+    distribution's support without letting it overlap a given forbidden region - the
+    support already claimed by another leaf for the same variable elsewhere in a
+    larger circuit, as happens when :class:`JointProbabilityTree` mounts one
+    independently fitted distribution per decision-tree leaf.
+    """
+
+    variable: Continuous = Continuous("x")
+
+    def model_with_single_piece(self, lower: float, upper: float) -> NygaInduction:
+        model = NygaInduction(self.variable)
+        root = SumUnit(probabilistic_circuit=model.probabilistic_circuit)
+        leaf_node = leaf(
+            UniformDistribution(
+                variable=self.variable, interval=closed(lower, upper).simple_sets[0]
+            ),
+            model.probabilistic_circuit,
+        )
+        root.add_subcircuit(leaf_node, 0.0)
+        return model
+
+    def test_widens_by_full_tolerance_without_forbidden_region(self):
+        model = self.model_with_single_piece(0.0, 5.0)
+        model.adjust_extreme_points()
+        widened = model.probabilistic_circuit.leaves[0].distribution.interval
+        self.assertEqual(widened.lower, -model.tolerance_at_extremes)
+        self.assertEqual(widened.upper, 5.0 + model.tolerance_at_extremes)
+
+    def test_clips_upper_bound_to_avoid_overlapping_forbidden_region(self):
+        # the raw leaf already sits closer to the neighbor than tolerance_at_extremes
+        model = self.model_with_single_piece(0.0, 4.9999995)
+        forbidden_region = closed(5.0, 10.0)
+        model.adjust_extreme_points(forbidden_region)
+        widened = model.probabilistic_circuit.leaves[0].distribution.interval
+
+        self.assertEqual(widened.upper, 5.0)
+        self.assertEqual(widened.right, Bound.OPEN)
+        self.assertTrue(
+            widened.as_composite_set().intersection_with(forbidden_region).is_empty()
+        )
 
 
 if __name__ == "__main__":

--- a/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
+++ b/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
@@ -1,10 +1,9 @@
 import unittest
-from typing import Optional
 
 import numpy as np
 import plotly.graph_objects as go
 from numpy import testing
-from random_events.interval import closed, closed_open, Bound, SimpleInterval
+from random_events.interval import closed, closed_open, reals, Bound, SimpleInterval
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
 from random_events.variable import Continuous
 from scipy.special import logsumexp
@@ -65,11 +64,13 @@ class InductionStepTestCase(unittest.TestCase):
         self.assertEqual(self.induction_step.right_connecting_point_from_index(5), 8.0)
 
     def test_create_uniform_distribution_edge_case(self):
+        # a single piece spans the whole (unset) support of the induction, i.e. the
+        # entire real line, rather than being clipped to the data's own bounds
         distribution = self.induction_step.create_uniform_distribution()
         self.assertEqual(
             distribution,
             UniformDistribution(
-                variable=self.variable, interval=closed(1, 9).simple_sets[0]
+                variable=self.variable, interval=reals().simple_sets[0]
             ),
         )
 
@@ -337,9 +338,7 @@ class SupportedUniformDistributionTestCase(unittest.TestCase):
     variable: Continuous = Continuous("x")
     sorted_data: np.array = np.array([1, 2, 3, 4, 7, 9])
 
-    def induction_step_with_support(
-        self, support: Optional[SimpleInterval]
-    ) -> InductionStep:
+    def induction_step_with_support(self, support: SimpleInterval) -> InductionStep:
         nyga_distribution = NygaInduction(
             self.variable, min_samples_per_quantile=1, support=support
         )
@@ -355,14 +354,14 @@ class SupportedUniformDistributionTestCase(unittest.TestCase):
             nyga_distribution,
         )
 
-    def test_edge_piece_uses_exact_data_bounds_without_a_support(self):
+    def test_edge_piece_is_unconstrained_by_the_default_support(self):
         distribution = self.induction_step_with_support(
-            None
+            reals().simple_sets[0]
         ).create_uniform_distribution()
         self.assertEqual(
             distribution,
             UniformDistribution(
-                variable=self.variable, interval=closed(1, 9).simple_sets[0]
+                variable=self.variable, interval=reals().simple_sets[0]
             ),
         )
 
@@ -388,15 +387,14 @@ class SupportedUniformDistributionTestCase(unittest.TestCase):
 
 class NygaInductionSupportTestCase(unittest.TestCase):
     """
-    Tests for how `NygaInduction.fit` establishes `support` when none is given, and
-    respects one that is - the mechanism that lets a sibling leaf's data (e.g.
-    another leaf of a :class:`JointProbabilityTree`) keep this distribution's support
-    from overlapping it.
+    Tests for how `NygaInduction.fit` narrows `support` - the mechanism that lets a
+    sibling leaf's data (e.g. another leaf of a :class:`JointProbabilityTree`) keep
+    this distribution's support from overlapping it.
     """
 
     variable: Continuous = Continuous("x")
 
-    def test_fit_defaults_support_to_data_range_widened_by_tolerance(self):
+    def test_fit_narrows_the_default_support_to_data_range_widened_by_tolerance(self):
         model = NygaInduction(
             self.variable, min_samples_per_quantile=1, min_likelihood_improvement=0
         )
@@ -410,7 +408,8 @@ class NygaInductionSupportTestCase(unittest.TestCase):
             model.support.upper, 3.0 + model.tolerance_at_extremes, delta=1e-5
         )
 
-    def test_fit_keeps_a_given_support(self):
+    def test_fit_narrows_a_given_support_no_further_than_the_tolerance_window(self):
+        # wide enough that the tolerance window around the data sits inside it
         given_support = closed(0.0, 10.0).simple_sets[0]
         model = NygaInduction(
             self.variable,
@@ -420,12 +419,31 @@ class NygaInductionSupportTestCase(unittest.TestCase):
         )
         model.fit([1.0, 2.0, 3.0])
 
-        self.assertEqual(model.support, given_support)
+        self.assertAlmostEqual(
+            model.support.lower, 1.0 - model.tolerance_at_extremes, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            model.support.upper, 3.0 + model.tolerance_at_extremes, delta=1e-5
+        )
+
+    def test_fit_narrows_a_given_support_to_stay_inside_it(self):
+        # narrower than the tolerance window around the data on the upper side
+        given_support = closed(0.0, 3.0000005).simple_sets[0]
+        model = NygaInduction(
+            self.variable,
+            support=given_support,
+            min_samples_per_quantile=1,
+            min_likelihood_improvement=0,
+        )
+        model.fit([1.0, 2.0, 3.0])
+
         widest_leaf = max(
             model.probabilistic_circuit.leaves,
             key=lambda leaf: leaf.distribution.interval.upper,
         )
-        self.assertEqual(widest_leaf.distribution.interval.upper, 10.0)
+        self.assertAlmostEqual(
+            widest_leaf.distribution.interval.upper, 3.0000005, delta=1e-5
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`NygaInduction.adjust_extreme_points` widens only the lowest and highest leaf of
*its own* circuit by `tolerance_at_extremes`, with no knowledge of any other
`NygaInduction` instance. `JointProbabilityTree.create_leaf_node` fits one such
instance independently per (decision-tree leaf, continuous variable) and mounts
them all into a shared circuit. When two sibling leaves split on the same
variable with data denser than `2 * tolerance_at_extremes` near the split
point, each leaf's independent widening can cross past the other leaf's
boundary, making the mounted circuit non-deterministic - even though a Nyga
distribution is supposed to be deterministic by construction.

- `NygaInduction` now carries a `support: SimpleInterval` field. Every uniform
  piece `InductionStep.create_uniform_distribution_from_indices` builds is
  intersected with it; the piece touching the globally first or last datapoint
  is constructed unbounded on that side beforehand, so the intersection is
  what pins its final boundary - whether that comes from the default
  tolerance widening or from a caller-supplied support. If no support is
  given, `fit()` defaults it to the data's own range widened by
  `tolerance_at_extremes` on both sides, matching the previous default
  behavior.
- `JointProbabilityTree.create_leaf_node` computes a tighter support per leaf
  via `leaf_support`, using `random_events` interval/nearest-neighbor logic
  over the raw data of every row *outside* that leaf for the variable being
  fit. This is independent of leaf processing order, since it does not rely
  on what has already been mounted into the shared circuit.
- Along the way, fixing this exposed a separate, pre-existing bug in
  `random_events`: `SimpleInterval.left`/`.right` setters passed a raw int to a
  pybind11 field typed as the native `BorderType` enum, which raised a
  `TypeError` on any use (nothing in the codebase called these setters before
  this fix needed to). That's fixed in its own commit.

## Test plan
- [x] `NygaInductionSupportTestCase`/`SupportedUniformDistributionTestCase` in
      `test_nyga_distribution.py` cover the new support-intersection mechanism
      directly (default support, a given support being respected, edge vs.
      internal pieces).
- [x] `DenseBoundaryDeterminismTestCase` in `test_jpt.py` reproduces the
      dense-boundary scenario through `create_leaf_node` and asserts
      `is_deterministic()`.
- [x] Verified new/changed tests fail against the pre-fix code, then pass
      after the fix.
- [x] Full `random_events` + `probabilistic_model` suites: 468 passed, 1
      skipped (unrelated), no regressions.

Made with the help of Claude in session https://claude.ai/code/session_012Q5tR41rBWzTBNmE4sLZmR