### PR TITLE
Add `--orm-build` option to control ORM interface build behavior; implement related tests and docs.

### DIFF
--- a/cognitive_robot_abstract_machine/exceptions.py
+++ b/cognitive_robot_abstract_machine/exceptions.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from krrood.exceptions import DataclassException
+from typing_extensions import Tuple
 
 
 @dataclass
@@ -63,3 +64,60 @@ class OrmGenerationFailedError(DataclassException, RuntimeError):
         return (
             "Run the generation again with --debug to follow what the generator does."
         )
+
+
+@dataclass
+class MissingOrmBuildChoiceError(DataclassException, ValueError):
+    """
+    Raised when a test run names the option that says when to build the ORM interfaces
+    without saying which choice it means.
+    """
+
+    option: str
+    """
+    The option that was left without a choice.
+    """
+
+    choices: Tuple[str, ...]
+    """
+    The choices it accepts.
+    """
+
+    def error_message(self) -> str:
+        return f"{self.option} says nothing about when to build the ORM interfaces."
+
+    def suggest_correction(self) -> str:
+        return f"Follow it with one of {', '.join(self.choices)}."
+
+
+@dataclass
+class UnknownOrmBuildChoiceError(DataclassException, ValueError):
+    """
+    Raised when a test run says to build the ORM interfaces at a time that does not
+    exist.
+    """
+
+    source: str
+    """
+    Where the choice was read, such as the option or the environment variable stating
+    it.
+    """
+
+    choice: str
+    """
+    What it said, which names no time to build at.
+    """
+
+    choices: Tuple[str, ...]
+    """
+    The choices it accepts.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"{self.source} says to build the ORM interfaces '{self.choice}', which is "
+            f"no time to build at."
+        )
+
+    def suggest_correction(self) -> str:
+        return f"State one of {', '.join(self.choices)}."

--- a/cognitive_robot_abstract_machine/orm_interfaces.py
+++ b/cognitive_robot_abstract_machine/orm_interfaces.py
@@ -37,6 +37,21 @@ INTERFACE_FILE_NAME = "ormatic_interface.py"
 Name every package's generator writes its interface to.
 """
 
+SOURCE_FILE_PATTERN = "*.py"
+"""
+What a module of a package is named like.
+"""
+
+MAPPING_ENGINE_SOURCE_FOLDERS: Tuple[Path, ...] = (
+    Path("krrood") / "src" / "krrood",
+    Path("cognitive_robot_abstract_machine"),
+)
+"""
+Folders of a checkout that every generator reads whichever package it is building for,
+relative to the root: the library that maps the classes, and the module that runs the
+generators.
+"""
+
 PROGRESS_DESCRIPTION = "Building ORM interfaces"
 """
 What the progress bar of a build calls itself.
@@ -180,6 +195,54 @@ class OrmInterface:
             / INTERFACE_FILE_NAME
         )
 
+    @property
+    def sources(self) -> Path:
+        """
+        The source folder holding the modules this interface maps.
+        """
+        return self.repository_root / self.package_name / "src" / self.package_name
+
+    @property
+    def mapping_engine_sources(self) -> List[Path]:
+        """
+        The folders of the library that maps this package's classes and of the module
+        that runs its generator.
+        """
+        return [
+            self.repository_root / folder for folder in MAPPING_ENGINE_SOURCE_FOLDERS
+        ]
+
+    @property
+    def inputs(self) -> List[Path]:
+        """
+        The files this package contributes to a build: its generator, the modules of its
+        source folder, and those of the mapping engine.
+
+        The interface itself is written by a build rather than read by one, so it is not
+        among them.
+        """
+        modules = [
+            module
+            for source_folder in (self.sources, *self.mapping_engine_sources)
+            for module in source_folder.rglob(SOURCE_FILE_PATTERN)
+            if module != self.path
+        ]
+        return [self.generator, *modules]
+
+    @property
+    def is_outdated(self) -> bool:
+        """
+        Whether this interface is missing, or older than a file this package contributes
+        to a build.
+
+        ..note:: A checkout that cannot build the interface counts as outdated, so the
+            build runs and reports what it is missing rather than being skipped.
+        """
+        if not self.path.exists() or not self.generator.exists():
+            return True
+        generated_at = self.path.stat().st_mtime
+        return any(source.stat().st_mtime > generated_at for source in self.inputs)
+
     def remove(self) -> None:
         """
         Delete the interface, so that a stale version cannot be imported while the new
