### PR TITLE
Fix random_events PyPI publish failing on cp38/cp39/cp312

### DIFF
--- a/random_events/pyproject.toml
+++ b/random_events/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "Random random events for probabilistic reasoning"
 readme = "README.md"
 requires-python = ">=3.8"
-license = "LGPL-3.0-only"
+license = {text = "LGPL-3.0-only"}
 authors = [
     {name = "Tom Schierenbeck", email = "tom_sch@uni-bremen.de"}
 ]


### PR DESCRIPTION
## Summary
- `random_events/pyproject.toml` declared `license = "LGPL-3.0-only"` as a bare PEP 639 SPDX string
- The `Publish random_events to PyPI` workflow builds wheels for Python 3.8–3.12 via cibuildwheel, each resolving its own build-isolation `setuptools`; for cp38/cp39/cp312 the resolved version only partially supports PEP 639 and rejects the value as ambiguous (`project.license must be valid exactly by one definition (2 matches found)`), failing those wheel builds while cp310/cp311 pass
- This has failed on the last two merges to `main` (#569, #570) without blocking the PRs themselves, since it's a separate publish workflow
- Switched to the legacy `license = {text = "LGPL-3.0-only"}` table form, which every `setuptools` version in the build matrix supports

## Test plan
- [ ] `Publish random_events to PyPI` workflow succeeds for all Python versions on merge

Made with the help of Claude.