@@ -270,6 +333,18 @@ class WorkspaceOrmInterfaces:
     """
     The interfaces in the order they are built, which follows their dependencies.
     """
+
+    @property
+    def is_outdated(self) -> bool:
+        """
+        Whether any interface is missing, or older than a file of the checkout a build
+        reads.
+
+        ..note:: A build covers every interface at once, so a package whose ORM model
+            another builds on outdates the whole workspace through its own interface,
+            and no interface has to look past its own package.
+        """
+        return any(interface.is_outdated for interface in self.interfaces)
 
     def regenerate(self, show_generator_output: bool = False) -> None:
         """

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -18,6 +18,19 @@ branches. Run ``python scripts/regenerate_all_orm.py`` to build them, which a fr
 clone needs before it can persist anything and a changed mapped datastructure needs
 again; CI generates them the same way for its tests.
 
+A test run builds them for itself, and a build takes about a minute, so by default it
+only pays for one when the checkout has not built its interfaces since the sources they
+are generated from changed. ``--orm-build`` overrides that:
+
+.. code:: bash
+
+  pytest --orm-build=auto     # the default: build only what the sources have outrun
+  pytest --orm-build=always   # build every run, whatever the checkout holds
+  pytest --orm-build=never    # build nothing, and read whatever the checkout holds
+
+Runs that state no choice on their command line take one from ``CRAM_ORM_BUILD``, which
+is how a shell or a CI job sets the default for every run it starts.
+
 If you have any questions or feedback, consider submitting a `GitHub
 Issue <https://github.com/cram2/cognitive_robot_abstract_machine/issues>`__.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,16 @@
 [pytest]
-addopts = -sv -m "not slow"
+# ROS Jazzy ships two pytest plugins, launch_testing and launch_ros, which pytest
+# auto-discovers via their entry points whenever the overlay is on PYTHONPATH. Their
+# collection hooks still declare pytest 7's `path` argument, renamed to `module_path` in
+# pytest 8, so pluggy rejects them at startup and the whole run aborts before collection.
+# ros2/launch fixed this on rolling but has not backported it to jazzy.
+#
+# Blocking them gives up ROS launch tests: a module whose `generate_test_description` is
+# marked `@pytest.mark.launch_test` or `@pytest.mark.rostest` would collect as a plain
+# module, so its launch description never starts the nodes under test and its `proc_info`
+# and `proc_output` fixtures are missing. The `--launch-args` flag goes with them. This
+# suite contains no such test.
+# If this ever changes, we will need to reevaluate this approach.
+addopts = -sv -m "not slow" -p no:launch_testing -p no:launch_ros
 markers =
     slow: marks stress/scale tests that build large motion statecharts (run with '-m slow')

--- a/test/cognitive_robot_abstract_machine_test/dataset/mapped_module.py
+++ b/test/cognitive_robot_abstract_machine_test/dataset/mapped_module.py
@@ -1,0 +1,11 @@
+"""
+A module of the kind a package's ORM interface is generated from.
+"""
+
+from __future__ import annotations
+
+
+class Container:
+    """
+    A class the generated interface maps.
+    """

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interface_build_hook.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interface_build_hook.py
@@ -1,23 +1,57 @@
+"""
+When a test run builds the ORM interfaces it reads, and which process does it.
+"""
+
+from __future__ import annotations
+
+import sys
+
 import pytest
+from typing_extensions import List
 
-from cognitive_robot_abstract_machine.orm_interfaces import WORKSPACE_ORM_INTERFACES
+from cognitive_robot_abstract_machine.exceptions import (
+    MissingOrmBuildChoiceError,
+    UnknownOrmBuildChoiceError,
+)
+from cognitive_robot_abstract_machine.orm_interfaces import (
+    WORKSPACE_ORM_INTERFACES,
+    WorkspaceOrmInterfaces,
+)
 
-from ..orm_interface_build import regenerate_orm_interfaces
+from ..orm_interface_build import ORM_BUILD_OPTION, OrmBuild, regenerate_orm_interfaces
 from ..pytest_environment import PytestEnvironmentVariable
+from .test_orm_interfaces import checkout, workspace  # noqa: F401  (shared fixtures)
+
+PYTEST_COMMAND = "pytest"
+"""
+The command the arguments of a run follow.
+"""
+
+UNKNOWN_CHOICE = "sometimes"
+"""
+A choice no run offers, for the readings of one to reject.
+"""
+
+ABBREVIATED_OPTION = ORM_BUILD_OPTION.removesuffix("uild")
+"""
+The option cut short, the way argparse lets a run abbreviate a long option.
+"""
 
 
 @pytest.fixture()
-def recorded_builds(monkeypatch) -> list:
+def recorded_builds(monkeypatch) -> List[str]:
     """
     Replace the real build with a recorder, so the guard can be exercised without paying
     for a whole regeneration.
 
     :return: The list every build appends to.
     """
-    builds = []
+    builds: List[str] = []
     monkeypatch.setattr(
         WORKSPACE_ORM_INTERFACES, "regenerate", lambda: builds.append("built")
     )
+    monkeypatch.setattr(sys, "argv", [PYTEST_COMMAND])
+    monkeypatch.setenv(PytestEnvironmentVariable.ORM_BUILD, OrmBuild.ALWAYS)
     regenerate_orm_interfaces.cache_clear()
     return builds
 
@@ -52,3 +86,154 @@ class TestOrmInterfacesBuiltOnlyByTheXdistController:
 
         assert regenerate_orm_interfaces() is True
         assert recorded_builds == ["built"]
+
+
+# %% the choice a run is started with
+
+
+@pytest.fixture
+def current_interfaces(workspace: WorkspaceOrmInterfaces) -> WorkspaceOrmInterfaces:
+    """
+    The interfaces of a checkout that has been built since its sources last changed.
+    """
+    workspace.regenerate()
+    return workspace
+
+
+@pytest.fixture
+def outdated_interfaces(
+    current_interfaces: WorkspaceOrmInterfaces,
+) -> WorkspaceOrmInterfaces:
+    """
+    The interfaces of a checkout that has not been built since its sources changed.
+    """
+    current_interfaces.interfaces[0].remove()
+    return current_interfaces
+
+
+class TestWhenAChoiceBuilds:
+    """
+    A run builds the interfaces every time, never, or only when the checkout has not
+    built them since its sources changed.
+    """
+
+    def test_never_skips_a_checkout_that_has_none(
+        self, outdated_interfaces: WorkspaceOrmInterfaces
+    ):
+        assert OrmBuild.NEVER.builds(outdated_interfaces) is False
+
+    def test_always_builds_a_current_checkout(
+        self, current_interfaces: WorkspaceOrmInterfaces
+    ):
+        assert OrmBuild.ALWAYS.builds(current_interfaces) is True
+
+    def test_auto_skips_a_current_checkout(
+        self, current_interfaces: WorkspaceOrmInterfaces
+    ):
+        assert OrmBuild.AUTO.builds(current_interfaces) is False
+
+    def test_auto_builds_an_outdated_checkout(
+        self, outdated_interfaces: WorkspaceOrmInterfaces
+    ):
+        assert OrmBuild.AUTO.builds(outdated_interfaces) is True
+
+
+class TestTheChoiceReachesTheProcessesOfARun:
+    """
+    The conftests build while pytest is still importing them, before it has parsed the
+    command line, so the choice is read off the arguments as they were given.
+    """
+
+    def test_a_run_stating_no_choice_builds_what_is_outdated(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", [PYTEST_COMMAND])
+        monkeypatch.delenv(PytestEnvironmentVariable.ORM_BUILD, raising=False)
+
+        assert OrmBuild.requested() is OrmBuild.AUTO
+
+    def test_a_choice_joined_to_the_option_is_read(self):
+        stated = OrmBuild.stated_on(
+            [PYTEST_COMMAND, f"{ORM_BUILD_OPTION}={OrmBuild.NEVER}"]
+        )
+
+        assert stated is OrmBuild.NEVER
+
+    def test_a_choice_following_the_option_is_read(self):
+        stated = OrmBuild.stated_on([PYTEST_COMMAND, ORM_BUILD_OPTION, OrmBuild.ALWAYS])
+
+        assert stated is OrmBuild.ALWAYS
+
+    def test_a_command_line_without_the_option_states_nothing(self):
+        assert OrmBuild.stated_on([PYTEST_COMMAND, "-q", "test"]) is None
+
+    def test_the_environment_states_a_choice_for_runs_that_state_none(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(sys, "argv", [PYTEST_COMMAND])
+        monkeypatch.setenv(PytestEnvironmentVariable.ORM_BUILD, OrmBuild.NEVER)
+
+        assert OrmBuild.requested() is OrmBuild.NEVER
+
+    def test_a_stated_choice_beats_the_environment(self, monkeypatch):
+        monkeypatch.setattr(
+            sys, "argv", [PYTEST_COMMAND, f"{ORM_BUILD_OPTION}={OrmBuild.ALWAYS}"]
+        )
+        monkeypatch.setenv(PytestEnvironmentVariable.ORM_BUILD, OrmBuild.NEVER)
+
+        assert OrmBuild.requested() is OrmBuild.ALWAYS
+
+    def test_an_abbreviated_option_is_read(self):
+        stated = OrmBuild.stated_on(
+            [PYTEST_COMMAND, f"{ABBREVIATED_OPTION}={OrmBuild.NEVER}"]
+        )
+
+        assert stated is OrmBuild.NEVER
+
+    def test_the_registered_option_and_the_one_the_build_read_agree(
+        self, pytestconfig: pytest.Config
+    ):
+        """
+        Pytest parses the option after the conftests have already built, so the two
+        readings of this run's command line must not be able to drift apart.
+        """
+        registered = pytestconfig.getoption(ORM_BUILD_OPTION)
+
+        expected = None if registered is None else OrmBuild(registered)
+        assert OrmBuild.stated_on(sys.argv) is expected
+
+
+class TestARunStatingAChoiceThatDoesNotExist:
+    """
+    The conftests read the choice before pytest parses the command line, so a choice
+    pytest would reject has to be rejected here as well, rather than crashing the import
+    or paying for a build the run is about to abandon.
+    """
+
+    def test_the_option_without_a_choice_is_rejected(self):
+        with pytest.raises(MissingOrmBuildChoiceError):
+            OrmBuild.stated_on([PYTEST_COMMAND, ORM_BUILD_OPTION])
+
+    def test_a_choice_the_option_does_not_offer_is_rejected(self):
+        with pytest.raises(UnknownOrmBuildChoiceError):
+            OrmBuild.stated_on([PYTEST_COMMAND, f"{ORM_BUILD_OPTION}={UNKNOWN_CHOICE}"])
+
+    def test_a_choice_the_environment_does_not_offer_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", [PYTEST_COMMAND])
+        monkeypatch.setenv(PytestEnvironmentVariable.ORM_BUILD, UNKNOWN_CHOICE)
+
+        with pytest.raises(UnknownOrmBuildChoiceError):
+            OrmBuild.requested()
+
+
+class TestARunThatBuildsNothing:
+    """
+    A run told not to build reads whatever interfaces the checkout holds.
+    """
+
+    def test_it_leaves_the_interfaces_alone(self, monkeypatch, recorded_builds):
+        monkeypatch.delenv(PytestEnvironmentVariable.XDIST_WORKER, raising=False)
+        monkeypatch.setattr(
+            sys, "argv", [PYTEST_COMMAND, f"{ORM_BUILD_OPTION}={OrmBuild.NEVER}"]
+        )
+
+        assert regenerate_orm_interfaces() is False
+        assert recorded_builds == []

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
@@ -26,7 +26,7 @@ from cognitive_robot_abstract_machine.orm_interfaces import (
     WorkspaceOrmInterfaces,
 )
 
-from .dataset import failing_generate_orm, generate_orm
+from .dataset import failing_generate_orm, generate_orm, mapped_module
 
 # %% a checkout of packages that generate an interface
 
@@ -40,11 +40,17 @@ STALE_INTERFACE_CONTENT = "# interface of a previous run\n"
 Content the interfaces of the checkout hold before it is regenerated.
 """
 
+SOURCE_MODULE_NAME = Path(mapped_module.__file__).name
+"""
+Name of the module of a package whose classes its interface maps.
+"""
+
 
 @pytest.fixture
 def checkout(tmp_path: Path) -> Path:
     """
-    A git checkout of two packages whose interfaces hold content of a previous run.
+    A git checkout of two packages whose interfaces hold content of a previous run,
+    beside the mapping engine every one of their generators reads.
     """
     for package_name in PACKAGE_NAMES:
         package_root = tmp_path / package_name
@@ -56,6 +62,14 @@ def checkout(tmp_path: Path) -> Path:
         interface = generate_orm.interface_of(package_root)
         interface.parent.mkdir(parents=True)
         interface.write_text(STALE_INTERFACE_CONTENT, encoding="utf-8")
+        shutil.copy(
+            Path(mapped_module.__file__), interface.parent.parent / SOURCE_MODULE_NAME
+        )
+
+    for source_folder in orm_interfaces.MAPPING_ENGINE_SOURCE_FOLDERS:
+        mapping_engine = tmp_path / source_folder
+        mapping_engine.mkdir(parents=True)
+        shutil.copy(Path(mapped_module.__file__), mapping_engine / SOURCE_MODULE_NAME)
 
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(
@@ -336,3 +350,96 @@ def test_a_build_showing_generator_output_keeps_no_bar(
     progress = orm_interfaces.BuildProgress(len(PACKAGE_NAMES), True)
     with progress:
         assert progress.bar is None
+
+
+# %% interfaces their sources have outrun
+
+
+def change_after_the_build(path: Path, interface: OrmInterface) -> None:
+    """
+    Give a file a modification time later than the interface's, as an edit made after
+    the build would.
+
+    :param path: The file to mark as changed.
+    :param interface: The interface the change comes after.
+    """
+    changed_at = interface.path.stat().st_mtime + 1
+    os.utime(path, (changed_at, changed_at))
+
+
+def test_a_freshly_built_checkout_is_current(workspace: WorkspaceOrmInterfaces):
+    workspace.regenerate()
+
+    assert workspace.is_outdated is False
+
+
+def test_a_missing_interface_is_outdated(workspace: WorkspaceOrmInterfaces):
+    workspace.regenerate()
+    workspace.interfaces[-1].remove()
+
+    assert workspace.interfaces[-1].is_outdated is True
+    assert workspace.is_outdated is True
+
+
+def test_a_changed_module_outdates_the_interface_of_its_package(
+    workspace: WorkspaceOrmInterfaces,
+):
+    workspace.regenerate()
+    interface = workspace.interfaces[0]
+
+    change_after_the_build(interface.sources / SOURCE_MODULE_NAME, interface)
+
+    assert interface.is_outdated is True
+
+
+def test_a_changed_module_leaves_the_interface_of_another_package_alone(
+    workspace: WorkspaceOrmInterfaces,
+):
+    workspace.regenerate()
+    interface = workspace.interfaces[0]
+
+    change_after_the_build(interface.sources / SOURCE_MODULE_NAME, interface)
+
+    assert workspace.interfaces[-1].is_outdated is False
+
+
+def test_a_changed_mapping_engine_module_outdates_every_interface(
+    workspace: WorkspaceOrmInterfaces,
+):
+    """
+    Every generator reads the library that maps the classes, so a change to it leaves no
+    interface of the checkout current.
+    """
+    workspace.regenerate()
+    interface = workspace.interfaces[0]
+
+    for source_folder in interface.mapping_engine_sources:
+        change_after_the_build(source_folder / SOURCE_MODULE_NAME, interface)
+
+    assert all(member.is_outdated for member in workspace.interfaces)
+    assert workspace.is_outdated is True
+
+
+def test_a_changed_generator_outdates_the_interface_it_writes(
+    workspace: WorkspaceOrmInterfaces,
+):
+    workspace.regenerate()
+    interface = workspace.interfaces[0]
+
+    change_after_the_build(interface.generator, interface)
+
+    assert interface.is_outdated is True
+
+
+def test_a_missing_generator_leaves_its_interface_outdated(
+    workspace: WorkspaceOrmInterfaces,
+):
+    """
+    A checkout that cannot build an interface is never current, so the build runs and
+    reports the missing generator rather than being skipped.
+    """
+    workspace.regenerate()
+    interface = workspace.interfaces[0]
+    interface.generator.unlink()
+
+    assert interface.is_outdated is True

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -168,8 +168,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ORM_BUILD_OPTION,
         choices=OrmBuild.choices(),
         default=None,
-        help="when to build the generated ORM interfaces; "
-        + ", ".join(f"'{choice}' {choice.description}" for choice in OrmBuild),
+        help=(
+            "when to build the generated ORM interfaces; "
+            f"'{OrmBuild.AUTO}' builds only what the checkout has not built since its "
+            f"sources changed, '{OrmBuild.ALWAYS}' builds every run, whatever the "
+            f"checkout holds, '{OrmBuild.NEVER}' builds nothing, and reads whatever the "
+            "checkout holds"
+        ),
     )
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,7 @@ from semantic_digital_twin.world_description.degree_of_freedom import (
     DegreeOfFreedomLimits,
 )
 
+from .orm_interface_build import ORM_BUILD_OPTION, OrmBuild
 from .pytest_environment import PytestEnvironmentVariable
 
 try:
@@ -152,6 +153,24 @@ The structure of fixtures in this conftest:
         after the test since there is no good method to reset the model after a test has changed it. 
 
 """
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """
+    Let a run state when it builds the ORM interfaces it reads.
+
+    ..note:: Registering the option is what lets a run state it and read it in ``--help``.
+        The build itself happens while pytest is still importing the conftests, before it
+        has parsed anything, so :meth:`OrmBuild.requested` reads the choice off the
+        arguments as they were given rather than off the parsed configuration.
+    """
+    parser.addoption(
+        ORM_BUILD_OPTION,
+        choices=OrmBuild.choices(),
+        default=None,
+        help="when to build the generated ORM interfaces; "
+        + ", ".join(f"'{choice}' {choice.description}" for choice in OrmBuild),
+    )
 
 
 def pytest_configure(config):

--- a/test/orm_interface_build.py
+++ b/test/orm_interface_build.py
@@ -62,23 +62,20 @@ class OrmBuild(StrEnum):
     When a run builds the ORM interfaces it reads.
     """
 
-    description: str
+    AUTO = "auto"
     """
-    What this choice does, as the help of the option says it.
+    Builds only what the checkout has not built since its sources changed.
     """
 
-    def __new__(cls, value: str, description: str) -> OrmBuild:
-        choice = str.__new__(cls, value)
-        choice._value_ = value
-        choice.description = description
-        return choice
+    ALWAYS = "always"
+    """
+    Builds every run, whatever the checkout holds.
+    """
 
-    AUTO = (
-        "auto",
-        "builds only what the checkout has not built since its sources changed",
-    )
-    ALWAYS = ("always", "builds every run, whatever the checkout holds")
-    NEVER = ("never", "builds nothing, and reads whatever the checkout holds")
+    NEVER = "never"
+    """
+    Builds nothing, and reads whatever the checkout holds.
+    """
 
     @classmethod
     def choices(cls) -> Tuple[str, ...]:

--- a/test/orm_interface_build.py
+++ b/test/orm_interface_build.py
@@ -4,22 +4,165 @@ Building the ORM interfaces a test run needs.
 Every package's ``ormatic_interface.py`` is generated rather than tracked, so a checkout
 holds none until something builds them. Only the packages whose tests read a mapped
 datastructure call this; the rest never pay for a build they would not read.
+
+A build takes about a minute, so a run only pays for it when the checkout has not built
+its interfaces since the sources changed. ``--orm-build`` overrides that.
 """
 
 from __future__ import annotations
 
 import os
+import sys
+from enum import StrEnum
 from functools import cache
 
-from cognitive_robot_abstract_machine.orm_interfaces import WORKSPACE_ORM_INTERFACES
+from typing_extensions import Optional, Sequence, Tuple
+
+from cognitive_robot_abstract_machine.exceptions import (
+    MissingOrmBuildChoiceError,
+    UnknownOrmBuildChoiceError,
+)
+from cognitive_robot_abstract_machine.orm_interfaces import (
+    WORKSPACE_ORM_INTERFACES,
+    WorkspaceOrmInterfaces,
+)
 
 from .pytest_environment import PytestEnvironmentVariable
+
+ORM_BUILD_OPTION = "--orm-build"
+"""
+The command line option a run states its choice with.
+"""
+
+OPTION_MARKER = "--"
+"""
+What a long option begins with, and the shortest an abbreviation of one can get.
+"""
+
+CHOICE_SEPARATOR = "="
+"""
+What joins a choice to the option on a command line.
+"""
+
+
+def names_the_orm_build_option(argument: str) -> bool:
+    """
+    Whether an argument names the option, spelled in full or cut short the way argparse
+    lets a run abbreviate a long option.
+
+    :param argument: The argument, with any choice joined to it already taken off.
+    """
+    if len(argument) <= len(OPTION_MARKER):
+        return False
+    return ORM_BUILD_OPTION.startswith(argument)
+
+
+class OrmBuild(StrEnum):
+    """
+    When a run builds the ORM interfaces it reads.
+    """
+
+    description: str
+    """
+    What this choice does, as the help of the option says it.
+    """
+
+    def __new__(cls, value: str, description: str) -> OrmBuild:
+        choice = str.__new__(cls, value)
+        choice._value_ = value
+        choice.description = description
+        return choice
+
+    AUTO = (
+        "auto",
+        "builds only what the checkout has not built since its sources changed",
+    )
+    ALWAYS = ("always", "builds every run, whatever the checkout holds")
+    NEVER = ("never", "builds nothing, and reads whatever the checkout holds")
+
+    @classmethod
+    def choices(cls) -> Tuple[str, ...]:
+        """
+        The choices a run can state, in the order the help of the option lists them.
+        """
+        return tuple(choice.value for choice in cls)
+
+    @classmethod
+    def named(cls, choice: str, source: str) -> OrmBuild:
+        """
+        Read the choice a value names.
+
+        :param choice: The value to read.
+        :param source: Where it was read, for a rejection to name.
+        :return: The choice it names.
+        :raises UnknownOrmBuildChoiceError: If it names none.
+        """
+        if choice not in cls.choices():
+            raise UnknownOrmBuildChoiceError(source, choice, cls.choices())
+        return cls(choice)
+
+    @classmethod
+    def stated_on(cls, arguments: Sequence[str]) -> Optional[OrmBuild]:
+        """
+        Read the choice a command line states, in either of the spellings argparse
+        accepts.
+
+        :param arguments: The arguments the run was started with.
+        :return: The choice they state, or nothing if they state none.
+        :raises MissingOrmBuildChoiceError: If they name the option and stop there.
+        :raises UnknownOrmBuildChoiceError: If they state a choice that does not exist.
+        """
+        for position, argument in enumerate(arguments):
+            option, separator, choice = argument.partition(CHOICE_SEPARATOR)
+            if not names_the_orm_build_option(option):
+                continue
+            if separator:
+                return cls.named(choice, option)
+            if position + 1 == len(arguments):
+                raise MissingOrmBuildChoiceError(option, cls.choices())
+            return cls.named(arguments[position + 1], option)
+        return None
+
+    @classmethod
+    def requested(cls) -> OrmBuild:
+        """
+        Read the choice this run was started with, taking the command line over the
+        environment.
+
+        ..note:: The conftests build while pytest is still importing them, before it has
+            parsed the command line, so the arguments are read as they were given.
+
+        :raises MissingOrmBuildChoiceError: If the command line names the option and
+            stops there.
+        :raises UnknownOrmBuildChoiceError: If either states a choice that does not
+            exist.
+        """
+        stated = cls.stated_on(sys.argv)
+        if stated is not None:
+            return stated
+        stated_in_environment = os.environ.get(PytestEnvironmentVariable.ORM_BUILD)
+        if stated_in_environment is None:
+            return cls.AUTO
+        return cls.named(stated_in_environment, PytestEnvironmentVariable.ORM_BUILD)
+
+    def builds(self, interfaces: WorkspaceOrmInterfaces) -> bool:
+        """
+        Whether this choice has the given interfaces built.
+
+        :param interfaces: The interfaces of the checkout under test.
+        """
+        if self is OrmBuild.NEVER:
+            return False
+        if self is OrmBuild.ALWAYS:
+            return True
+        return interfaces.is_outdated
 
 
 @cache
 def regenerate_orm_interfaces() -> bool:
     """
-    Build the ORM interfaces of this checkout, once per process and never on a worker.
+    Build the ORM interfaces of this checkout, as far as the run asked for, once per
+    process and never on a worker.
 
     The controller imports the conftests before it starts any worker, so building there
     leaves the interfaces on disk by the time a worker imports a mapped datastructure.
@@ -30,6 +173,8 @@ def regenerate_orm_interfaces() -> bool:
     :return: Whether this call built them.
     """
     if os.environ.get(PytestEnvironmentVariable.XDIST_WORKER):
+        return False
+    if not OrmBuild.requested().builds(WORKSPACE_ORM_INTERFACES):
         return False
     WORKSPACE_ORM_INTERFACES.regenerate()
     return True

--- a/test/pytest_environment.py
+++ b/test/pytest_environment.py
@@ -1,5 +1,5 @@
 """
-What pytest tells the processes of a run about themselves.
+What the processes of a test run read about the run they belong to.
 """
 
 from __future__ import annotations
@@ -9,10 +9,16 @@ from enum import StrEnum
 
 class PytestEnvironmentVariable(StrEnum):
     """
-    Environment variables pytest sets for the processes of a run.
+    Environment variables the processes of a run read.
     """
 
     XDIST_WORKER = "PYTEST_XDIST_WORKER"
     """
     Names the xdist worker a process is; absent in the controller.
+    """
+
+    ORM_BUILD = "CRAM_ORM_BUILD"
+    """
+    Names when the run builds the ORM interfaces, for runs that state no ``--orm-build``
+    on their command line; absent, a run builds what is outdated.
     """


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul to how ORM interface builds are managed, tested, and configured in the project. The changes also update documentation to reflect the new workflow and provide improved fixtures and utilities for testing.

* Added the `OrmBuild` enum and related logic, allowing test runs to specify when ORM interfaces should be built using the `--orm-build` option or the `CRAM_ORM_BUILD` environment variable. This enables three modes: always, never, or auto (only when sources have changed). 
* Implemented properties and methods in `OrmInterface` and `WorkspaceOrmInterfaces` to determine if interfaces are outdated based on their source files, mapping engine dependencies, and generators. 