### PR TITLE
Add distribution_of/probability_of EQL constructs, reuse average() for expectations

### DIFF
--- a/krrood/doc/eql/user/probabilistic_queries.md
+++ b/krrood/doc/eql/user/probabilistic_queries.md
@@ -13,66 +13,47 @@ kernelspec:
 
 # Probabilistic Queries
 
-Sometimes a query should not return rows at all, but something *about* the
-distribution those rows would have come from -- the distribution itself, the
-probability of a condition, or the expectation of an attribute. `set_of`/`entity`
-always resolve to enumerated results; instead:
-
-| Read as... | Construct | Resolves to |
-|---|---|---|
-| "the distribution of ..." | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a `ProbabilisticModel` |
-| "the probability of ..." | {py:func}`~krrood.entity_query_language.factories.probability_of` | a `float` |
-| "the average of ..." | {py:func}`~krrood.entity_query_language.factories.average` (already existing) | a `float` |
-
-Like `cause`/`confounder` (see {doc}`causality`), `distribution_of`/`probability_of`
-only mean anything under
-{py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`: querying a
-probabilistic model directly is a probabilistic operation, not a data selection, so
-neither has a native or SQL evaluation strategy at all -- evaluating either any other
-way raises
-{py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`.
-`average(...)` is different: it already has an ordinary native meaning (the mean of
-enumerated rows), and `ProbabilisticBackend` recognizes a *bare* `average(...)`
-selection and answers it in closed form instead -- same call, correct answer under
-either backend.
-
-## `distribution_of`: the probabilistic interpretation of `a`/`an`/`the`
-
-{py:func}`~krrood.entity_query_language.factories.a` already builds a
-{py:class}`~krrood.entity_query_language.query.match.Match` that
-{py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend` conditions and
-truncates before *sampling* instances from it -- literal-valued kwargs condition the
-circuit, `.where(...)` conditions truncate it, and underspecified (`...`) fields are
-the free variables it samples.
-{py:func}`~krrood.entity_query_language.factories.distribution_of` asks for exactly
-that same conditioned-and-truncated model, just returned directly instead of sampled
-from:
+Mira runs quality control at a coin mint. Every coin that comes off the press gets
+measured by three sensors -- diameter, thickness, and weight -- and the mint has
+already fitted a probabilistic model to a long history of these measurements: given
+how the press was set up on a given run, what do the resulting coins tend to look
+like? Mira doesn't build that model herself; she just has questions for it.
 
 ```python
 from dataclasses import dataclass
 
+@dataclass
+class Coin:
+    a: float  # diameter
+    b: float  # thickness
+    c: float  # weight
+```
+
+`set_of`/`entity` answer questions about *actual coins* -- "find me the coins whose
+diameter is under spec". Mira's questions today are different: not about which coins
+exist, but about the *model itself*. Three constructs answer that kind of question:
+
+| Mira's question reads as... | Construct | Answer |
+|---|---|---|
+| "On average, how wide are the coins?" | {py:func}`~krrood.entity_query_language.factories.average` | a number |
+| "What fraction of coins are dangerously thin?" | {py:func}`~krrood.entity_query_language.factories.probability_of` | a number |
+| "Given today's press settings, what does the shape of the remaining measurements look like?" | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a distribution |
+
+All three need the fitted model to answer, so they only work when evaluated with
+{py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`, the backend
+that knows how to reach it:
+
+```python
 from probabilistic_model.distributions.uniform import UniformDistribution
 from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
     ProbabilisticCircuit, ProductUnit, leaf,
 )
 from random_events.interval import closed
-from random_events.product_algebra import SimpleEvent
 from random_events.variable import Continuous
 
-from krrood.entity_query_language.backends import ProbabilisticBackend
-from krrood.entity_query_language.factories import a, average, distribution_of, probability_of
-from krrood.parametrization.model_registries import DictRegistry
-
-
-@dataclass
-class Coin:
-    a: float
-    b: float
-    c: float
-
-
-# Named "Coin.<field>" up front, the same convention used in the causality example, so
-# DictRegistry can look each field up by its qualified name.
+# Stand-in for the mint's already-fitted model: today's press run, in isolation,
+# produces diameter/thickness/weight uniformly across a range each. (Named
+# "Coin.<field>" so DictRegistry -- see below -- can look each field up by name.)
 var_a = Continuous("Coin.a")
 var_b = Continuous("Coin.b")
 var_c = Continuous("Coin.c")
@@ -83,8 +64,60 @@ root.add_subcircuit(leaf(UniformDistribution(variable=var_a, interval=closed(0, 
 root.add_subcircuit(leaf(UniformDistribution(variable=var_b, interval=closed(0, 2).simple_sets[0]), circuit))
 root.add_subcircuit(leaf(UniformDistribution(variable=var_c, interval=closed(0, 3).simple_sets[0]), circuit))
 
-backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.factories import a, average, distribution_of, probability_of, variable
+from krrood.parametrization.model_registries import DictRegistry
 
+backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+```
+
+## "On average, how wide are the coins?"
+
+The simplest question, and it uses a construct Mira already knows -- `average`, the
+same one that averages a column of matched rows. Called *bare* (no `set_of`, no
+`.grouped_by()`) against a model-backed backend, it answers straight from the model
+instead of averaging a sample of rows:
+
+```python
+x = variable(Coin)
+print(average(x.a).first(backend=backend))
+# 0.5
+```
+
+That's it -- same function Mira would use in an ordinary query, just pointed at a
+model instead of a table of coins.
+
+## "What fraction of coins are dangerously thin?"
+
+Suppose anything under 0.5 fails inspection.
+
+```python
+x = variable(Coin)
+print(probability_of(x.a < 0.5).first(backend=backend))
+# 0.5
+```
+
+There's a simpler way to think about this that Mira already knows from ordinary
+querying: take a big batch of coins, count how many have diameter under 0.5, divide by
+how many coins there are. That *is* what a probability means, and it's a perfectly
+valid way to estimate one. `probability_of` doesn't do that, though -- there's no batch
+of coins involved at all. It reads the answer directly off the fitted model, so
+instead of an estimate that gets better with a bigger batch, Mira gets the exact
+number the model implies, every time.
+
+## "Given today's press settings, what does the rest look like?"
+
+The press was calibrated to punch out 1.5g coins today, and Mira has already screened
+out anything under the 0.2 diameter minimum. She's not asking for a number now -- she
+wants to see the *shape* of what's left: how thickness and diameter vary once weight
+is pinned down and the too-narrow coins are gone.
+
+This is exactly the kind of thing `a(...)`/`an(...)`/`the(...)` already describe --
+Mira would normally write this same shape of match to *generate* example coins that
+fit these settings. `distribution_of` asks the identical question, just answered
+differently: instead of generating coins, it hands back the distribution itself.
+
+```python
 match = a(Coin)(a=..., b=..., c=1.5)
 match.where(match.variable.a > 0.2)
 
@@ -93,22 +126,24 @@ print(sorted(v.name for v in result.variables))
 # ['Coin.a', 'Coin.b', 'Coin.c']
 ```
 
-`c=1.5` conditions the circuit (`c` stays in the model, but as a point mass at 1.5 --
-conditioning doesn't drop the variable, it collapses its distribution); `a > 0.2`
-truncates it; `b` is free and untouched, since it's independent of `a`/`c`:
+`c=1.5` is the press setting; `.where(a > 0.2)` is the screening step; `a`/`b`
+(diameter/thickness) are left open (`...`) -- what Mira wants to see the shape of.
+The result is an ordinary distribution object, queryable like the mint's original
+model:
 
 ```python
+from random_events.product_algebra import SimpleEvent
+
 a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()
 print(result.probability(a_range))
-# 1.0 -- everything left satisfies a > 0.2
+# 1.0 -- everything left satisfies a > 0.2, by construction
 
 b_range = SimpleEvent.from_data({var_b: closed(0, 1)}).as_composite_set()
 print(result.probability(b_range))
-# 0.5 -- unchanged, b is independent of a and c
+# 0.5 -- unchanged: thickness never depended on diameter or weight to begin with
 ```
 
-Pass extra `*variables` to narrow the result to a subset of the match's free variables
-(further marginalization) -- e.g. just `a`, dropping `b` and the now-degenerate `c`:
+If Mira only cares about diameter specifically, she can ask for just that:
 
 ```python
 narrowed = distribution_of(match, match.variable.a).first(backend=backend)
@@ -116,105 +151,21 @@ print({v.name for v in narrowed.variables})
 # {'Coin.a'}
 ```
 
-## `probability_of`
+## Recap
 
-Unlike `distribution_of`, this doesn't wrap a `Match` -- it takes a bare condition
-directly, any expression a `.where(...)` condition already accepts (comparators
-combined with `and_`/`or_`/`not_`, ranges, ...):
+- **`average(x.a)`** -- the same aggregator used for row-averaging, pointed at a model
+  instead of a table; answers with the model's exact expectation.
+- **`probability_of(condition)`** -- the exact answer a "count matching rows / count
+  all rows" estimate is aiming for, computed directly from the model instead of
+  estimated from a sample. Accepts any condition a `.where(...)` clause does.
+- **`distribution_of(match, *variables)`** -- the same match Mira would write to
+  *generate* coins, answered with the shape of the distribution instead of samples
+  from it. Optional `*variables` narrow which measurements the answer covers.
 
-```python
-p = probability_of(match.variable.a < 0.5).first(backend=backend)
-print(p)
-# 0.5
-```
-
-## `average`: the expectation, via the construct EQL already has
-
-There's no separate "expectation" construct. The existing
-{py:func}`~krrood.entity_query_language.factories.average` aggregator -- the same one
-used inside `set_of(...)`/`entity(...)` to average enumerated rows -- already reads
-declaratively as "the average of ...", so `ProbabilisticBackend` reuses it directly:
-evaluated bare (no `set_of`, `.grouped_by()`, `.where()`, ...), it resolves in closed
-form via `ProbabilisticModel.moment` instead of sampling and averaging rows:
-
-```python
-expectation_a = average(match.variable.a).first(backend=backend)
-print(expectation_a)
-# 0.5 -- midpoint of Uniform([0, 1])
-```
-
-The same call against an ordinary (non-probabilistic) backend still does the ordinary
-thing -- averages enumerated values:
-
-```python
-from krrood.entity_query_language.factories import variable
-
-heights = [1, 2, 3, 4, 5]
-heights_var = variable(int, domain=heights)
-print(average(heights_var).first())
-# 3.0
-```
-
-Grouped, filtered, or otherwise-modified `average(...)` calls are *not* reinterpreted
-probabilistically -- there's no enumerated data to group over from a bare
-`variable(...)`, so `ProbabilisticBackend` falls through to its ordinary
-generative-backend error rather than silently ignoring the grouping.
-
-## Scope
-
-- **`distribution_of`/`probability_of`: evaluate with `ProbabilisticBackend` only.**
-  Evaluating either natively, or with any other backend, always raises
-  {py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`.
-- **`probability_of`: one class per query.** Every attribute a condition constrains
-  must be reached from the same `variable(...)` root -- e.g. `probability_of(and_(x.a
-  < 5, y.b < 5))` for two different classes' variables raises
-  {py:class}`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`,
-  since every {py:class}`~krrood.parametrization.model_registries.ModelRegistry`
-  resolves a single model per class. `distribution_of(...)` never raises this: it
-  wraps a single `Match`, which is always for one class by construction.
-- **`average`: only a bare selection is reinterpreted.** `average(x.a)` evaluated
-  directly; anything with `.grouped_by()`/`.where()`/etc. attached falls through to
-  the ordinary (non-probabilistic) evaluation path.
-
-## Verbalization
-
-`distribution_of`/`probability_of` are also verbalizable, via
-{py:func}`~krrood.entity_query_language.verbalization.pipeline.verbalize_expression`
-(see {doc}`verbalization`). `distribution_of(match)` reuses the match's own `given
-that`/`where` grammar, with two changes from the match's own rendering: its imperative
-*"Find"*/*"Generate"* header becomes a definite *"The distribution over …"* (a
-distribution is asked for, not rows, so it takes neither verb), and its underspecified
-(`...`) fields -- the distribution's free variables -- aren't named at all, unlike the
-match's own generative *"and predict its battery value"* clause: *"the distribution
-over a Coin"* already means "over every attribute not given", so a query that just
-selects everything (`a(Coin)(a=..., b=..., c=...)`) verbalizes as plainly as *"The
-distribution over a Coin"*. When `*variables` marginalizes that default to a subset,
-they're named directly in the subject instead (*"the a of a Coin"*) rather than a
-trailing qualifier like *"restricted to …"*, which reads like a truncation (a `where`)
-rather than a choice of which variables the joint is even over.
-`probability_of(condition)` recurses the condition through the ordinary comparator
-grammar, prefixed with *"the probability that …"*. `average(...)` needs no
-verbalization changes: it's an ordinary aggregator node already verbalized (*"the
-average of …"*) regardless of which backend will evaluate it.
-
-```python
-from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
-
-match = a(Coin)(a=..., b=..., c=1.5)
-match.where(match.variable.a > 0.2)
-
-print(verbalize_expression(distribution_of(match)))
-# "The distribution over a Coin given that its c is 1.5, where its a is greater
-#  than 0.2"
-
-print(verbalize_expression(distribution_of(match, match.variable.a)))
-# "The distribution over the a of a Coin given that its c is 1.5, where its a is
-#  greater than 0.2"
-
-x = variable(Coin)
-print(verbalize_expression(probability_of(x.a < 0.5)))
-# "the probability that the a of a Coin is less than 0.5"
-```
+All three only work with a probabilistic backend behind them -- there's no table of
+rows to fall back to, only the model. And two of the names should look familiar
+already: `distribution_of`/`average` are how `a(...)`/`an(...)`/`the(...)` and
+`average(...)` already read, just answered from a different place.
 
 ---
 
@@ -229,7 +180,6 @@ print(verbalize_expression(probability_of(x.a < 0.5)))
 - {py:class}`~krrood.entity_query_language.operators.aggregators.Average`
 - {py:meth}`~krrood.entity_query_language.backends.ProbabilisticBackend._resolve_average`
 - {py:meth}`~krrood.parametrization.parameterizer.UnderspecifiedParameters.resolve_conditioned_and_truncated_model`
-- {py:class}`~krrood.parametrization.parameterizer.SelectedAttributesParameters`
-- {py:class}`~krrood.parametrization.parameterizer.ConditionParameters`
+- {py:class}`~krrood.parametrization.parameterizer.ModelQueryParameters`
 - {py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`
 - {py:class}`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`

--- a/krrood/doc/eql/user/probabilistic_queries.md
+++ b/krrood/doc/eql/user/probabilistic_queries.md
@@ -164,7 +164,7 @@ print(result.probability(temperature_range))
 To narrow down to temperature specifically:
 
 ```python
-narrowed = distribution_of(match, match.variable.temperature).first(backend=backend)
+narrowed = distribution_of(match, marginalize_for=(match.variable.temperature,)).first(backend=backend)
 print({v.name for v in narrowed.variables})
 # {'Robot.temperature'}
 ```
@@ -177,11 +177,11 @@ print({v.name for v in narrowed.variables})
 - **`probability_of(condition)`** -- counts a real fleet's matching robots when one is
   on hand, or reads the exact answer straight off the model when there's only a fitted
   model. Accepts any condition a `.where(...)` clause does.
-- **`distribution_of(match, *variables)`** -- the same match that would normally
-  *generate* robots, answered with the shape of the distribution instead of samples
-  from it. Optional `*variables` narrow which readings the answer covers. Unlike the
-  other two, there's no batch-counting equivalent for a whole distribution, so this
-  one only ever works with a fitted model behind it.
+- **`distribution_of(match, marginalize_for=...)`** -- the same match that would
+  normally *generate* robots, answered with the shape of the distribution instead of
+  samples from it. Optional `marginalize_for` narrows which readings the answer
+  covers. Unlike the other two, there's no batch-counting equivalent for a whole
+  distribution, so this one only ever works with a fitted model behind it.
 
 Two of the names should look familiar already: `distribution_of`/`average` are how
 `a(...)`/`an(...)`/`the(...)` and `average(...)` already read, just capable of being

--- a/krrood/doc/eql/user/probabilistic_queries.md
+++ b/krrood/doc/eql/user/probabilistic_queries.md
@@ -1,0 +1,235 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Probabilistic Queries
+
+Sometimes a query should not return rows at all, but something *about* the
+distribution those rows would have come from -- the distribution itself, the
+probability of a condition, or the expectation of an attribute. `set_of`/`entity`
+always resolve to enumerated results; instead:
+
+| Read as... | Construct | Resolves to |
+|---|---|---|
+| "the distribution of ..." | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a `ProbabilisticModel` |
+| "the probability of ..." | {py:func}`~krrood.entity_query_language.factories.probability_of` | a `float` |
+| "the average of ..." | {py:func}`~krrood.entity_query_language.factories.average` (already existing) | a `float` |
+
+Like `cause`/`confounder` (see {doc}`causality`), `distribution_of`/`probability_of`
+only mean anything under
+{py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`: querying a
+probabilistic model directly is a probabilistic operation, not a data selection, so
+neither has a native or SQL evaluation strategy at all -- evaluating either any other
+way raises
+{py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`.
+`average(...)` is different: it already has an ordinary native meaning (the mean of
+enumerated rows), and `ProbabilisticBackend` recognizes a *bare* `average(...)`
+selection and answers it in closed form instead -- same call, correct answer under
+either backend.
+
+## `distribution_of`: the probabilistic interpretation of `a`/`an`/`the`
+
+{py:func}`~krrood.entity_query_language.factories.a` already builds a
+{py:class}`~krrood.entity_query_language.query.match.Match` that
+{py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend` conditions and
+truncates before *sampling* instances from it -- literal-valued kwargs condition the
+circuit, `.where(...)` conditions truncate it, and underspecified (`...`) fields are
+the free variables it samples.
+{py:func}`~krrood.entity_query_language.factories.distribution_of` asks for exactly
+that same conditioned-and-truncated model, just returned directly instead of sampled
+from:
+
+```python
+from dataclasses import dataclass
+
+from probabilistic_model.distributions.uniform import UniformDistribution
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit, ProductUnit, leaf,
+)
+from random_events.interval import closed
+from random_events.product_algebra import SimpleEvent
+from random_events.variable import Continuous
+
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.factories import a, average, distribution_of, probability_of
+from krrood.parametrization.model_registries import DictRegistry
+
+
+@dataclass
+class Coin:
+    a: float
+    b: float
+    c: float
+
+
+# Named "Coin.<field>" up front, the same convention used in the causality example, so
+# DictRegistry can look each field up by its qualified name.
+var_a = Continuous("Coin.a")
+var_b = Continuous("Coin.b")
+var_c = Continuous("Coin.c")
+
+circuit = ProbabilisticCircuit()
+root = ProductUnit(probabilistic_circuit=circuit)
+root.add_subcircuit(leaf(UniformDistribution(variable=var_a, interval=closed(0, 1).simple_sets[0]), circuit))
+root.add_subcircuit(leaf(UniformDistribution(variable=var_b, interval=closed(0, 2).simple_sets[0]), circuit))
+root.add_subcircuit(leaf(UniformDistribution(variable=var_c, interval=closed(0, 3).simple_sets[0]), circuit))
+
+backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+match = a(Coin)(a=..., b=..., c=1.5)
+match.where(match.variable.a > 0.2)
+
+result = distribution_of(match).first(backend=backend)
+print(sorted(v.name for v in result.variables))
+# ['Coin.a', 'Coin.b', 'Coin.c']
+```
+
+`c=1.5` conditions the circuit (`c` stays in the model, but as a point mass at 1.5 --
+conditioning doesn't drop the variable, it collapses its distribution); `a > 0.2`
+truncates it; `b` is free and untouched, since it's independent of `a`/`c`:
+
+```python
+a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()
+print(result.probability(a_range))
+# 1.0 -- everything left satisfies a > 0.2
+
+b_range = SimpleEvent.from_data({var_b: closed(0, 1)}).as_composite_set()
+print(result.probability(b_range))
+# 0.5 -- unchanged, b is independent of a and c
+```
+
+Pass extra `*variables` to narrow the result to a subset of the match's free variables
+(further marginalization) -- e.g. just `a`, dropping `b` and the now-degenerate `c`:
+
+```python
+narrowed = distribution_of(match, match.variable.a).first(backend=backend)
+print({v.name for v in narrowed.variables})
+# {'Coin.a'}
+```
+
+## `probability_of`
+
+Unlike `distribution_of`, this doesn't wrap a `Match` -- it takes a bare condition
+directly, any expression a `.where(...)` condition already accepts (comparators
+combined with `and_`/`or_`/`not_`, ranges, ...):
+
+```python
+p = probability_of(match.variable.a < 0.5).first(backend=backend)
+print(p)
+# 0.5
+```
+
+## `average`: the expectation, via the construct EQL already has
+
+There's no separate "expectation" construct. The existing
+{py:func}`~krrood.entity_query_language.factories.average` aggregator -- the same one
+used inside `set_of(...)`/`entity(...)` to average enumerated rows -- already reads
+declaratively as "the average of ...", so `ProbabilisticBackend` reuses it directly:
+evaluated bare (no `set_of`, `.grouped_by()`, `.where()`, ...), it resolves in closed
+form via `ProbabilisticModel.moment` instead of sampling and averaging rows:
+
+```python
+expectation_a = average(match.variable.a).first(backend=backend)
+print(expectation_a)
+# 0.5 -- midpoint of Uniform([0, 1])
+```
+
+The same call against an ordinary (non-probabilistic) backend still does the ordinary
+thing -- averages enumerated values:
+
+```python
+from krrood.entity_query_language.factories import variable
+
+heights = [1, 2, 3, 4, 5]
+heights_var = variable(int, domain=heights)
+print(average(heights_var).first())
+# 3.0
+```
+
+Grouped, filtered, or otherwise-modified `average(...)` calls are *not* reinterpreted
+probabilistically -- there's no enumerated data to group over from a bare
+`variable(...)`, so `ProbabilisticBackend` falls through to its ordinary
+generative-backend error rather than silently ignoring the grouping.
+
+## Scope
+
+- **`distribution_of`/`probability_of`: evaluate with `ProbabilisticBackend` only.**
+  Evaluating either natively, or with any other backend, always raises
+  {py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`.
+- **`probability_of`: one class per query.** Every attribute a condition constrains
+  must be reached from the same `variable(...)` root -- e.g. `probability_of(and_(x.a
+  < 5, y.b < 5))` for two different classes' variables raises
+  {py:class}`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`,
+  since every {py:class}`~krrood.parametrization.model_registries.ModelRegistry`
+  resolves a single model per class. `distribution_of(...)` never raises this: it
+  wraps a single `Match`, which is always for one class by construction.
+- **`average`: only a bare selection is reinterpreted.** `average(x.a)` evaluated
+  directly; anything with `.grouped_by()`/`.where()`/etc. attached falls through to
+  the ordinary (non-probabilistic) evaluation path.
+
+## Verbalization
+
+`distribution_of`/`probability_of` are also verbalizable, via
+{py:func}`~krrood.entity_query_language.verbalization.pipeline.verbalize_expression`
+(see {doc}`verbalization`). `distribution_of(match)` reuses the match's own `given
+that`/`where` grammar, with two changes from the match's own rendering: its imperative
+*"Find"*/*"Generate"* header becomes a definite *"The distribution over …"* (a
+distribution is asked for, not rows, so it takes neither verb), and its underspecified
+(`...`) fields -- the distribution's free variables -- aren't named at all, unlike the
+match's own generative *"and predict its battery value"* clause: *"the distribution
+over a Coin"* already means "over every attribute not given", so a query that just
+selects everything (`a(Coin)(a=..., b=..., c=...)`) verbalizes as plainly as *"The
+distribution over a Coin"*. When `*variables` marginalizes that default to a subset,
+they're named directly in the subject instead (*"the a of a Coin"*) rather than a
+trailing qualifier like *"restricted to …"*, which reads like a truncation (a `where`)
+rather than a choice of which variables the joint is even over.
+`probability_of(condition)` recurses the condition through the ordinary comparator
+grammar, prefixed with *"the probability that …"*. `average(...)` needs no
+verbalization changes: it's an ordinary aggregator node already verbalized (*"the
+average of …"*) regardless of which backend will evaluate it.
+
+```python
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
+
+match = a(Coin)(a=..., b=..., c=1.5)
+match.where(match.variable.a > 0.2)
+
+print(verbalize_expression(distribution_of(match)))
+# "The distribution over a Coin given that its c is 1.5, where its a is greater
+#  than 0.2"
+
+print(verbalize_expression(distribution_of(match, match.variable.a)))
+# "The distribution over the a of a Coin given that its c is 1.5, where its a is
+#  greater than 0.2"
+
+x = variable(Coin)
+print(verbalize_expression(probability_of(x.a < 0.5)))
+# "the probability that the a of a Coin is less than 0.5"
+```
+
+---
+
+## API Reference
+
+- {py:func}`~krrood.entity_query_language.factories.distribution_of`
+- {py:func}`~krrood.entity_query_language.factories.probability_of`
+- {py:func}`~krrood.entity_query_language.factories.average`
+- {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.ProbabilisticQuery`
+- {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Distribution`
+- {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
+- {py:class}`~krrood.entity_query_language.operators.aggregators.Average`
+- {py:meth}`~krrood.entity_query_language.backends.ProbabilisticBackend._resolve_average`
+- {py:meth}`~krrood.parametrization.parameterizer.UnderspecifiedParameters.resolve_conditioned_and_truncated_model`
+- {py:class}`~krrood.parametrization.parameterizer.SelectedAttributesParameters`
+- {py:class}`~krrood.parametrization.parameterizer.ConditionParameters`
+- {py:class}`~krrood.entity_query_language.exceptions.BackendCannotEvaluateProbabilisticQuery`
+- {py:class}`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`

--- a/krrood/doc/eql/user/probabilistic_queries.md
+++ b/krrood/doc/eql/user/probabilistic_queries.md
@@ -13,11 +13,11 @@ kernelspec:
 
 # Probabilistic Queries
 
-Nova operates a warehouse robot fleet. Every robot streams back telemetry -- speed,
-motor temperature, battery charge -- and the fleet team has already fitted a
-probabilistic model to a long history of that telemetry: given how a shift starts,
-what do the readings tend to look like over the course of it? Nova doesn't build that
-model; she just has questions for it.
+Consider a warehouse robot fleet. Every robot streams back telemetry -- speed, motor
+temperature, battery charge -- and a probabilistic model has already been fitted to a
+long history of that telemetry: given how a shift starts, what do the readings tend to
+look like over the course of it? Nothing here builds that model; the questions below
+are answered from it.
 
 ```python
 from dataclasses import dataclass
@@ -30,17 +30,17 @@ class Robot:
 ```
 
 `set_of`/`entity` answer questions about *actual robots* -- "find me the robots
-running hot right now". Nova's questions today are different: not about which robots
+running hot right now". The questions below are different: not about which robots
 exist, but about the *model itself*. Three constructs answer that kind of question:
 
-| Nova's question reads as... | Construct | Answer |
+| Question | Construct | Answer |
 |---|---|---|
 | "On average, how fast do robots move?" | {py:func}`~krrood.entity_query_language.factories.average` | a number |
 | "What fraction of robots run dangerously hot?" | {py:func}`~krrood.entity_query_language.factories.probability_of` | a number |
 | "Given today's charge level, what does the rest look like?" | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a distribution |
 
-Nova doesn't have live telemetry yet -- only the fitted model -- so all three
-questions below get answered from it, via
+Without live telemetry on hand -- only the fitted model -- all three questions below
+get answered from it, via
 {py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`, the backend
 that knows how to reach it:
 
@@ -52,8 +52,8 @@ from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
 from random_events.interval import closed
 from random_events.variable import Continuous
 
-# Stand-in for the fleet team's already-fitted model: over a shift, in isolation,
-# each reading varies uniformly across its own range. (Named "Robot.<field>" so
+# Stand-in for the fleet's already-fitted model: over a shift, in isolation, each
+# reading varies uniformly across its own range. (Named "Robot.<field>" so
 # DictRegistry -- see below -- can look each field up by name.)
 var_temperature = Continuous("Robot.temperature")
 var_speed = Continuous("Robot.speed")
@@ -74,10 +74,10 @@ backend = ProbabilisticBackend(model_registry=DictRegistry({Robot: circuit}))
 
 ## "On average, how fast do robots move?"
 
-The simplest question, and it uses a construct Nova already knows -- `average`, the
-same one that averages a column of matched rows. Called *bare* (no `set_of`, no
-`.grouped_by()`) against a model-backed backend, it answers straight from the model
-instead of averaging a sample of rows:
+The simplest question, and it uses a construct already familiar from ordinary
+querying -- `average`, the same one that averages a column of matched rows. Called
+*bare* (no `set_of`, no `.grouped_by()`) against a model-backed backend, it answers
+straight from the model instead of averaging a sample of rows:
 
 ```python
 x = variable(Robot)
@@ -85,8 +85,8 @@ print(average(x.speed).first(backend=backend))
 # 1.0
 ```
 
-That's it -- same function Nova would use in an ordinary query, just pointed at a
-model instead of a table of robots.
+That's it -- same function used in an ordinary query, just pointed at a model instead
+of a table of robots.
 
 ## "What fraction of robots run dangerously hot?"
 
@@ -98,11 +98,10 @@ print(probability_of(x.temperature > 0.5).first(backend=backend))
 # 0.5
 ```
 
-There's a simpler way to think about this that Nova already knows from ordinary
-querying: take a batch of robots, count how many are running hot, divide by how many
-robots there are. That *is* what a probability means, so `probability_of` can answer
-it exactly that way too -- when Nova has live telemetry on hand instead of the fitted
-model:
+There's a simpler way to think about this, already familiar from ordinary querying:
+take a batch of robots, count how many are running hot, divide by how many robots
+there are. That *is* what a probability means, so `probability_of` can answer it
+exactly that way too -- when live telemetry is on hand instead of the fitted model:
 
 ```python
 robots_online_now = [
@@ -126,15 +125,15 @@ size, because there never was a fleet to begin with.
 
 ## "Given today's charge level, what does the rest look like?"
 
-Every robot left the dock at a 1.5 charge level today, and Nova has already screened
-out anything moving slower than 0.2. She's not asking for a number now -- she wants to
-see the *shape* of what's left: how temperature and speed vary once charge is pinned
-down and the too-slow robots are gone.
+Every robot left the dock at a 1.5 charge level today, and anything moving slower than
+0.2 has already been screened out. The question isn't for a number now -- it's for the
+*shape* of what's left: how temperature and speed vary once charge is pinned down and
+the too-slow robots are gone.
 
-This is exactly the kind of thing `a(...)`/`an(...)`/`the(...)` already describe --
-Nova would normally write this same shape of match to *generate* example robots that
-fit these conditions. `distribution_of` asks the identical question, just answered
-differently: instead of generating robots, it hands back the distribution itself.
+This is exactly the kind of thing `a(...)`/`an(...)`/`the(...)` already describe -- the
+same shape of match would normally *generate* example robots that fit these
+conditions. `distribution_of` asks the identical question, just answered differently:
+instead of generating robots, it hands back the distribution itself.
 
 ```python
 match = a(Robot)(temperature=..., speed=..., charge=1.5)
@@ -146,8 +145,8 @@ print(sorted(v.name for v in result.variables))
 ```
 
 `charge=1.5` is today's dock charge level; `.where(speed > 0.2)` is the screening
-step; `temperature`/`speed` are left open (`...`) -- what Nova wants to see the shape
-of. The result is an ordinary distribution object, queryable like the fleet's original
+step; `temperature`/`speed` are left open (`...`) -- what the shape should be seen of.
+The result is an ordinary distribution object, queryable like the fleet's original
 model:
 
 ```python
@@ -162,7 +161,7 @@ print(result.probability(temperature_range))
 # 0.5 -- unchanged: temperature never depended on speed or charge to begin with
 ```
 
-If Nova only cares about temperature specifically, she can ask for just that:
+To narrow down to temperature specifically:
 
 ```python
 narrowed = distribution_of(match, match.variable.temperature).first(backend=backend)
@@ -178,7 +177,7 @@ print({v.name for v in narrowed.variables})
 - **`probability_of(condition)`** -- counts a real fleet's matching robots when one is
   on hand, or reads the exact answer straight off the model when there's only a fitted
   model. Accepts any condition a `.where(...)` clause does.
-- **`distribution_of(match, *variables)`** -- the same match Nova would write to
+- **`distribution_of(match, *variables)`** -- the same match that would normally
   *generate* robots, answered with the shape of the distribution instead of samples
   from it. Optional `*variables` narrow which readings the answer covers. Unlike the
   other two, there's no batch-counting equivalent for a whole distribution, so this

--- a/krrood/doc/eql/user/probabilistic_queries.md
+++ b/krrood/doc/eql/user/probabilistic_queries.md
@@ -13,33 +13,34 @@ kernelspec:
 
 # Probabilistic Queries
 
-Mira runs quality control at a coin mint. Every coin that comes off the press gets
-measured by three sensors -- diameter, thickness, and weight -- and the mint has
-already fitted a probabilistic model to a long history of these measurements: given
-how the press was set up on a given run, what do the resulting coins tend to look
-like? Mira doesn't build that model herself; she just has questions for it.
+Nova operates a warehouse robot fleet. Every robot streams back telemetry -- speed,
+motor temperature, battery charge -- and the fleet team has already fitted a
+probabilistic model to a long history of that telemetry: given how a shift starts,
+what do the readings tend to look like over the course of it? Nova doesn't build that
+model; she just has questions for it.
 
 ```python
 from dataclasses import dataclass
 
 @dataclass
-class Coin:
-    a: float  # diameter
-    b: float  # thickness
-    c: float  # weight
+class Robot:
+    temperature: float
+    speed: float
+    charge: float
 ```
 
-`set_of`/`entity` answer questions about *actual coins* -- "find me the coins whose
-diameter is under spec". Mira's questions today are different: not about which coins
+`set_of`/`entity` answer questions about *actual robots* -- "find me the robots
+running hot right now". Nova's questions today are different: not about which robots
 exist, but about the *model itself*. Three constructs answer that kind of question:
 
-| Mira's question reads as... | Construct | Answer |
+| Nova's question reads as... | Construct | Answer |
 |---|---|---|
-| "On average, how wide are the coins?" | {py:func}`~krrood.entity_query_language.factories.average` | a number |
-| "What fraction of coins are dangerously thin?" | {py:func}`~krrood.entity_query_language.factories.probability_of` | a number |
-| "Given today's press settings, what does the shape of the remaining measurements look like?" | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a distribution |
+| "On average, how fast do robots move?" | {py:func}`~krrood.entity_query_language.factories.average` | a number |
+| "What fraction of robots run dangerously hot?" | {py:func}`~krrood.entity_query_language.factories.probability_of` | a number |
+| "Given today's charge level, what does the rest look like?" | {py:func}`~krrood.entity_query_language.factories.distribution_of` | a distribution |
 
-All three need the fitted model to answer, so they only work when evaluated with
+Nova doesn't have live telemetry yet -- only the fitted model -- so all three
+questions below get answered from it, via
 {py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`, the backend
 that knows how to reach it:
 
@@ -51,121 +52,141 @@ from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
 from random_events.interval import closed
 from random_events.variable import Continuous
 
-# Stand-in for the mint's already-fitted model: today's press run, in isolation,
-# produces diameter/thickness/weight uniformly across a range each. (Named
-# "Coin.<field>" so DictRegistry -- see below -- can look each field up by name.)
-var_a = Continuous("Coin.a")
-var_b = Continuous("Coin.b")
-var_c = Continuous("Coin.c")
+# Stand-in for the fleet team's already-fitted model: over a shift, in isolation,
+# each reading varies uniformly across its own range. (Named "Robot.<field>" so
+# DictRegistry -- see below -- can look each field up by name.)
+var_temperature = Continuous("Robot.temperature")
+var_speed = Continuous("Robot.speed")
+var_charge = Continuous("Robot.charge")
 
 circuit = ProbabilisticCircuit()
 root = ProductUnit(probabilistic_circuit=circuit)
-root.add_subcircuit(leaf(UniformDistribution(variable=var_a, interval=closed(0, 1).simple_sets[0]), circuit))
-root.add_subcircuit(leaf(UniformDistribution(variable=var_b, interval=closed(0, 2).simple_sets[0]), circuit))
-root.add_subcircuit(leaf(UniformDistribution(variable=var_c, interval=closed(0, 3).simple_sets[0]), circuit))
+root.add_subcircuit(leaf(UniformDistribution(variable=var_temperature, interval=closed(0, 1).simple_sets[0]), circuit))
+root.add_subcircuit(leaf(UniformDistribution(variable=var_speed, interval=closed(0, 2).simple_sets[0]), circuit))
+root.add_subcircuit(leaf(UniformDistribution(variable=var_charge, interval=closed(0, 3).simple_sets[0]), circuit))
 
 from krrood.entity_query_language.backends import ProbabilisticBackend
 from krrood.entity_query_language.factories import a, average, distribution_of, probability_of, variable
 from krrood.parametrization.model_registries import DictRegistry
 
-backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+backend = ProbabilisticBackend(model_registry=DictRegistry({Robot: circuit}))
 ```
 
-## "On average, how wide are the coins?"
+## "On average, how fast do robots move?"
 
-The simplest question, and it uses a construct Mira already knows -- `average`, the
+The simplest question, and it uses a construct Nova already knows -- `average`, the
 same one that averages a column of matched rows. Called *bare* (no `set_of`, no
 `.grouped_by()`) against a model-backed backend, it answers straight from the model
 instead of averaging a sample of rows:
 
 ```python
-x = variable(Coin)
-print(average(x.a).first(backend=backend))
-# 0.5
+x = variable(Robot)
+print(average(x.speed).first(backend=backend))
+# 1.0
 ```
 
-That's it -- same function Mira would use in an ordinary query, just pointed at a
-model instead of a table of coins.
+That's it -- same function Nova would use in an ordinary query, just pointed at a
+model instead of a table of robots.
 
-## "What fraction of coins are dangerously thin?"
+## "What fraction of robots run dangerously hot?"
 
-Suppose anything under 0.5 fails inspection.
+Suppose anything above 0.5 counts as running hot.
 
 ```python
-x = variable(Coin)
-print(probability_of(x.a < 0.5).first(backend=backend))
+x = variable(Robot)
+print(probability_of(x.temperature > 0.5).first(backend=backend))
 # 0.5
 ```
 
-There's a simpler way to think about this that Mira already knows from ordinary
-querying: take a big batch of coins, count how many have diameter under 0.5, divide by
-how many coins there are. That *is* what a probability means, and it's a perfectly
-valid way to estimate one. `probability_of` doesn't do that, though -- there's no batch
-of coins involved at all. It reads the answer directly off the fitted model, so
-instead of an estimate that gets better with a bigger batch, Mira gets the exact
-number the model implies, every time.
+There's a simpler way to think about this that Nova already knows from ordinary
+querying: take a batch of robots, count how many are running hot, divide by how many
+robots there are. That *is* what a probability means, so `probability_of` can answer
+it exactly that way too -- when Nova has live telemetry on hand instead of the fitted
+model:
 
-## "Given today's press settings, what does the rest look like?"
+```python
+robots_online_now = [
+    Robot(temperature=0.2, speed=1.0, charge=2.0),
+    Robot(temperature=0.4, speed=1.0, charge=2.0),
+    Robot(temperature=0.6, speed=1.0, charge=2.0),
+    Robot(temperature=0.9, speed=1.0, charge=2.0),
+]
 
-The press was calibrated to punch out 1.5g coins today, and Mira has already screened
-out anything under the 0.2 diameter minimum. She's not asking for a number now -- she
-wants to see the *shape* of what's left: how thickness and diameter vary once weight
-is pinned down and the too-narrow coins are gone.
+y = variable(Robot, domain=robots_online_now)
+print(probability_of(y.temperature > 0.5).first())
+# 0.5 -- 2 of the 4 robots above are running hot
+```
+
+Same construct, same syntax -- `probability_of` picks whichever strategy fits the
+backend it's given: count the online fleet when it's on hand (no fitted model needed
+at all), or read the exact answer straight off the model when there's no live fleet to
+count, only the model (as with `backend` above). The counting answer is only ever as
+good as the fleet it's counting; the model-based one is exact regardless of fleet
+size, because there never was a fleet to begin with.
+
+## "Given today's charge level, what does the rest look like?"
+
+Every robot left the dock at a 1.5 charge level today, and Nova has already screened
+out anything moving slower than 0.2. She's not asking for a number now -- she wants to
+see the *shape* of what's left: how temperature and speed vary once charge is pinned
+down and the too-slow robots are gone.
 
 This is exactly the kind of thing `a(...)`/`an(...)`/`the(...)` already describe --
-Mira would normally write this same shape of match to *generate* example coins that
-fit these settings. `distribution_of` asks the identical question, just answered
-differently: instead of generating coins, it hands back the distribution itself.
+Nova would normally write this same shape of match to *generate* example robots that
+fit these conditions. `distribution_of` asks the identical question, just answered
+differently: instead of generating robots, it hands back the distribution itself.
 
 ```python
-match = a(Coin)(a=..., b=..., c=1.5)
-match.where(match.variable.a > 0.2)
+match = a(Robot)(temperature=..., speed=..., charge=1.5)
+match.where(match.variable.speed > 0.2)
 
 result = distribution_of(match).first(backend=backend)
 print(sorted(v.name for v in result.variables))
-# ['Coin.a', 'Coin.b', 'Coin.c']
+# ['Robot.charge', 'Robot.speed', 'Robot.temperature']
 ```
 
-`c=1.5` is the press setting; `.where(a > 0.2)` is the screening step; `a`/`b`
-(diameter/thickness) are left open (`...`) -- what Mira wants to see the shape of.
-The result is an ordinary distribution object, queryable like the mint's original
+`charge=1.5` is today's dock charge level; `.where(speed > 0.2)` is the screening
+step; `temperature`/`speed` are left open (`...`) -- what Nova wants to see the shape
+of. The result is an ordinary distribution object, queryable like the fleet's original
 model:
 
 ```python
 from random_events.product_algebra import SimpleEvent
 
-a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()
-print(result.probability(a_range))
-# 1.0 -- everything left satisfies a > 0.2, by construction
+speed_range = SimpleEvent.from_data({var_speed: closed(0.2, 2)}).as_composite_set()
+print(result.probability(speed_range))
+# 1.0 -- everything left satisfies speed > 0.2, by construction
 
-b_range = SimpleEvent.from_data({var_b: closed(0, 1)}).as_composite_set()
-print(result.probability(b_range))
-# 0.5 -- unchanged: thickness never depended on diameter or weight to begin with
+temperature_range = SimpleEvent.from_data({var_temperature: closed(0, 0.5)}).as_composite_set()
+print(result.probability(temperature_range))
+# 0.5 -- unchanged: temperature never depended on speed or charge to begin with
 ```
 
-If Mira only cares about diameter specifically, she can ask for just that:
+If Nova only cares about temperature specifically, she can ask for just that:
 
 ```python
-narrowed = distribution_of(match, match.variable.a).first(backend=backend)
+narrowed = distribution_of(match, match.variable.temperature).first(backend=backend)
 print({v.name for v in narrowed.variables})
-# {'Coin.a'}
+# {'Robot.temperature'}
 ```
 
 ## Recap
 
-- **`average(x.a)`** -- the same aggregator used for row-averaging, pointed at a model
-  instead of a table; answers with the model's exact expectation.
-- **`probability_of(condition)`** -- the exact answer a "count matching rows / count
-  all rows" estimate is aiming for, computed directly from the model instead of
-  estimated from a sample. Accepts any condition a `.where(...)` clause does.
-- **`distribution_of(match, *variables)`** -- the same match Mira would write to
-  *generate* coins, answered with the shape of the distribution instead of samples
-  from it. Optional `*variables` narrow which measurements the answer covers.
+- **`average(x.speed)`** -- the same aggregator used for row-averaging; averages a
+  real fleet when one is on hand, or reads the model's exact expectation when there's
+  only a fitted model.
+- **`probability_of(condition)`** -- counts a real fleet's matching robots when one is
+  on hand, or reads the exact answer straight off the model when there's only a fitted
+  model. Accepts any condition a `.where(...)` clause does.
+- **`distribution_of(match, *variables)`** -- the same match Nova would write to
+  *generate* robots, answered with the shape of the distribution instead of samples
+  from it. Optional `*variables` narrow which readings the answer covers. Unlike the
+  other two, there's no batch-counting equivalent for a whole distribution, so this
+  one only ever works with a fitted model behind it.
 
-All three only work with a probabilistic backend behind them -- there's no table of
-rows to fall back to, only the model. And two of the names should look familiar
-already: `distribution_of`/`average` are how `a(...)`/`an(...)`/`the(...)` and
-`average(...)` already read, just answered from a different place.
+Two of the names should look familiar already: `distribution_of`/`average` are how
+`a(...)`/`an(...)`/`the(...)` and `average(...)` already read, just capable of being
+answered from a model instead of only ever a table.
 
 ---
 

--- a/krrood/src/krrood/entity_query_language/backends.py
+++ b/krrood/src/krrood/entity_query_language/backends.py
@@ -5,7 +5,7 @@ from types import NoneType
 from typing import Iterable, TypeVar
 
 import random_events.variable
-from random_events.product_algebra import Event
+from random_events.product_algebra import Event, VariableMap
 from sqlalchemy.orm import sessionmaker
 from typing_extensions import ClassVar, Dict, List, Optional
 
@@ -21,6 +21,10 @@ from krrood.entity_query_language.operators.causal import (
     CauseEffectVariables,
     ScoredIntervention,
 )
+from krrood.entity_query_language.operators.probabilistic_queries import (
+    ProbabilisticQuery,
+)
+from krrood.entity_query_language.operators.aggregators import Average
 from krrood.entity_query_language.core.variable import Variable
 from krrood.entity_query_language.evaluable import Evaluable
 from krrood.entity_query_language.exceptions import (
@@ -34,7 +38,7 @@ from krrood.entity_query_language.exceptions import (
 )
 from krrood.entity_query_language.factories import entity, set_of, variable
 from krrood.entity_query_language.query.match import Match, AttributeMatch
-from krrood.entity_query_language.query.query import Query
+from krrood.entity_query_language.query.query import Entity, Query
 from krrood.ormatic.eql_interface import eql_to_sql
 
 try:
@@ -51,6 +55,7 @@ try:
     )
     from krrood.parametrization.parameterizer import (
         UnderspecifiedParameters,
+        SelectedAttributesParameters,
     )
 except ImportError as e:
     logger.debug(f"Couldn't import probabilistic model needed classes: {e}")
@@ -59,6 +64,7 @@ except ImportError as e:
     MultipleEffectVariablesNotSupported = NoneType
     ModelRegistry = NoneType
     FullyFactorizedRegistry = NoneType
+    SelectedAttributesParameters = NoneType
     UnderspecifiedParameters = NoneType
 
 T = TypeVar("T")
@@ -307,6 +313,65 @@ class ProbabilisticBackend(GenerativeBackend):
     This is only used if the query does not specify a limit.
     """
 
+    def evaluate(self, expression: Evaluable) -> Iterable[T]:
+        if isinstance(expression, ProbabilisticQuery):
+            yield expression._resolve_(self.model_registry)
+            return
+        bare_average = self._bare_average_selection(expression)
+        if bare_average is not None:
+            yield self._resolve_average(bare_average)
+            return
+        yield from super().evaluate(expression)
+
+    @staticmethod
+    def _bare_average_selection(expression: Evaluable) -> Optional[Average]:
+        """
+        :param expression: The expression being evaluated.
+        :return: The :class:`~krrood.entity_query_language.operators.aggregators.Average`
+            ``expression`` selects, if it is an otherwise-untouched
+            :class:`~krrood.entity_query_language.query.query.Entity` selecting one
+            (i.e. what ``average(x.A).evaluate(...)`` builds -- see
+            :meth:`~krrood.entity_query_language.operators.aggregators.Aggregator.evaluate`)
+            over an attribute chain, so it can be answered in closed form. ``None``
+            otherwise, e.g. when the average is grouped, filtered, or over something
+            other than an attribute.
+        """
+        if not isinstance(expression, Entity):
+            return None
+        aggregator = expression.selected_aggregator
+        if not isinstance(aggregator, Average):
+            return None
+        if aggregator._leaf_attribute_ is None:
+            return None
+        if any(
+            builder is not None
+            for builder in (
+                expression._where_builder_,
+                expression._grouped_by_builder_,
+                expression._having_builder_,
+                expression._ordered_by_builder_,
+            )
+        ):
+            return None
+        return aggregator
+
+    def _resolve_average(self, average: Average) -> float:
+        """
+        Resolve a bare ``average(...)`` selection to the exact expectation of its
+        attribute, via ``ProbabilisticModel.moment``, instead of sampling and
+        averaging rows.
+
+        :param average: The average aggregator to resolve.
+        :return: The expectation of the averaged attribute.
+        """
+        attribute = average._leaf_attribute_
+        parameters = SelectedAttributesParameters((attribute,))
+        model = self.model_registry.get_model(parameters)
+        [random_event_variable] = parameters.variables.values()
+        order = VariableMap({random_event_variable: 1})
+        center = VariableMap({random_event_variable: 0})
+        return model.moment(order, center)[random_event_variable]
+
     def _evaluate(self, expression: Match[T]) -> Iterable[T]:
 
         # generate parameters from example instance values
@@ -331,33 +396,19 @@ class ProbabilisticBackend(GenerativeBackend):
                 expression,
                 cause_effect.confounder_variables,
             )
-            truncated = primary.narrowed_circuit
-        else:
-            # apply conditions from literal assignments to underspecified variables
-            conditioned, _ = model.conditional(
-                parameters.conditioning_assignments_from_literal_values
+            truncated = parameters.apply_krrood_variable_truncation(
+                primary.narrowed_circuit
             )
-            if conditioned is None:
-                raise NoSolutionFound(expression.expression)
+        else:
+            # apply literal-assignment conditions, then where-conditions, then
+            # krrood-variable-assignment truncations -- see
+            # UnderspecifiedParameters.resolve_conditioned_and_truncated_model, which
+            # Distribution._resolve_ also reuses to answer a distribution(...) query
+            # with exactly this same sequence, without the sampling step below.
+            truncated = parameters.resolve_conditioned_and_truncated_model(model)
 
-            # apply conditions from the where statements
-            if parameters.truncation_assignments_from_where_conditions:
-                truncated, _ = conditioned.truncated(
-                    parameters.truncation_assignments_from_where_conditions
-                )
-            else:
-                truncated = conditioned
-
-        # apply conditions from variable assignments to underspecified variables
-        if parameters.truncation_assignments_from_krrood_variables:
-            complete_event = parameters.truncation_assignments_from_krrood_variables[0]
-            complete_event.fill_missing_variables(parameters.variables.values())
-            for event in parameters.truncation_assignments_from_krrood_variables[1:]:
-                complete_event = complete_event.intersection_with(event)
-            truncated, _ = truncated.truncated(complete_event, singleton_allowed=True)
-
-            if truncated is None:
-                raise NoSolutionFound(expression.expression)
+        if truncated is None:
+            raise NoSolutionFound(expression.expression)
 
         number_of_samples = expression.expression._limit_ or self.number_of_samples
 

--- a/krrood/src/krrood/entity_query_language/backends.py
+++ b/krrood/src/krrood/entity_query_language/backends.py
@@ -5,7 +5,7 @@ from types import NoneType
 from typing import Iterable, TypeVar
 
 import random_events.variable
-from random_events.product_algebra import Event, VariableMap
+from random_events.product_algebra import Event
 from sqlalchemy.orm import sessionmaker
 from typing_extensions import ClassVar, Dict, List, Optional
 
@@ -343,6 +343,10 @@ class ProbabilisticBackend(GenerativeBackend):
             return None
         if aggregator._leaf_attribute_ is None:
             return None
+        if aggregator._distinct_:
+            # native evaluation deduplicates values before averaging; the closed-form
+            # expectation has no notion of that, so it must not silently stand in
+            return None
         if any(
             builder is not None
             for builder in (
@@ -358,7 +362,7 @@ class ProbabilisticBackend(GenerativeBackend):
     def _resolve_average(self, average: Average) -> float:
         """
         Resolve a bare ``average(...)`` selection to the exact expectation of its
-        attribute, via ``ProbabilisticModel.moment``, instead of sampling and
+        attribute, via ``ProbabilisticModel.expectation``, instead of sampling and
         averaging rows.
 
         :param average: The average aggregator to resolve.
@@ -368,9 +372,7 @@ class ProbabilisticBackend(GenerativeBackend):
         parameters = SelectedAttributesParameters((attribute,))
         model = self.model_registry.get_model(parameters)
         [random_event_variable] = parameters.variables.values()
-        order = VariableMap({random_event_variable: 1})
-        center = VariableMap({random_event_variable: 0})
-        return model.moment(order, center)[random_event_variable]
+        return model.expectation((random_event_variable,))[random_event_variable]
 
     def _evaluate(self, expression: Match[T]) -> Iterable[T]:
 

--- a/krrood/src/krrood/entity_query_language/core/base_expressions.py
+++ b/krrood/src/krrood/entity_query_language/core/base_expressions.py
@@ -85,8 +85,25 @@ class RuleTreeContext:
     """
 
 
+class HasExpression(ABC):
+    """
+    Anything verbalization/build steps can resolve to a single underlying
+    :class:`SymbolicExpression` to scan or build, regardless of what kind of object
+    routes to it (a plain expression, a :class:`~krrood.entity_query_language.query.match.Match`,
+    a :class:`~krrood.entity_query_language.operators.probabilistic_queries.ProbabilisticQuery`,
+    ...). Callers use :meth:`_get_expression_` polymorphically instead of an
+    ``isinstance`` chain over every such wrapper type.
+    """
+
+    @abstractmethod
+    def _get_expression_(self) -> SymbolicExpression:
+        """
+        :return: The ``SymbolicExpression`` this object represents or wraps.
+        """
+
+
 @dataclass(eq=False)
-class SymbolicExpression(AbstractContextManager):
+class SymbolicExpression(AbstractContextManager, HasExpression):
     """
     Base class for all symbolic expressions.
 
@@ -154,6 +171,9 @@ class SymbolicExpression(AbstractContextManager):
 
     def __post_init__(self):
         self._expression_ = self
+
+    def _get_expression_(self) -> SymbolicExpression:
+        return self
 
     def _node_for_new_position_(self) -> SymbolicExpression:
         """

--- a/krrood/src/krrood/entity_query_language/exceptions.py
+++ b/krrood/src/krrood/entity_query_language/exceptions.py
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
         AbstractMatchExpression,
         AttributeMatch,
     )
+    from krrood.entity_query_language.operators.probabilistic_queries import (
+        ProbabilisticQuery,
+    )
 
 
 @dataclass
@@ -932,6 +935,35 @@ class BackendCannotEvaluateCause(DataclassException):
 
     def suggest_correction(self) -> str:
         return "Evaluate with a ProbabilisticBackend backed by a CausalCircuit-aware model registry."
+
+
+@dataclass
+class BackendCannotEvaluateProbabilisticQuery(DataclassException):
+    """
+    Raised when a
+    :class:`~krrood.entity_query_language.operators.probabilistic_queries.ProbabilisticQuery`
+    (``distribution(...)``, ``probability(...)``, ``moment(...)``) is evaluated
+    natively or with any backend other than
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`.
+
+    Querying a probabilistic model directly is a probabilistic operation, not a data
+    selection: it has no native/SQL evaluation strategy, unlike every other query
+    construct in this package.
+    """
+
+    expression: ProbabilisticQuery
+    """
+    The probabilistic query that was evaluated.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"{self.expression} cannot be evaluated natively: querying a probabilistic "
+            f"model directly is a probabilistic operation, not a data selection."
+        )
+
+    def suggest_correction(self) -> str:
+        return "Evaluate with a ProbabilisticBackend backed by a model registry, e.g. .evaluate(backend=ProbabilisticBackend(...))."
 
 
 @dataclass

--- a/krrood/src/krrood/entity_query_language/exceptions.py
+++ b/krrood/src/krrood/entity_query_language/exceptions.py
@@ -942,13 +942,16 @@ class BackendCannotEvaluateProbabilisticQuery(DataclassException):
     """
     Raised when a
     :class:`~krrood.entity_query_language.operators.probabilistic_queries.ProbabilisticQuery`
-    (``distribution_of(...)``, ``probability_of(...)``) is evaluated natively or with
-    any backend other than
+    is evaluated with any backend other than
     :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`.
 
     Querying a probabilistic model directly is a probabilistic operation, not a data
-    selection: it has no native/SQL evaluation strategy, unlike every other query
-    construct in this package.
+    selection, so most of these have no native/SQL evaluation strategy at all --
+    unlike every other query construct in this package. The one exception is
+    :class:`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
+    (``probability_of(...)``), which *does* evaluate natively (counting matching rows
+    over an enumerable domain) and never raises this; ``distribution_of(...)`` still
+    does, unconditionally.
     """
 
     expression: ProbabilisticQuery

--- a/krrood/src/krrood/entity_query_language/exceptions.py
+++ b/krrood/src/krrood/entity_query_language/exceptions.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     )
     from krrood.entity_query_language.operators.probabilistic_queries import (
         ProbabilisticQuery,
-        Probability,
     )
 
 
@@ -965,32 +964,6 @@ class BackendCannotEvaluateProbabilisticQuery(DataclassException):
 
     def suggest_correction(self) -> str:
         return "Evaluate with a ProbabilisticBackend backed by a model registry, e.g. .evaluate(backend=ProbabilisticBackend(...))."
-
-
-@dataclass
-class ProbabilityConditionNotVerbalizable(DataclassException):
-    """
-    Raised when ``verbalize_expression`` is asked to verbalize a
-    :class:`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
-    (``probability_of(...)``) whose condition is a plain ``bool`` rather than an EQL
-    expression -- e.g. ``probability_of(True)``. There is no attribute/chain to scan
-    for referring expressions (articles, coreference) in a bare literal, unlike every
-    other condition shape ``.where(...)``/``probability_of(...)`` accept.
-    """
-
-    probability: Probability
-    """
-    The probability expression whose condition could not be verbalized.
-    """
-
-    def error_message(self) -> str:
-        return (
-            f"{self.probability} has a plain bool condition, which carries nothing "
-            f"to verbalize."
-        )
-
-    def suggest_correction(self) -> str:
-        return "Only verbalize a probability_of(...) built from an EQL condition (comparators, and_/or_/not_), not a bare True/False."
 
 
 @dataclass

--- a/krrood/src/krrood/entity_query_language/exceptions.py
+++ b/krrood/src/krrood/entity_query_language/exceptions.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     )
     from krrood.entity_query_language.operators.probabilistic_queries import (
         ProbabilisticQuery,
+        Probability,
     )
 
 
@@ -942,8 +943,8 @@ class BackendCannotEvaluateProbabilisticQuery(DataclassException):
     """
     Raised when a
     :class:`~krrood.entity_query_language.operators.probabilistic_queries.ProbabilisticQuery`
-    (``distribution(...)``, ``probability(...)``, ``moment(...)``) is evaluated
-    natively or with any backend other than
+    (``distribution_of(...)``, ``probability_of(...)``) is evaluated natively or with
+    any backend other than
     :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`.
 
     Querying a probabilistic model directly is a probabilistic operation, not a data
@@ -964,6 +965,32 @@ class BackendCannotEvaluateProbabilisticQuery(DataclassException):
 
     def suggest_correction(self) -> str:
         return "Evaluate with a ProbabilisticBackend backed by a model registry, e.g. .evaluate(backend=ProbabilisticBackend(...))."
+
+
+@dataclass
+class ProbabilityConditionNotVerbalizable(DataclassException):
+    """
+    Raised when ``verbalize_expression`` is asked to verbalize a
+    :class:`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
+    (``probability_of(...)``) whose condition is a plain ``bool`` rather than an EQL
+    expression -- e.g. ``probability_of(True)``. There is no attribute/chain to scan
+    for referring expressions (articles, coreference) in a bare literal, unlike every
+    other condition shape ``.where(...)``/``probability_of(...)`` accept.
+    """
+
+    probability: Probability
+    """
+    The probability expression whose condition could not be verbalized.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"{self.probability} has a plain bool condition, which carries nothing "
+            f"to verbalize."
+        )
+
+    def suggest_correction(self) -> str:
+        return "Only verbalize a probability_of(...) built from an EQL condition (comparators, and_/or_/not_), not a bare True/False."
 
 
 @dataclass

--- a/krrood/src/krrood/entity_query_language/factories.py
+++ b/krrood/src/krrood/entity_query_language/factories.py
@@ -123,7 +123,9 @@ def set_of(*selected_variables: Union[Selectable[T], Any]) -> SetOf:
     return SetOf(_selected_variables_=selected_variables)
 
 
-def distribution_of(match: Match, *variables: Attribute) -> Distribution:
+def distribution_of(
+    match: Match, *, marginalize_for: Tuple[Attribute, ...] = ()
+) -> Distribution:
     """
     Request the distribution a match's conditions describe -- the probabilistic
     interpretation of :py:func:`a`/:py:func:`an`/:py:func:`the`. Literal-valued kwargs
@@ -139,13 +141,13 @@ def distribution_of(match: Match, *variables: Attribute) -> Distribution:
     sampling instances from it.
 
     :param match: The match whose conditions describe the distribution.
-    :param variables: Optionally, a subset of the match's free variables to narrow the
-        result to (further marginalization), e.g. ``distribution_of(match,
-        match.variable.outcome)``. Without them, every one of the match's free
-        variables is kept.
+    :param marginalize_for: Optionally, a subset of the match's free variables to
+        narrow the result to (further marginalization), e.g. ``distribution_of(match,
+        marginalize_for=(match.variable.outcome,))``. Without it, every one of the
+        match's free variables is kept.
     :return: Distribution descriptor.
     """
-    return Distribution(match=match, variables=variables)
+    return Distribution(match=match, marginalize_for=marginalize_for)
 
 
 def probability_of(condition: ConditionType) -> Probability:

--- a/krrood/src/krrood/entity_query_language/factories.py
+++ b/krrood/src/krrood/entity_query_language/factories.py
@@ -31,6 +31,10 @@ from krrood.entity_query_language.operators.causal import (
     cause,
     confounder,
 )
+from krrood.entity_query_language.operators.probabilistic_queries import (
+    Probability,
+    Distribution,
+)
 from krrood.entity_query_language.core.helpers import _resolve_domain
 from krrood.entity_query_language.core.mapped_variable import (
     FlatVariable,
@@ -117,6 +121,52 @@ def set_of(*selected_variables: Union[Selectable[T], Any]) -> SetOf:
     :return: Set descriptor.
     """
     return SetOf(_selected_variables_=selected_variables)
+
+
+def distribution_of(match: Match, *variables: Attribute) -> Distribution:
+    """
+    Request the distribution a match's conditions describe -- the probabilistic
+    interpretation of :py:func:`a`/:py:func:`an`/:py:func:`the`. Literal-valued kwargs
+    condition the circuit (``arm=0.3``), ``.where(...)`` conditions truncate it, and
+    underspecified (``...``) fields are the joint's free variables, e.g.
+    ``distribution_of(a(Pick)(arm=0.3, outcome=...))``.
+
+    Unlike :py:func:`set_of`/:py:func:`entity`, this never resolves to rows: it must be
+    evaluated with a
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, which returns
+    the resolved
+    :class:`~probabilistic_model.probabilistic_model.ProbabilisticModel` instead of
+    sampling instances from it.
+
+    :param match: The match whose conditions describe the distribution.
+    :param variables: Optionally, a subset of the match's free variables to narrow the
+        result to (further marginalization), e.g. ``distribution_of(match,
+        match.variable.outcome)``. Without them, every one of the match's free
+        variables is kept.
+    :return: Distribution descriptor.
+    """
+    return Distribution(match=match, variables=variables)
+
+
+def probability_of(condition: ConditionType) -> Probability:
+    """
+    Request the probability of a condition, e.g. ``probability_of(x.A > 5)`` for
+    ``x = variable(MyClass)``. The condition may be any expression a ``.where(...)``
+    condition already accepts.
+
+    Like :py:func:`distribution_of`, this never resolves to rows: it must be evaluated
+    with a
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, which returns
+    the resolved probability as a plain ``float``.
+
+    For the expectation of an attribute, use the existing :py:func:`average` aggregator
+    instead -- {py:class}`~krrood.entity_query_language.backends.ProbabilisticBackend`
+    already recognizes a bare ``average(...)`` selection and answers it in closed form.
+
+    :param condition: The condition to compute the probability of.
+    :return: Probability descriptor.
+    """
+    return Probability(condition=condition)
 
 
 # %% Variable Declaration
@@ -736,13 +786,19 @@ def average(
     distinct: bool = False,
 ) -> Union[T, Average]:
     """
-    Computes the sum of values produced by the given variable.
+    Computes the average of values produced by the given variable.
 
-    :param variable: The variable for which the sum is calculated.
+    Evaluated bare (``average(x.A).first(backend=...)``, with no enclosing
+    ``set_of``/``grouped_by``) against a
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, this resolves
+    in closed form via ``ProbabilisticModel.moment`` instead of sampling and averaging
+    rows -- the same declarative call reads correctly under either backend.
+
+    :param variable: The variable for which the average is calculated.
     :param key: A function that extracts a comparison key from each variable value.
     :param default: The value returned when the iterable is empty.
     :param distinct: Whether to only consider distinct values.
-    :return: A Sum object that can be evaluated to find the sum of values.
+    :return: An Average object that can be evaluated to find the average of values.
     """
     return Average(
         variable, _key_function_=key, _default_value_=default, _distinct_=distinct

--- a/krrood/src/krrood/entity_query_language/factories.py
+++ b/krrood/src/krrood/entity_query_language/factories.py
@@ -17,6 +17,7 @@ from typing_extensions import (
     Optional,
     Tuple,
     Type,
+    TYPE_CHECKING,
     TypeVar,
     overload,
 )
@@ -30,10 +31,6 @@ from krrood.entity_query_language.core.base_expressions import (
 from krrood.entity_query_language.operators.causal import (
     cause,
     confounder,
-)
-from krrood.entity_query_language.operators.probabilistic_queries import (
-    Probability,
-    Distribution,
 )
 from krrood.entity_query_language.core.helpers import _resolve_domain
 from krrood.entity_query_language.core.mapped_variable import (
@@ -95,6 +92,12 @@ from krrood.entity_query_language.rules.conclusion_selector import (
 from krrood.entity_query_language.utils import is_iterable
 from krrood.symbol_graph.symbol_graph import Symbol, SymbolGraph
 
+if TYPE_CHECKING:
+    from krrood.entity_query_language.operators.probabilistic_queries import (
+        Distribution,
+        Probability,
+    )
+
 ConditionType = Union[SymbolicExpression, bool, Predicate, TruthValueOperator]
 """
 The possible types for conditions.
@@ -147,6 +150,11 @@ def distribution_of(
         match's free variables is kept.
     :return: Distribution descriptor.
     """
+    # Local import: avoids a circular import through operators/probabilistic_queries.py.
+    from krrood.entity_query_language.operators.probabilistic_queries import (
+        Distribution,
+    )
+
     return Distribution(match=match, marginalize_for=marginalize_for)
 
 
@@ -168,6 +176,9 @@ def probability_of(condition: ConditionType) -> Probability:
     :param condition: The condition to compute the probability of.
     :return: Probability descriptor.
     """
+    # Local import: avoids a circular import through operators/probabilistic_queries.py.
+    from krrood.entity_query_language.operators.probabilistic_queries import Probability
+
     return Probability(condition=condition)
 
 

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -23,6 +23,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing_extensions import Any, Iterator, Tuple, TYPE_CHECKING
 
+from krrood.entity_query_language.core.base_expressions import SymbolicExpression
+from krrood.entity_query_language.core.variable import Literal
 from krrood.entity_query_language.evaluable import Evaluable
 from krrood.entity_query_language.exceptions import (
     BackendCannotEvaluateProbabilisticQuery,
@@ -81,12 +83,28 @@ class Probability(ProbabilisticQuery):
     condition already accepts (comparators combined with ``and_``/``or_``/``not_``,
     ranges, ...) -- it is translated into a
     {py:class}`~random_events.product_algebra.Event` the same way.
+
+    ``ConditionType`` also allows a bare ``bool`` (``probability_of(True)``); a plain
+    Python ``bool`` carries no attribute/chain, so it's wrapped in a
+    :class:`~krrood.entity_query_language.core.variable.Literal` on construction, the
+    same normalization ``and_``/``or_``/``not_`` already apply to a bare-bool operand
+    -- this keeps ``condition`` always a real EQL expression, so it verbalizes (*"the
+    probability that True"*) with no special-casing needed downstream. It still won't
+    *evaluate*, though: a content-free condition names no class, so there is no model
+    to resolve it against --
+    :class:`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`
+    (empty ``owner_classes``) is raised at resolution time, same as any other
+    condition that references no attributes.
     """
 
     condition: ConditionType
     """
     The condition to compute the probability of.
     """
+
+    def __post_init__(self):
+        if not isinstance(self.condition, SymbolicExpression):
+            self.condition = Literal(_value_=self.condition)
 
     def _resolve_(self, model_registry: ModelRegistry) -> float:
         from krrood.parametrization.parameterizer import ConditionParameters

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -44,7 +44,6 @@ from krrood.parametrization.random_events_translator import (
 )
 if TYPE_CHECKING:
     from krrood.entity_query_language.core.mapped_variable import Attribute
-    from krrood.entity_query_language.factories import ConditionType
     from krrood.entity_query_language.query.match import Match
     from krrood.parametrization.model_registries import ModelRegistry
 
@@ -90,7 +89,7 @@ class Probability(ProbabilisticQuery):
     See :doc:`/krrood/doc/eql/user/probabilistic_queries` for the full walkthrough.
     """
 
-    condition: ConditionType
+    condition: SymbolicExpression
     """
     The condition to compute the probability of.
     """

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -55,10 +55,12 @@ class ProbabilisticQuery(Evaluable, ABC):
     ``distribution_of``, ``probability_of`` -- rather than selecting or generating
     rows/instances.
 
-    This is a probabilistic operation, not a data selection, so none of these ever
-    resolve natively or under any backend other than
+    This is a probabilistic operation, not a data selection, so by default none of
+    these resolve natively or under any backend other than
     :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, which
     dispatches to :meth:`_resolve_` for whichever subclass it is given.
+    :class:`Probability` is the one exception -- see its own
+    :meth:`~Probability._evaluate_natively_`.
     """
 
     def _evaluate_natively_(self) -> Iterator:
@@ -84,14 +86,25 @@ class Probability(ProbabilisticQuery):
     ranges, ...) -- it is translated into a
     {py:class}`~random_events.product_algebra.Event` the same way.
 
+    Unlike :class:`Distribution`, this one resolves two ways: exactly, in closed form
+    via :meth:`_resolve_`, under a
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`; or, under
+    any other backend, natively via :meth:`_evaluate_natively_` -- a probability is
+    definitionally the fraction of a domain's rows the condition holds for, so that's
+    counted directly, the same way any other EQL query counts matching rows. The
+    native path needs an enumerable domain (e.g. ``x = variable(MyClass, domain=...)``
+    ) to count over; the closed-form path needs a fitted model instead. Whichever
+    ``.evaluate(backend=...)``/``.first(backend=...)`` is given decides which one
+    runs.
+
     ``ConditionType`` also allows a bare ``bool`` (``probability_of(True)``); a plain
     Python ``bool`` carries no attribute/chain, so it's wrapped in a
     :class:`~krrood.entity_query_language.core.variable.Literal` on construction, the
     same normalization ``and_``/``or_``/``not_`` already apply to a bare-bool operand
     -- this keeps ``condition`` always a real EQL expression, so it verbalizes (*"the
     probability that True"*) with no special-casing needed downstream. It still won't
-    *evaluate*, though: a content-free condition names no class, so there is no model
-    to resolve it against --
+    *evaluate*, though, either way: a content-free condition names no class, so there
+    is neither a model to resolve it against nor a domain to count rows over --
     :class:`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`
     (empty ``owner_classes``) is raised at resolution time, same as any other
     condition that references no attributes.
@@ -105,6 +118,46 @@ class Probability(ProbabilisticQuery):
     def __post_init__(self):
         if not isinstance(self.condition, SymbolicExpression):
             self.condition = Literal(_value_=self.condition)
+
+    def _evaluate_natively_(self) -> Iterator[float]:
+        """
+        Fallback for every backend other than
+        :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`: a
+        probability is, definitionally, the fraction of a domain's rows that satisfy
+        the condition -- counted the same way any other EQL query counts matching
+        rows, via ``entity(count(root)).where(condition)`` (see
+        ``test_eql/test_core/test_aggregations.py::test_count`` for the same pattern),
+        so this reuses whatever backend support ``count``/``.where()`` already have,
+        rather than reimplementing counting itself. Unlike
+        :meth:`_resolve_`'s exact, closed-form answer, this is only as good as the
+        variable's domain (all of it must be enumerable) -- it's the estimate
+        :meth:`_resolve_` computes exactly instead, when a
+        :class:`~krrood.entity_query_language.backends.ProbabilisticBackend` is used.
+
+        :raises JointQueryAcrossClassesNotSupported: If the condition references
+            attributes reached from more than one ``variable(...)`` root, or none.
+        """
+        from krrood.entity_query_language.factories import count, entity
+        from krrood.parametrization.exceptions import (
+            JointQueryAcrossClassesNotSupported,
+        )
+        from krrood.parametrization.random_events_translator import (
+            WhereExpressionToRandomEventTranslator,
+        )
+
+        referenced_attributes = WhereExpressionToRandomEventTranslator(
+            self.condition
+        ).variables.keys()
+        roots = {attribute._chain_root_ for attribute in referenced_attributes}
+        if len(roots) != 1:
+            raise JointQueryAcrossClassesNotSupported(
+                {root._type_ for root in roots}
+            )
+        [root_variable] = roots
+
+        matching_count = entity(count(root_variable)).where(self.condition).first()
+        total_count = entity(count(root_variable)).first()
+        yield matching_count / total_count
 
     def _resolve_(self, model_registry: ModelRegistry) -> float:
         from krrood.parametrization.parameterizer import ConditionParameters

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -33,6 +33,10 @@ from krrood.entity_query_language.exceptions import (
     BackendCannotEvaluateProbabilisticQuery,
     NoSolutionFound,
 )
+from krrood.parametrization.exceptions import JointQueryAcrossClassesNotSupported
+from krrood.parametrization.random_events_translator import (
+    WhereExpressionToRandomEventTranslator,
+)
 if TYPE_CHECKING:
     from krrood.entity_query_language.core.mapped_variable import Attribute
     from krrood.entity_query_language.factories import ConditionType
@@ -43,15 +47,18 @@ if TYPE_CHECKING:
         UnderspecifiedParameters,
     )
 
-# Every local import below (inside a method body, not at module level) exists to avoid
-# a circular import: krrood.entity_query_language.factories imports Distribution/
-# Probability from this module, so anything imported here at module level that reaches
-# back to factories -- directly (factories.count/entity) or indirectly
-# (krrood.parametrization.parameterizer, which itself imports from factories) -- would
-# cycle. Deferring those imports into each method body instead (matching
-# operators/causal.py's existing leaf-module pattern) delays them until a backend
-# actually evaluates the query, by which point every module involved has finished
-# loading.
+# krrood.entity_query_language.factories imports Distribution/Probability from this
+# module, so anything imported here at module level that reaches back to factories
+# would cycle. JointQueryAcrossClassesNotSupported/WhereExpressionToRandomEventTranslator
+# (imported above) don't -- neither krrood.parametrization.exceptions nor
+# krrood.parametrization.random_events_translator import factories.py at runtime (only
+# under TYPE_CHECKING, for a type hint neither ever needs at runtime). The two imports
+# below stay local instead: factories.count/entity is a direct runtime dependency on
+# factories.py itself, and krrood.parametrization.parameterizer imports factories.and_
+# for real (not just a type hint) -- both would cycle if hoisted, so they're deferred
+# into each method body instead (matching operators/causal.py's existing leaf-module
+# pattern), delaying them until a backend actually evaluates the query, by which point
+# every module involved has finished loading.
 
 
 @dataclass(eq=False, repr=False)
@@ -112,14 +119,8 @@ class Probability(ProbabilisticQuery):
         :raises JointQueryAcrossClassesNotSupported: If the condition references
             attributes reached from more than one ``variable(...)`` root, or none.
         """
-        # See the module-level comment above for why these are local imports.
+        # See the module-level comment above for why this is a local import.
         from krrood.entity_query_language.factories import count, entity
-        from krrood.parametrization.exceptions import (
-            JointQueryAcrossClassesNotSupported,
-        )
-        from krrood.parametrization.random_events_translator import (
-            WhereExpressionToRandomEventTranslator,
-        )
 
         referenced_attributes = WhereExpressionToRandomEventTranslator(
             self.condition

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -20,10 +20,13 @@ same base, the same shape ``operators/aggregators.py`` bundles ``Sum``/``Max``/`
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing_extensions import Any, Iterator, Tuple, TYPE_CHECKING
 
-from krrood.entity_query_language.core.base_expressions import SymbolicExpression
+from krrood.entity_query_language.core.base_expressions import (
+    HasExpression,
+    SymbolicExpression,
+)
 from krrood.entity_query_language.core.variable import Literal
 from krrood.entity_query_language.evaluable import Evaluable
 from krrood.entity_query_language.exceptions import (
@@ -40,16 +43,19 @@ if TYPE_CHECKING:
         UnderspecifiedParameters,
     )
 
-# krrood.parametrization.parameterizer reaches back to this module's own package
-# (krrood.entity_query_language.factories imports Distribution/Probability from here),
-# so importing it at module level -- like operators/causal.py's leaf-module imports --
-# would be circular. Each _resolve_ imports it locally instead, deferred until a
-# ProbabilisticBackend actually evaluates the query, by which point every module
-# involved has finished loading.
+# Every local import below (inside a method body, not at module level) exists to avoid
+# a circular import: krrood.entity_query_language.factories imports Distribution/
+# Probability from this module, so anything imported here at module level that reaches
+# back to factories -- directly (factories.count/entity) or indirectly
+# (krrood.parametrization.parameterizer, which itself imports from factories) -- would
+# cycle. Deferring those imports into each method body instead (matching
+# operators/causal.py's existing leaf-module pattern) delays them until a backend
+# actually evaluates the query, by which point every module involved has finished
+# loading.
 
 
 @dataclass(eq=False, repr=False)
-class ProbabilisticQuery(Evaluable, ABC):
+class ProbabilisticQuery(Evaluable, HasExpression, ABC):
     """
     Shared base for EQL constructs that query a probabilistic model directly --
     ``distribution_of``, ``probability_of`` -- rather than selecting or generating
@@ -80,34 +86,13 @@ class ProbabilisticQuery(Evaluable, ABC):
 @dataclass(eq=False, repr=False)
 class Probability(ProbabilisticQuery):
     """
-    Requests the probability of a condition, e.g. ``probability_of(x.A > 5)`` for
-    ``x = variable(MyClass)``. The condition may be any expression a ``.where(...)``
-    condition already accepts (comparators combined with ``and_``/``or_``/``not_``,
-    ranges, ...) -- it is translated into a
-    {py:class}`~random_events.product_algebra.Event` the same way.
+    The probability of a condition, e.g. ``probability_of(x.A > 5)`` for
+    ``x = variable(MyClass)``. Accepts any condition a ``.where(...)`` clause does.
 
-    Unlike :class:`Distribution`, this one resolves two ways: exactly, in closed form
-    via :meth:`_resolve_`, under a
-    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`; or, under
-    any other backend, natively via :meth:`_evaluate_natively_` -- a probability is
-    definitionally the fraction of a domain's rows the condition holds for, so that's
-    counted directly, the same way any other EQL query counts matching rows. The
-    native path needs an enumerable domain (e.g. ``x = variable(MyClass, domain=...)``
-    ) to count over; the closed-form path needs a fitted model instead. Whichever
-    ``.evaluate(backend=...)``/``.first(backend=...)`` is given decides which one
-    runs.
-
-    ``ConditionType`` also allows a bare ``bool`` (``probability_of(True)``); a plain
-    Python ``bool`` carries no attribute/chain, so it's wrapped in a
-    :class:`~krrood.entity_query_language.core.variable.Literal` on construction, the
-    same normalization ``and_``/``or_``/``not_`` already apply to a bare-bool operand
-    -- this keeps ``condition`` always a real EQL expression, so it verbalizes (*"the
-    probability that True"*) with no special-casing needed downstream. It still won't
-    *evaluate*, though, either way: a content-free condition names no class, so there
-    is neither a model to resolve it against nor a domain to count rows over --
-    :class:`~krrood.parametrization.exceptions.JointQueryAcrossClassesNotSupported`
-    (empty ``owner_classes``) is raised at resolution time, same as any other
-    condition that references no attributes.
+    Resolves two ways: exactly via :meth:`_resolve_` under a
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, or by
+    counting matching rows via :meth:`_evaluate_natively_` under any other backend.
+    See :doc:`/krrood/doc/eql/user/probabilistic_queries` for the full walkthrough.
     """
 
     condition: ConditionType
@@ -121,22 +106,13 @@ class Probability(ProbabilisticQuery):
 
     def _evaluate_natively_(self) -> Iterator[float]:
         """
-        Fallback for every backend other than
-        :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`: a
-        probability is, definitionally, the fraction of a domain's rows that satisfy
-        the condition -- counted the same way any other EQL query counts matching
-        rows, via ``entity(count(root)).where(condition)`` (see
-        ``test_eql/test_core/test_aggregations.py::test_count`` for the same pattern),
-        so this reuses whatever backend support ``count``/``.where()`` already have,
-        rather than reimplementing counting itself. Unlike
-        :meth:`_resolve_`'s exact, closed-form answer, this is only as good as the
-        variable's domain (all of it must be enumerable) -- it's the estimate
-        :meth:`_resolve_` computes exactly instead, when a
-        :class:`~krrood.entity_query_language.backends.ProbabilisticBackend` is used.
+        Counts matching rows via ``entity(count(root)).where(condition)`` instead of
+        resolving a model -- works under any backend with an enumerable domain.
 
         :raises JointQueryAcrossClassesNotSupported: If the condition references
             attributes reached from more than one ``variable(...)`` root, or none.
         """
+        # See the module-level comment above for why these are local imports.
         from krrood.entity_query_language.factories import count, entity
         from krrood.parametrization.exceptions import (
             JointQueryAcrossClassesNotSupported,
@@ -160,11 +136,15 @@ class Probability(ProbabilisticQuery):
         yield matching_count / total_count
 
     def _resolve_(self, model_registry: ModelRegistry) -> float:
+        # See the module-level comment above for why this is a local import.
         from krrood.parametrization.parameterizer import ConditionParameters
 
         parameters = ConditionParameters(self.condition)
         model = model_registry.get_model(parameters)
         return model.probability(parameters.event)
+
+    def _get_expression_(self) -> SymbolicExpression:
+        return self.condition
 
     def __repr__(self) -> str:
         return f"probability_of({self.condition!r})"
@@ -186,10 +166,10 @@ class Distribution(ProbabilisticQuery):
     ``distribution_of(a(Pick)(arm=0.3, outcome=...))`` -- the distribution over
     ``outcome`` given ``arm == 0.3``.
 
-    Optional trailing ``*variables`` narrow the result to a subset of the match's free
-    variables (further marginalization), e.g.
-    ``distribution_of(match, match.variable.outcome)``. Without them, every one of the
-    match's free variables is kept.
+    Optional keyword-only ``marginalize_for`` narrows the result to a subset of the
+    match's free variables (further marginalization), e.g.
+    ``distribution_of(match, marginalize_for=(match.variable.outcome,))``. Without it,
+    every one of the match's free variables is kept.
     """
 
     match: Match
@@ -197,13 +177,14 @@ class Distribution(ProbabilisticQuery):
     The match whose conditions describe the distribution.
     """
 
-    variables: Tuple[Attribute, ...] = ()
+    marginalize_for: Tuple[Attribute, ...] = field(default_factory=tuple)
     """
     The match's variables to narrow the result to. Empty keeps every one of the
     match's free variables.
     """
 
     def _resolve_(self, model_registry: ModelRegistry) -> Any:
+        # See the module-level comment above for why this is a local import.
         from krrood.parametrization.parameterizer import UnderspecifiedParameters
 
         parameters = UnderspecifiedParameters(self.match)
@@ -212,14 +193,23 @@ class Distribution(ProbabilisticQuery):
         if result is None:
             raise NoSolutionFound(self)
 
-        if self.variables:
-            selected = [parameters.variables[v._name_] for v in self.variables]
+        if self.marginalize_for:
+            selected = [
+                parameters.variables[v._name_] for v in self.marginalize_for
+            ]
             result = result.marginal(selected)
             if result is None:
                 raise NoSolutionFound(self)
 
         return result
 
+    def _get_expression_(self) -> SymbolicExpression:
+        return self.match._get_expression_()
+
     def __repr__(self) -> str:
-        args = "".join(f", {v!r}" for v in self.variables)
+        args = (
+            f", marginalize_for={self.marginalize_for!r}"
+            if self.marginalize_for
+            else ""
+        )
         return f"distribution_of({self.match!r}{args})"

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -33,7 +33,12 @@ from krrood.entity_query_language.exceptions import (
     BackendCannotEvaluateProbabilisticQuery,
     NoSolutionFound,
 )
+from krrood.entity_query_language.factories import count, entity
 from krrood.parametrization.exceptions import JointQueryAcrossClassesNotSupported
+from krrood.parametrization.parameterizer import (
+    ConditionParameters,
+    UnderspecifiedParameters,
+)
 from krrood.parametrization.random_events_translator import (
     WhereExpressionToRandomEventTranslator,
 )
@@ -42,10 +47,6 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.factories import ConditionType
     from krrood.entity_query_language.query.match import Match
     from krrood.parametrization.model_registries import ModelRegistry
-    from krrood.parametrization.parameterizer import (
-        ConditionParameters,
-        UnderspecifiedParameters,
-    )
 
 
 @dataclass(eq=False, repr=False)
@@ -106,9 +107,6 @@ class Probability(ProbabilisticQuery):
         :raises JointQueryAcrossClassesNotSupported: If the condition references
             attributes reached from more than one ``variable(...)`` root, or none.
         """
-        # Local import: avoids a circular import through factories.py.
-        from krrood.entity_query_language.factories import count, entity
-
         referenced_attributes = WhereExpressionToRandomEventTranslator(
             self.condition
         ).variables.keys()
@@ -124,9 +122,6 @@ class Probability(ProbabilisticQuery):
         yield matching_count / total_count
 
     def _resolve_(self, model_registry: ModelRegistry) -> float:
-        # Local import: avoids a circular import through factories.py.
-        from krrood.parametrization.parameterizer import ConditionParameters
-
         parameters = ConditionParameters(self.condition)
         model = model_registry.get_model(parameters)
         return model.probability(parameters.event)
@@ -172,9 +167,6 @@ class Distribution(ProbabilisticQuery):
     """
 
     def _resolve_(self, model_registry: ModelRegistry) -> Any:
-        # Local import: avoids a circular import through factories.py.
-        from krrood.parametrization.parameterizer import UnderspecifiedParameters
-
         parameters = UnderspecifiedParameters(self.match)
         model = model_registry.get_model(parameters)
         result = parameters.resolve_conditioned_and_truncated_model(model)

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -1,0 +1,154 @@
+"""
+Constructs for querying a probabilistic model directly from the Entity Query Language:
+``distribution_of`` and ``probability_of``.
+
+A third case -- the expectation of an attribute -- reuses the existing
+:class:`~krrood.entity_query_language.operators.aggregators.Average` aggregator
+(``average(...)``) instead of a bespoke construct here:
+:class:`~krrood.entity_query_language.backends.ProbabilisticBackend` recognizes a bare
+``average(...)`` selection and answers it in closed form via
+``ProbabilisticModel.moment`` instead of sampling and averaging rows, so the same
+declarative call reads correctly under either backend. See
+:meth:`~krrood.entity_query_language.backends.ProbabilisticBackend._resolve_average`.
+
+Bundled in one module rather than one file each (unlike ``operators/causal.py``, which
+is one coupled do()-intervention feature) because these are parallel operations on the
+same base, the same shape ``operators/aggregators.py`` bundles ``Sum``/``Max``/``Min``/
+... in.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing_extensions import Any, Iterator, Tuple, TYPE_CHECKING
+
+from krrood.entity_query_language.evaluable import Evaluable
+from krrood.entity_query_language.exceptions import (
+    BackendCannotEvaluateProbabilisticQuery,
+    NoSolutionFound,
+)
+if TYPE_CHECKING:
+    from krrood.entity_query_language.core.mapped_variable import Attribute
+    from krrood.entity_query_language.factories import ConditionType
+    from krrood.entity_query_language.query.match import Match
+    from krrood.parametrization.model_registries import ModelRegistry
+    from krrood.parametrization.parameterizer import (
+        ConditionParameters,
+        UnderspecifiedParameters,
+    )
+
+# krrood.parametrization.parameterizer reaches back to this module's own package
+# (krrood.entity_query_language.factories imports Distribution/Probability from here),
+# so importing it at module level -- like operators/causal.py's leaf-module imports --
+# would be circular. Each _resolve_ imports it locally instead, deferred until a
+# ProbabilisticBackend actually evaluates the query, by which point every module
+# involved has finished loading.
+
+
+@dataclass(eq=False, repr=False)
+class ProbabilisticQuery(Evaluable, ABC):
+    """
+    Shared base for EQL constructs that query a probabilistic model directly --
+    ``distribution_of``, ``probability_of`` -- rather than selecting or generating
+    rows/instances.
+
+    This is a probabilistic operation, not a data selection, so none of these ever
+    resolve natively or under any backend other than
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`, which
+    dispatches to :meth:`_resolve_` for whichever subclass it is given.
+    """
+
+    def _evaluate_natively_(self) -> Iterator:
+        raise BackendCannotEvaluateProbabilisticQuery(self)
+
+    @abstractmethod
+    def _resolve_(self, model_registry: ModelRegistry) -> Any:
+        """
+        Resolve this query against a model obtained from ``model_registry``.
+
+        :param model_registry: The registry to resolve a model with.
+        :return: Whatever the underlying ``ProbabilisticModel`` operation naturally
+            returns -- a plain value, unwrapped.
+        """
+
+
+@dataclass(eq=False, repr=False)
+class Probability(ProbabilisticQuery):
+    """
+    Requests the probability of a condition, e.g. ``probability_of(x.A > 5)`` for
+    ``x = variable(MyClass)``. The condition may be any expression a ``.where(...)``
+    condition already accepts (comparators combined with ``and_``/``or_``/``not_``,
+    ranges, ...) -- it is translated into a
+    {py:class}`~random_events.product_algebra.Event` the same way.
+    """
+
+    condition: ConditionType
+    """
+    The condition to compute the probability of.
+    """
+
+    def _resolve_(self, model_registry: ModelRegistry) -> float:
+        from krrood.parametrization.parameterizer import ConditionParameters
+
+        parameters = ConditionParameters(self.condition)
+        model = model_registry.get_model(parameters)
+        return model.probability(parameters.event)
+
+    def __repr__(self) -> str:
+        return f"probability_of({self.condition!r})"
+
+
+@dataclass(eq=False, repr=False)
+class Distribution(ProbabilisticQuery):
+    """
+    Requests the distribution a :class:`~krrood.entity_query_language.query.match.Match`'s
+    conditions describe -- the probabilistic interpretation of
+    :py:func:`~krrood.entity_query_language.factories.a`/:py:func:`~krrood.entity_query_language.factories.an`/
+    :py:func:`~krrood.entity_query_language.factories.the`. Exactly the same sequence
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend` already
+    applies before *sampling* from a match -- literal-valued kwargs condition the
+    circuit (``arm=0.3``), ``.where(...)`` conditions truncate it, and underspecified
+    (``...``) fields are the joint's free variables -- just returned directly instead
+    of sampled from:
+
+    ``distribution_of(a(Pick)(arm=0.3, outcome=...))`` -- the distribution over
+    ``outcome`` given ``arm == 0.3``.
+
+    Optional trailing ``*variables`` narrow the result to a subset of the match's free
+    variables (further marginalization), e.g.
+    ``distribution_of(match, match.variable.outcome)``. Without them, every one of the
+    match's free variables is kept.
+    """
+
+    match: Match
+    """
+    The match whose conditions describe the distribution.
+    """
+
+    variables: Tuple[Attribute, ...] = ()
+    """
+    The match's variables to narrow the result to. Empty keeps every one of the
+    match's free variables.
+    """
+
+    def _resolve_(self, model_registry: ModelRegistry) -> Any:
+        from krrood.parametrization.parameterizer import UnderspecifiedParameters
+
+        parameters = UnderspecifiedParameters(self.match)
+        model = model_registry.get_model(parameters)
+        result = parameters.resolve_conditioned_and_truncated_model(model)
+        if result is None:
+            raise NoSolutionFound(self)
+
+        if self.variables:
+            selected = [parameters.variables[v._name_] for v in self.variables]
+            result = result.marginal(selected)
+            if result is None:
+                raise NoSolutionFound(self)
+
+        return result
+
+    def __repr__(self) -> str:
+        args = "".join(f", {v!r}" for v in self.variables)
+        return f"distribution_of({self.match!r}{args})"

--- a/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
+++ b/krrood/src/krrood/entity_query_language/operators/probabilistic_queries.py
@@ -47,19 +47,6 @@ if TYPE_CHECKING:
         UnderspecifiedParameters,
     )
 
-# krrood.entity_query_language.factories imports Distribution/Probability from this
-# module, so anything imported here at module level that reaches back to factories
-# would cycle. JointQueryAcrossClassesNotSupported/WhereExpressionToRandomEventTranslator
-# (imported above) don't -- neither krrood.parametrization.exceptions nor
-# krrood.parametrization.random_events_translator import factories.py at runtime (only
-# under TYPE_CHECKING, for a type hint neither ever needs at runtime). The two imports
-# below stay local instead: factories.count/entity is a direct runtime dependency on
-# factories.py itself, and krrood.parametrization.parameterizer imports factories.and_
-# for real (not just a type hint) -- both would cycle if hoisted, so they're deferred
-# into each method body instead (matching operators/causal.py's existing leaf-module
-# pattern), delaying them until a backend actually evaluates the query, by which point
-# every module involved has finished loading.
-
 
 @dataclass(eq=False, repr=False)
 class ProbabilisticQuery(Evaluable, HasExpression, ABC):
@@ -119,7 +106,7 @@ class Probability(ProbabilisticQuery):
         :raises JointQueryAcrossClassesNotSupported: If the condition references
             attributes reached from more than one ``variable(...)`` root, or none.
         """
-        # See the module-level comment above for why this is a local import.
+        # Local import: avoids a circular import through factories.py.
         from krrood.entity_query_language.factories import count, entity
 
         referenced_attributes = WhereExpressionToRandomEventTranslator(
@@ -137,7 +124,7 @@ class Probability(ProbabilisticQuery):
         yield matching_count / total_count
 
     def _resolve_(self, model_registry: ModelRegistry) -> float:
-        # See the module-level comment above for why this is a local import.
+        # Local import: avoids a circular import through factories.py.
         from krrood.parametrization.parameterizer import ConditionParameters
 
         parameters = ConditionParameters(self.condition)
@@ -185,7 +172,7 @@ class Distribution(ProbabilisticQuery):
     """
 
     def _resolve_(self, model_registry: ModelRegistry) -> Any:
-        # See the module-level comment above for why this is a local import.
+        # Local import: avoids a circular import through factories.py.
         from krrood.parametrization.parameterizer import UnderspecifiedParameters
 
         parameters = UnderspecifiedParameters(self.match)

--- a/krrood/src/krrood/entity_query_language/query/match.py
+++ b/krrood/src/krrood/entity_query_language/query/match.py
@@ -29,6 +29,7 @@ from typing_extensions import (
 
 from krrood.class_diagrams.utils import get_type_hints_of_object
 from krrood.entity_query_language.core.base_expressions import (
+    HasExpression,
     Selectable,
     SymbolicExpression,
 )
@@ -196,7 +197,7 @@ class AbstractMatchExpression(Generic[T], ABC):
 
 
 @dataclass(eq=False)
-class Match(Evaluable, AbstractMatchExpression[T], HasFactoryAndKwargs[T]):
+class Match(Evaluable, AbstractMatchExpression[T], HasFactoryAndKwargs[T], HasExpression):
     """
     Construct a query that looks for the pattern provided by the type and the keyword arguments.
     Example usage where we look for an object of type Drawer with body of type Body that has the name"drawer_1":
@@ -310,6 +311,9 @@ class Match(Evaluable, AbstractMatchExpression[T], HasFactoryAndKwargs[T]):
         entity_._quantify_(self._quantifier_type_)
         self._expression = entity_
         return entity_
+
+    def _get_expression_(self) -> SymbolicExpression:
+        return self.expression
 
     def _resolve(
         self,

--- a/krrood/src/krrood/entity_query_language/verbalization/grammar/probabilistic_queries/rules.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/grammar/probabilistic_queries/rules.py
@@ -1,0 +1,139 @@
+"""
+Grammar rules for the probabilistic query constructs:
+:class:`~krrood.entity_query_language.operators.probabilistic_queries.Distribution` and
+:class:`~krrood.entity_query_language.operators.probabilistic_queries.Probability`.
+
+Auto-registered by :mod:`~krrood.entity_query_language.verbalization.grammar.framework.registry`
+(any module named ``rules.py`` under ``grammar/`` is walked and imported, and every concrete
+:class:`~krrood.entity_query_language.verbalization.grammar.framework.phrase_rule.PhraseRule`
+subclass found is added to ``RULES``) -- nothing else needs editing to wire these in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import List
+
+from krrood.entity_query_language.operators.probabilistic_queries import (
+    Distribution,
+    Probability,
+)
+from krrood.entity_query_language.verbalization.fragments.base import (
+    BlockFragment,
+    PhraseFragment,
+    RoleFragment,
+    VerbalizationFragment,
+    oxford_comma,
+)
+from krrood.entity_query_language.verbalization.grammar.framework.phrase_rule import (
+    PhraseRule,
+    RuleContext,
+)
+from krrood.entity_query_language.verbalization.grammar.match.assembler import (
+    MatchAssembler,
+)
+from krrood.entity_query_language.verbalization.vocabulary.english import (
+    Articles,
+    Conjunctions,
+    Directive,
+    Keywords,
+    Prepositions,
+)
+
+
+@dataclass
+class DistributionRule(PhraseRule):
+    """
+    Realise ``distribution_of(match)`` as *"The distribution over <match subject>,
+    given that …, where …"*, and ``distribution_of(match, *variables)`` (marginalized
+    to a subset of the match's free variables) as *"The distribution over the
+    <variables> of <match subject>, given that …, where …"*.
+
+    Reuses the match's own *"given that"*/*"where"* grammar (see
+    :class:`~krrood.entity_query_language.verbalization.grammar.match.assembler.MatchAssembler`),
+    but builds its own header rather than delegating to :meth:`MatchAssembler.realize`
+    outright, for two reasons: the header takes a definite description
+    (:attr:`~....vocabulary.english.Directive.DISTRIBUTION_OVER`) rather than either of
+    the match's imperative *"Find"*/*"Generate"* verbs, since a distribution is asked
+    for, not rows; and a distribution's underspecified (``...``) fields are its
+    free/output variables by default, not values to fill in, so the match's generative
+    *"and predict its … value(s)"* clause is dropped entirely rather than reworded --
+    "the distribution over a Coin" already means "over every attribute not given", the
+    same way an unqualified marginal does, so nothing is lost by omitting them. When
+    ``*variables`` narrows that default, they're named directly in the subject (*"the
+    battery of a Robot"*) -- not a trailing qualifier like *"restricted to"*, which
+    reads like a truncation (a ``where``), not a choice of which variables the joint is
+    even over.
+
+    >>> from krrood.entity_query_language.factories import a, distribution_of
+    >>> match = a(Robot)(name="R2", battery=...)
+    >>> verbalize_expression(distribution_of(match))
+    "The distribution over a Robot given that its name is 'R2'"
+    >>> verbalize_expression(distribution_of(match, match.variable.battery))
+    "The distribution over the battery of a Robot given that its name is 'R2'"
+    """
+
+    construct = Distribution
+
+    def build(self, node: Distribution, context: RuleContext) -> VerbalizationFragment:
+        context.services.performative_override = Directive.DISTRIBUTION_OVER
+        assembler = MatchAssembler(context)
+        plan = assembler.plan(node.match)
+
+        subject = context.child(plan.selection)
+        if node.variables:
+            variable_list = oxford_comma(
+                [
+                    RoleFragment.for_attribute(
+                        attribute._owner_class_, attribute._attribute_name_
+                    )
+                    for attribute in node.variables
+                ],
+                Conjunctions.AND.as_fragment(),
+            )
+            subject = PhraseFragment(
+                parts=[
+                    Articles.THE.as_fragment(),
+                    variable_list,
+                    Prepositions.OF.as_fragment(),
+                    subject,
+                ]
+            )
+        header = PhraseFragment(
+            parts=[Directive.DISTRIBUTION_OVER.as_fragment(), subject]
+        )
+
+        items: List[VerbalizationFragment] = []
+        given = assembler._given_that_block(plan)
+        if given is not None:
+            items.append(given)
+        where = assembler._where_block(plan)
+        if where is not None:
+            items.append(where)
+
+        return BlockFragment(header=header, items=items, source=node.match.expression)
+
+
+@dataclass
+class ProbabilityRule(PhraseRule):
+    """
+    Realise ``probability_of(condition)`` as *"the probability that <condition>"* --
+    the condition is recursed through the ordinary comparator/logical-operator grammar
+    via ``context.child``, so it reads exactly as it would inside a ``where`` clause.
+
+    >>> from krrood.entity_query_language.factories import probability_of, variable
+    >>> robot = variable(Robot, [])
+    >>> verbalize_expression(probability_of(robot.battery > 50))
+    'the probability that the battery of a Robot is greater than 50'
+    """
+
+    construct = Probability
+
+    def build(self, node: Probability, context: RuleContext) -> VerbalizationFragment:
+        return PhraseFragment(
+            parts=[
+                Keywords.THE_PROBABILITY_THAT.as_fragment(),
+                context.child(node.condition),
+            ]
+        )

--- a/krrood/src/krrood/entity_query_language/verbalization/grammar/probabilistic_queries/rules.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/grammar/probabilistic_queries/rules.py
@@ -46,9 +46,9 @@ from krrood.entity_query_language.verbalization.vocabulary.english import (
 class DistributionRule(PhraseRule):
     """
     Realise ``distribution_of(match)`` as *"The distribution over <match subject>,
-    given that …, where …"*, and ``distribution_of(match, *variables)`` (marginalized
-    to a subset of the match's free variables) as *"The distribution over the
-    <variables> of <match subject>, given that …, where …"*.
+    given that …, where …"*, and ``distribution_of(match, marginalize_for=...)``
+    (marginalized to a subset of the match's free variables) as *"The distribution
+    over the <variables> of <match subject>, given that …, where …"*.
 
     Reuses the match's own *"given that"*/*"where"* grammar (see
     :class:`~krrood.entity_query_language.verbalization.grammar.match.assembler.MatchAssembler`),
@@ -61,16 +61,16 @@ class DistributionRule(PhraseRule):
     *"and predict its … value(s)"* clause is dropped entirely rather than reworded --
     "the distribution over a Coin" already means "over every attribute not given", the
     same way an unqualified marginal does, so nothing is lost by omitting them. When
-    ``*variables`` narrows that default, they're named directly in the subject (*"the
-    battery of a Robot"*) -- not a trailing qualifier like *"restricted to"*, which
-    reads like a truncation (a ``where``), not a choice of which variables the joint is
-    even over.
+    ``marginalize_for`` narrows that default, they're named directly in the subject
+    (*"the battery of a Robot"*) -- not a trailing qualifier like *"restricted to"*,
+    which reads like a truncation (a ``where``), not a choice of which variables the
+    joint is even over.
 
     >>> from krrood.entity_query_language.factories import a, distribution_of
     >>> match = a(Robot)(name="R2", battery=...)
     >>> verbalize_expression(distribution_of(match))
     "The distribution over a Robot given that its name is 'R2'"
-    >>> verbalize_expression(distribution_of(match, match.variable.battery))
+    >>> verbalize_expression(distribution_of(match, marginalize_for=(match.variable.battery,)))
     "The distribution over the battery of a Robot given that its name is 'R2'"
     """
 
@@ -82,13 +82,13 @@ class DistributionRule(PhraseRule):
         plan = assembler.plan(node.match)
 
         subject = context.child(plan.selection)
-        if node.variables:
+        if node.marginalize_for:
             variable_list = oxford_comma(
                 [
                     RoleFragment.for_attribute(
                         attribute._owner_class_, attribute._attribute_name_
                     )
-                    for attribute in node.variables
+                    for attribute in node.marginalize_for
                 ],
                 Conjunctions.AND.as_fragment(),
             )

--- a/krrood/src/krrood/entity_query_language/verbalization/pipeline.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/pipeline.py
@@ -26,8 +26,6 @@ from krrood.entity_query_language.verbalization.rendering.renderer import (
     ParagraphRenderer,
 )
 from krrood.entity_query_language.verbalization.verbalizer import EQLVerbalizer
-from krrood.entity_query_language.operators.probabilistic_queries import Distribution
-from krrood.entity_query_language.query.match import Match
 from krrood.entity_query_language.query.query import Query
 
 if TYPE_CHECKING:
@@ -140,12 +138,12 @@ class VerbalizationPipeline:
         >>> VerbalizationPipeline.plain().verbalize(a(entity(variable(Robot, []))))
         'Find a Robot'
         """
-        if isinstance(expression, Match):
-            expression.expression.build()
-        elif isinstance(expression, Query):
-            expression.build()
-        elif isinstance(expression, Distribution):
-            expression.match.expression.build()
+        # Match/Distribution/Probability all resolve, via _get_expression_, to the
+        # underlying SymbolicExpression that actually needs building -- only a Query
+        # has anything to build.
+        target = expression._get_expression_()
+        if isinstance(target, Query):
+            target.build()
         fragment = self._verbalizer.build(
             expression, services, performative=directive_for_backend(backend)
         )

--- a/krrood/src/krrood/entity_query_language/verbalization/pipeline.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/pipeline.py
@@ -26,6 +26,7 @@ from krrood.entity_query_language.verbalization.rendering.renderer import (
     ParagraphRenderer,
 )
 from krrood.entity_query_language.verbalization.verbalizer import EQLVerbalizer
+from krrood.entity_query_language.operators.probabilistic_queries import Distribution
 from krrood.entity_query_language.query.match import Match
 from krrood.entity_query_language.query.query import Query
 
@@ -143,6 +144,8 @@ class VerbalizationPipeline:
             expression.expression.build()
         elif isinstance(expression, Query):
             expression.build()
+        elif isinstance(expression, Distribution):
+            expression.match.expression.build()
         fragment = self._verbalizer.build(
             expression, services, performative=directive_for_backend(backend)
         )

--- a/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.verbalization.vocabulary.english import Directive
 
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
-from krrood.entity_query_language.exceptions import ProbabilityConditionNotVerbalizable
 from krrood.entity_query_language.operators.probabilistic_queries import (
     Distribution,
     Probability,
@@ -66,17 +65,14 @@ class EQLVerbalizer:
         # everything inside it (selection, values, conditions) is scanned/folded through its
         # resolved query expression. Distribution/Probability are Evaluable-only (not
         # SymbolicExpression), so the referring-expression scan needs the SymbolicExpression they
-        # actually wrap instead -- the underlying match's resolved query, or the condition.
+        # actually wrap instead -- the underlying match's resolved query, or the condition
+        # (Probability.__post_init__ already normalizes a bare bool into a Literal, so
+        # .condition is always a real SymbolicExpression here).
         if isinstance(expression, Match):
             scan_target = expression.expression
         elif isinstance(expression, Distribution):
             scan_target = expression.match.expression
         elif isinstance(expression, Probability):
-            if not isinstance(expression.condition, SymbolicExpression):
-                # a bare bool (legal per ConditionType) carries no attribute/chain to
-                # scan for referring expressions -- fail clearly here rather than
-                # crashing later on a plain value with no _all_expressions_
-                raise ProbabilityConditionNotVerbalizable(expression)
             scan_target = expression.condition
         else:
             scan_target = expression

--- a/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
@@ -8,6 +8,10 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.verbalization.vocabulary.english import Directive
 
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
+from krrood.entity_query_language.operators.probabilistic_queries import (
+    Distribution,
+    Probability,
+)
 from krrood.entity_query_language.query.match import Match
 from krrood.entity_query_language.verbalization.context import MicroplanningServices
 from krrood.entity_query_language.verbalization.engine import fold, root_context
@@ -59,10 +63,19 @@ class EQLVerbalizer:
         """
         # A match is not a foldable EQL node but a builder; it routes to its own assembler and
         # everything inside it (selection, values, conditions) is scanned/folded through its
-        # resolved query expression.
-        scan_target = (
-            expression.expression if isinstance(expression, Match) else expression
-        )
+        # resolved query expression. Distribution/Probability are Evaluable-only (not
+        # SymbolicExpression), so the referring-expression scan needs the SymbolicExpression they
+        # actually wrap instead -- the underlying match's resolved query, or the condition.
+        if isinstance(expression, Match):
+            scan_target = expression.expression
+        elif isinstance(expression, Distribution):
+            scan_target = expression.match.expression
+        elif isinstance(expression, Probability) and isinstance(
+            expression.condition, SymbolicExpression
+        ):
+            scan_target = expression.condition
+        else:
+            scan_target = expression
         if services is None:
             services = MicroplanningServices.from_expression(scan_target)
         if performative is not None:

--- a/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
@@ -8,10 +8,6 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.verbalization.vocabulary.english import Directive
 
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
-from krrood.entity_query_language.operators.probabilistic_queries import (
-    Distribution,
-    Probability,
-)
 from krrood.entity_query_language.query.match import Match
 from krrood.entity_query_language.verbalization.context import MicroplanningServices
 from krrood.entity_query_language.verbalization.engine import fold, root_context
@@ -63,19 +59,10 @@ class EQLVerbalizer:
         """
         # A match is not a foldable EQL node but a builder; it routes to its own assembler and
         # everything inside it (selection, values, conditions) is scanned/folded through its
-        # resolved query expression. Distribution/Probability are Evaluable-only (not
-        # SymbolicExpression), so the referring-expression scan needs the SymbolicExpression they
-        # actually wrap instead -- the underlying match's resolved query, or the condition
-        # (Probability.__post_init__ already normalizes a bare bool into a Literal, so
-        # .condition is always a real SymbolicExpression here).
-        if isinstance(expression, Match):
-            scan_target = expression.expression
-        elif isinstance(expression, Distribution):
-            scan_target = expression.match.expression
-        elif isinstance(expression, Probability):
-            scan_target = expression.condition
-        else:
-            scan_target = expression
+        # resolved query expression. Match/Distribution/Probability all implement
+        # HasExpression, so the referring-expression scan can ask any of them for the
+        # SymbolicExpression they actually wrap without an isinstance chain here.
+        scan_target = expression._get_expression_()
         if services is None:
             services = MicroplanningServices.from_expression(scan_target)
         if performative is not None:

--- a/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/verbalizer.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.verbalization.vocabulary.english import Directive
 
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
+from krrood.entity_query_language.exceptions import ProbabilityConditionNotVerbalizable
 from krrood.entity_query_language.operators.probabilistic_queries import (
     Distribution,
     Probability,
@@ -70,9 +71,12 @@ class EQLVerbalizer:
             scan_target = expression.expression
         elif isinstance(expression, Distribution):
             scan_target = expression.match.expression
-        elif isinstance(expression, Probability) and isinstance(
-            expression.condition, SymbolicExpression
-        ):
+        elif isinstance(expression, Probability):
+            if not isinstance(expression.condition, SymbolicExpression):
+                # a bare bool (legal per ConditionType) carries no attribute/chain to
+                # scan for referring expressions -- fail clearly here rather than
+                # crashing later on a plain value with no _all_expressions_
+                raise ProbabilityConditionNotVerbalizable(expression)
             scan_target = expression.condition
         else:
             scan_target = expression

--- a/krrood/src/krrood/entity_query_language/verbalization/vocabulary/english.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/vocabulary/english.py
@@ -209,16 +209,21 @@ class Keywords(VocabEnum):
     TRUE = KeyWord("true")
     WHAT_CAUSES = KeyWord("what causes")
     TO_BE = KeyWord("to be")
+    THE_PROBABILITY_THAT = KeyWord("the probability that")
 
 
 class Directive(VocabEnum):
     """
-    The imperative verb that opens a request: *"Find"* a match in the domain,
-    or *"Generate"* an underspecified one.
+    The opening phrase of a request: *"Find"* a match in the domain, *"Generate"* an
+    underspecified one, or *"The distribution over"* one whose free variables'
+    distribution is wanted instead of a concrete match -- the two imperatives ask for
+    rows, the third asks for a description of the query, so it takes the same slot
+    without being one itself.
     """
 
     FIND = KeyWord("Find")
     GENERATE = KeyWord("Generate")
+    DISTRIBUTION_OVER = KeyWord("The distribution over")
 
 
 class Logicals(VocabEnum):

--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from typing_extensions import Any, List, Type
+from typing_extensions import Any, List, Set, Type
 
 import random_events.variable
 from krrood.entity_query_language.core.variable import Variable
@@ -133,3 +133,38 @@ class MultipleEffectVariablesNotSupported(DataclassException):
 
     def suggest_correction(self) -> str:
         return "Declare exactly one effect per query."
+
+
+@dataclass
+class JointQueryAcrossClassesNotSupported(DataclassException):
+    """
+    Raised when a probabilistic query (``probability(...)``, ``moment(...)``)
+    references attributes of more than one EQL class, e.g. ``moment(x.A, y.B)`` for
+    ``x = variable(ClassOne)`` and ``y = variable(ClassTwo)``.
+
+    ``distribution(...)`` never raises this: it wraps a single ``Match``, which is
+    always for one class by construction.
+
+    Every :class:`~krrood.parametrization.model_registries.ModelRegistry` resolves a
+    single model per class, so there is no established way to ground a query spanning
+    two different classes' models yet.
+    """
+
+    owner_classes: Set[Type]
+    """
+    The distinct owner classes found among the query's referenced attributes.
+    """
+
+    def error_message(self) -> str:
+        names = ", ".join(sorted(cls.__name__ for cls in self.owner_classes))
+        return (
+            f"The query referenced attributes owned by {len(self.owner_classes)} "
+            f"different classes ({names}), but only a single-class query is "
+            f"supported."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Reference attributes reached from a single variable(...) root, or split "
+            "into separate queries."
+        )

--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -138,11 +138,12 @@ class MultipleEffectVariablesNotSupported(DataclassException):
 @dataclass
 class JointQueryAcrossClassesNotSupported(DataclassException):
     """
-    Raised when a probabilistic query (``probability(...)``, ``moment(...)``)
-    references attributes of more than one EQL class, e.g. ``moment(x.A, y.B)`` for
+    Raised when a probabilistic query (``probability_of(...)``, ``average(...)``)
+    references attributes of more than one EQL class, e.g. ``average(x.A)`` combined
+    with attributes of a second class in the same call, for
     ``x = variable(ClassOne)`` and ``y = variable(ClassTwo)``.
 
-    ``distribution(...)`` never raises this: it wraps a single ``Match``, which is
+    ``distribution_of(...)`` never raises this: it wraps a single ``Match``, which is
     always for one class by construction.
 
     Every :class:`~krrood.parametrization.model_registries.ModelRegistry` resolves a
@@ -167,4 +168,35 @@ class JointQueryAcrossClassesNotSupported(DataclassException):
         return (
             "Reference attributes reached from a single variable(...) root, or split "
             "into separate queries."
+        )
+
+
+@dataclass
+class RelationalCircuitRegistryRequiresMatch(DataclassException):
+    """
+    Raised when a :class:`~krrood.parametrization.model_registries.RelationalCircuitRegistry`
+    is asked to resolve a model for parameters that aren't a
+    :class:`~krrood.parametrization.parameterizer.UnderspecifiedParameters` (i.e. not a
+    ``Match``, directly or wrapped by ``distribution_of(...)``) -- ``probability_of(...)``
+    and a bare ``average(...)`` build the lighter
+    :class:`~krrood.parametrization.parameterizer.ConditionParameters`/
+    :class:`~krrood.parametrization.parameterizer.SelectedAttributesParameters`
+    instead, which carry no match statement to ground.
+    """
+
+    parameters: Any
+    """
+    The parameters that were given instead of an ``UnderspecifiedParameters``.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"RelationalCircuitRegistry needs a Match's full statement to ground its "
+            f"circuit, but got {type(self.parameters).__name__}, which carries none."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Use RelationalCircuitRegistry only with distribution_of(...) (or a bare "
+            "Match), not probability_of(...)/average(...)."
         )

--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -9,11 +9,6 @@ from krrood.entity_query_language.core.variable import Variable
 from krrood.exceptions import DataclassException, InputError
 
 if TYPE_CHECKING:
-    # None of these exceptions construct a Probability/Distribution -- ConditionType is
-    # only ever a dataclass field annotation here, so importing krrood.entity_query_
-    # language.factories at runtime (which would cycle back through
-    # operators/probabilistic_queries.py, which factories.py imports Distribution/
-    # Probability from) isn't needed.
     from krrood.entity_query_language.factories import ConditionType
 
 

--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -139,7 +139,9 @@ class MultipleEffectVariablesNotSupported(DataclassException):
 class JointQueryAcrossClassesNotSupported(DataclassException):
     """
     Raised when a probabilistic query (``probability_of(...)``, ``average(...)``)
-    references attributes of more than one EQL class, e.g. ``average(x.A)`` combined
+    doesn't reference attributes of exactly one EQL class -- either none at all, e.g.
+    ``probability_of(True)`` (a content-free condition names no class, so there is no
+    model to resolve it against), or more than one, e.g. ``average(x.A)`` combined
     with attributes of a second class in the same call, for
     ``x = variable(ClassOne)`` and ``y = variable(ClassTwo)``.
 
@@ -147,16 +149,22 @@ class JointQueryAcrossClassesNotSupported(DataclassException):
     always for one class by construction.
 
     Every :class:`~krrood.parametrization.model_registries.ModelRegistry` resolves a
-    single model per class, so there is no established way to ground a query spanning
-    two different classes' models yet.
+    single model per class, so there is no established way to ground a query
+    referencing zero, or more than one, classes' models yet.
     """
 
     owner_classes: Set[Type]
     """
-    The distinct owner classes found among the query's referenced attributes.
+    The distinct owner classes found among the query's referenced attributes -- empty
+    when it referenced none at all.
     """
 
     def error_message(self) -> str:
+        if not self.owner_classes:
+            return (
+                "The query referenced no class-bound attributes at all, so there is "
+                "no model to resolve it against."
+            )
         names = ", ".join(sorted(cls.__name__ for cls in self.owner_classes))
         return (
             f"The query referenced attributes owned by {len(self.owner_classes)} "

--- a/krrood/src/krrood/parametrization/exceptions.py
+++ b/krrood/src/krrood/parametrization/exceptions.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
-from typing_extensions import Any, List, Set, Type
+from typing_extensions import Any, List, Set, TYPE_CHECKING, Type
 
 import random_events.variable
 from krrood.entity_query_language.core.variable import Variable
-from krrood.entity_query_language.factories import ConditionType
 from krrood.exceptions import DataclassException, InputError
+
+if TYPE_CHECKING:
+    # None of these exceptions construct a Probability/Distribution -- ConditionType is
+    # only ever a dataclass field annotation here, so importing krrood.entity_query_
+    # language.factories at runtime (which would cycle back through
+    # operators/probabilistic_queries.py, which factories.py imports Distribution/
+    # Probability from) isn't needed.
+    from krrood.entity_query_language.factories import ConditionType
 
 
 @dataclass

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing_extensions import Type, Dict
+from typing_extensions import Type, Dict, Union
 
-from krrood.parametrization.parameterizer import UnderspecifiedParameters
+from krrood.parametrization.parameterizer import (
+    UnderspecifiedParameters,
+    SelectedAttributesParameters,
+    ConditionParameters,
+)
 from krrood.utils import get_class_and_attribute_name
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
@@ -13,16 +17,29 @@ from probabilistic_model.probabilistic_circuit.relational.rspn import (
 from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized
 from probabilistic_model.probabilistic_model import ProbabilisticModel
 
+ModelResolutionParameters = Union[
+    UnderspecifiedParameters,
+    SelectedAttributesParameters,
+    ConditionParameters,
+]
+"""
+Whatever a :class:`ModelRegistry` needs to resolve a model: a full
+:class:`~krrood.parametrization.parameterizer.UnderspecifiedParameters` (for a
+``Match`` or a ``distribution(...)``, which wraps one), or one of the lighter parameter
+classes for the other probabilistic query constructs (``moment``, ``probability``) --
+all of them expose ``.variables`` and ``.queried_class``.
+"""
+
 
 @dataclass
 class ModelRegistry(ABC):
     """
     A registry that selects probabilistic models for given underspecified parameters of
-    match-queries.
+    match-queries (or other probabilistic queries).
     """
 
     @abstractmethod
-    def get_model(self, parameters: UnderspecifiedParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
         """
         :param parameters: The parameters to get a model for.
         :return: A probabilistic model that can be used to generate answers for the given expression.
@@ -35,7 +52,7 @@ class FullyFactorizedRegistry(ModelRegistry):
     A registry that always returns a fully factorized model.
     """
 
-    def get_model(self, parameters: UnderspecifiedParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
         return fully_factorized(parameters.variables.values())
 
 
@@ -50,8 +67,8 @@ class DictRegistry(ModelRegistry):
     A dictionary that maps classes to probabilistic models.
     """
 
-    def get_model(self, parameters: UnderspecifiedParameters) -> ProbabilisticModel:
-        return self.models[parameters.statement._expression.selected_variable._type_]
+    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+        return self.models[parameters.queried_class]
 
 
 @dataclass
@@ -60,6 +77,11 @@ class RelationalCircuitRegistry(ModelRegistry):
     A registry that grounds a RelationalProbabilisticCircuit for the queried statement
     and aligns its variable names to the UnderspecifiedParameters convention before
     returning.
+
+    Only supports :class:`~krrood.parametrization.parameterizer.UnderspecifiedParameters`
+    (i.e. a ``Match``, directly or wrapped by ``distribution(...)``): grounding needs
+    the full match statement, which ``moment``'s/``probability``'s lighter parameter
+    classes don't carry.
     """
 
     relational_probabilistic_circuit: RelationalProbabilisticCircuit
@@ -97,5 +119,5 @@ class CausalCircuitRegistry(ModelRegistry):
     A dictionary that maps classes to pre-built causal circuits.
     """
 
-    def get_model(self, parameters: UnderspecifiedParameters) -> ProbabilisticModel:
-        return self.circuits[parameters.statement._expression.selected_variable._type_]
+    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+        return self.circuits[parameters.queried_class]

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -1,12 +1,11 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing_extensions import Type, Dict, Union
+from typing_extensions import Type, Dict
 
 from krrood.parametrization.exceptions import RelationalCircuitRegistryRequiresMatch
 from krrood.parametrization.parameterizer import (
+    ModelQueryParameters,
     UnderspecifiedParameters,
-    SelectedAttributesParameters,
-    ConditionParameters,
 )
 from krrood.utils import get_class_and_attribute_name
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
@@ -18,19 +17,6 @@ from probabilistic_model.probabilistic_circuit.relational.rspn import (
 from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized
 from probabilistic_model.probabilistic_model import ProbabilisticModel
 
-ModelResolutionParameters = Union[
-    UnderspecifiedParameters,
-    SelectedAttributesParameters,
-    ConditionParameters,
-]
-"""
-Whatever a :class:`ModelRegistry` needs to resolve a model: a full
-:class:`~krrood.parametrization.parameterizer.UnderspecifiedParameters` (for a
-``Match`` or a ``distribution(...)``, which wraps one), or one of the lighter parameter
-classes for the other probabilistic query constructs (``moment``, ``probability``) --
-all of them expose ``.variables`` and ``.queried_class``.
-"""
-
 
 @dataclass
 class ModelRegistry(ABC):
@@ -40,7 +26,7 @@ class ModelRegistry(ABC):
     """
 
     @abstractmethod
-    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         """
         :param parameters: The parameters to get a model for.
         :return: A probabilistic model that can be used to generate answers for the given expression.
@@ -53,7 +39,7 @@ class FullyFactorizedRegistry(ModelRegistry):
     A registry that always returns a fully factorized model.
     """
 
-    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         return fully_factorized(parameters.variables.values())
 
 
@@ -68,7 +54,7 @@ class DictRegistry(ModelRegistry):
     A dictionary that maps classes to probabilistic models.
     """
 
-    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         return self.models[parameters.queried_class]
 
 
@@ -92,7 +78,7 @@ class RelationalCircuitRegistry(ModelRegistry):
     The trained relational probabilistic circuit to ground.
     """
 
-    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         if not isinstance(parameters, UnderspecifiedParameters):
             raise RelationalCircuitRegistryRequiresMatch(parameters)
         grounded = self.relational_probabilistic_circuit.ground(parameters.statement)
@@ -124,5 +110,5 @@ class CausalCircuitRegistry(ModelRegistry):
     A dictionary that maps classes to pre-built causal circuits.
     """
 
-    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         return self.circuits[parameters.queried_class]

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing_extensions import Type, Dict, Union
 
+from krrood.parametrization.exceptions import RelationalCircuitRegistryRequiresMatch
 from krrood.parametrization.parameterizer import (
     UnderspecifiedParameters,
     SelectedAttributesParameters,
@@ -79,9 +80,11 @@ class RelationalCircuitRegistry(ModelRegistry):
     returning.
 
     Only supports :class:`~krrood.parametrization.parameterizer.UnderspecifiedParameters`
-    (i.e. a ``Match``, directly or wrapped by ``distribution(...)``): grounding needs
-    the full match statement, which ``moment``'s/``probability``'s lighter parameter
-    classes don't carry.
+    (i.e. a ``Match``, directly or wrapped by ``distribution_of(...)``): grounding needs
+    the full match statement, which ``average``'s/``probability_of``'s lighter
+    parameter classes don't carry -- resolving one of those raises
+    :class:`~krrood.parametrization.exceptions.RelationalCircuitRegistryRequiresMatch`
+    rather than failing on a missing attribute.
     """
 
     relational_probabilistic_circuit: RelationalProbabilisticCircuit
@@ -89,7 +92,9 @@ class RelationalCircuitRegistry(ModelRegistry):
     The trained relational probabilistic circuit to ground.
     """
 
-    def get_model(self, parameters: UnderspecifiedParameters) -> ProbabilisticModel:
+    def get_model(self, parameters: ModelResolutionParameters) -> ProbabilisticModel:
+        if not isinstance(parameters, UnderspecifiedParameters):
+            raise RelationalCircuitRegistryRequiresMatch(parameters)
         grounded = self.relational_probabilistic_circuit.ground(parameters.statement)
         class_prefix = self.relational_probabilistic_circuit.class_.__name__
         rename_map = {}

--- a/krrood/src/krrood/parametrization/parameterizer.py
+++ b/krrood/src/krrood/parametrization/parameterizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import EnumType
 from functools import cached_property
@@ -55,8 +56,64 @@ if TYPE_CHECKING:
     from probabilistic_model.probabilistic_model import ProbabilisticModel
 
 
+class ModelQueryParameters(ABC):
+    """
+    Shared interface between EQL constructs and ``ProbabilisticModel``: whatever a
+    :class:`~krrood.parametrization.model_registries.ModelRegistry` needs to resolve a
+    model, regardless of which EQL construct is asking. Three constructs each build
+    their own parameters this way -- :class:`UnderspecifiedParameters` for a ``Match``
+    (``distribution_of(...)`` too, which wraps one), :class:`SelectedAttributesParameters`
+    for a bare attribute selection (``average(...)``), and :class:`ConditionParameters`
+    for a bare condition (``probability_of(...)``) -- so a registry can type against
+    this one interface instead of a union of the three.
+    """
+
+    @property
+    @abstractmethod
+    def variables(self) -> dict[str, random_events.variable.Variable]:
+        """
+        :return: A dictionary that maps variable names to the random events variables
+            this query references.
+        """
+
+    @property
+    @abstractmethod
+    def queried_class(self) -> Type:
+        """
+        :return: The single class this query's model must be resolved for.
+        :raises JointQueryAcrossClassesNotSupported: If the query references
+            attributes reached from more than one owner class.
+        """
+
+    @staticmethod
+    def _single_owner_class(attributes: Iterable[Attribute]) -> Type:
+        """
+        Shared ``queried_class`` implementation for the two subclasses
+        (:class:`SelectedAttributesParameters`, :class:`ConditionParameters`) that
+        resolve their class from a plain collection of attributes rather than a
+        ``Match``'s own selected variable.
+
+        :param attributes: The attributes a subclass's ``queried_class`` was given.
+        :return: The single class every attribute is reached from -- the class of each
+            attribute chain's root ``variable(...)``, not its immediate parent (so a
+            multi-hop chain like ``x.arm.battery`` resolves to ``x``'s class, matching
+            what every :class:`ModelRegistry
+            <krrood.parametrization.model_registries.ModelRegistry>` is keyed on, not
+            ``Arm``).
+        :raises JointQueryAcrossClassesNotSupported: If the attributes are reached from
+            more than one owner class -- every :class:`ModelRegistry
+            <krrood.parametrization.model_registries.ModelRegistry>` resolves a single
+            model per class, so a query joining several classes' models is not
+            supported.
+        """
+        owner_classes = {attribute._chain_root_._type_ for attribute in attributes}
+        if len(owner_classes) != 1:
+            raise JointQueryAcrossClassesNotSupported(owner_classes)
+        return owner_classes.pop()
+
+
 @dataclass
-class UnderspecifiedParameters:
+class UnderspecifiedParameters(ModelQueryParameters):
     """
     A class that extracts all necessary information from a
     {py:class}`~krrood.entity_query_language.query.match.Match` and binds it together.
@@ -660,28 +717,8 @@ class UnderspecifiedParameters:
             return type_
 
 
-def _single_owner_class(attributes: Iterable[Attribute]) -> Type:
-    """
-    :param attributes: The attributes a probabilistic query (``distribution_of(...)``,
-        ``probability_of(...)``, ``average(...)``) was given.
-    :return: The single class every attribute is reached from -- the class of each
-        attribute chain's root ``variable(...)``, not its immediate parent (so a
-        multi-hop chain like ``x.arm.battery`` resolves to ``x``'s class, matching what
-        every :class:`ModelRegistry <krrood.parametrization.model_registries.ModelRegistry>`
-        is keyed on, not ``Arm``).
-    :raises JointQueryAcrossClassesNotSupported: If the attributes are reached from
-        more than one owner class -- every :class:`ModelRegistry
-        <krrood.parametrization.model_registries.ModelRegistry>` resolves a single
-        model per class, so a query joining several classes' models is not supported.
-    """
-    owner_classes = {attribute._chain_root_._type_ for attribute in attributes}
-    if len(owner_classes) != 1:
-        raise JointQueryAcrossClassesNotSupported(owner_classes)
-    return owner_classes.pop()
-
-
 @dataclass
-class SelectedAttributesParameters:
+class SelectedAttributesParameters(ModelQueryParameters):
     """
     A class that extracts all necessary information from a bare selection of
     attributes and binds it together.
@@ -707,7 +744,7 @@ class SelectedAttributesParameters:
         :raises JointQueryAcrossClassesNotSupported: If the selected attributes are
             reached from more than one owner class.
         """
-        return _single_owner_class(self.attributes)
+        return self._single_owner_class(self.attributes)
 
     @cached_property
     def variables(self) -> dict[str, random_events.variable.Variable]:
@@ -724,12 +761,11 @@ class SelectedAttributesParameters:
 
 
 @dataclass
-class ConditionParameters:
+class ConditionParameters(ModelQueryParameters):
     """
     A class that extracts all necessary information from a condition expression given
     to {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
-    or {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Truncated`
-    and binds it together, reusing the same
+    (``probability_of(...)``) and binds it together, reusing the same
     :class:`~krrood.parametrization.random_events_translator.WhereExpressionToRandomEventTranslator`
     a ``Match``'s ``where`` conditions are already translated with.
     """
@@ -765,4 +801,4 @@ class ConditionParameters:
         :raises JointQueryAcrossClassesNotSupported: If the condition constrains
             attributes reached from more than one owner class.
         """
-        return _single_owner_class(self._translator.variables.keys())
+        return self._single_owner_class(self._translator.variables.keys())

--- a/krrood/src/krrood/parametrization/parameterizer.py
+++ b/krrood/src/krrood/parametrization/parameterizer.py
@@ -7,17 +7,30 @@ from functools import cached_property
 from types import UnionType, EllipsisType
 
 import numpy as np
-from typing_extensions import Any, Iterable, Optional, Union, get_args
-from krrood.parametrization.exceptions import EmptyVariableDomain, InvalidEllipsis
+from typing_extensions import (
+    Any,
+    Iterable,
+    Optional,
+    TYPE_CHECKING,
+    Type,
+    Union,
+    get_args,
+)
+from krrood.parametrization.exceptions import (
+    EmptyVariableDomain,
+    InvalidEllipsis,
+    JointQueryAcrossClassesNotSupported,
+)
 import random_events.variable
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
+from krrood.entity_query_language.core.mapped_variable import Attribute
 from krrood.entity_query_language.operators.causal import (
     Cause,
     CausesEffect,
     Confounder,
 )
 from krrood.entity_query_language.core.variable import Literal, Variable
-from krrood.entity_query_language.factories import and_
+from krrood.entity_query_language.factories import and_, ConditionType
 from krrood.entity_query_language.operators.core_logical_operators import (
     AND,
     flatten_operands,
@@ -37,6 +50,9 @@ from random_events.variable import (
     variable_from_name_and_type,
     most_appropriate_variable_type,
 )
+
+if TYPE_CHECKING:
+    from probabilistic_model.probabilistic_model import ProbabilisticModel
 
 
 @dataclass
@@ -173,6 +189,63 @@ class UnderspecifiedParameters:
             result.update(self._extract_variables_from_attribute_match(attribute_match))
 
         return result
+
+    @property
+    def queried_class(self) -> type:
+        """
+        :return: The class the match's selected variable is an instance of.
+        """
+        return self.statement._expression.selected_variable._type_
+
+    def resolve_conditioned_and_truncated_model(
+        self, model: ProbabilisticModel
+    ) -> Optional[ProbabilisticModel]:
+        """
+        Apply this match's literal-value conditions, then its where-conditions, then
+        its krrood-variable-assignment truncations, to ``model``, in that order -- the
+        same sequence
+        :class:`~krrood.entity_query_language.backends.ProbabilisticBackend` already
+        applies to a non-causal match before sampling from it.
+
+        :param model: The model to condition and truncate.
+        :return: The resulting model, or ``None`` if any step leaves no solution.
+        """
+        conditioned, _ = model.conditional(
+            self.conditioning_assignments_from_literal_values
+        )
+        if conditioned is None:
+            return None
+
+        if self.truncation_assignments_from_where_conditions:
+            truncated, _ = conditioned.truncated(
+                self.truncation_assignments_from_where_conditions
+            )
+        else:
+            truncated = conditioned
+        if truncated is None:
+            return None
+
+        return self.apply_krrood_variable_truncation(truncated)
+
+    def apply_krrood_variable_truncation(
+        self, model: ProbabilisticModel
+    ) -> Optional[ProbabilisticModel]:
+        """
+        Truncate ``model`` on this match's symbolic-variable-assignment constraints
+        (e.g. ``z=variable(int, domain=[1, 2, 3])``), if any.
+
+        :param model: The model to truncate.
+        :return: ``model`` unchanged if there are no such constraints, the truncated
+            model otherwise, or ``None`` if truncating leaves no solution.
+        """
+        if not self.truncation_assignments_from_krrood_variables:
+            return model
+        complete_event = self.truncation_assignments_from_krrood_variables[0]
+        complete_event.fill_missing_variables(self.variables.values())
+        for event in self.truncation_assignments_from_krrood_variables[1:]:
+            complete_event = complete_event.intersection_with(event)
+        truncated, _ = model.truncated(complete_event, singleton_allowed=True)
+        return truncated
 
     def _extract_variables_from_attribute_match(
         self, attribute_match: AttributeMatch
@@ -585,3 +658,108 @@ class UnderspecifiedParameters:
             return most_appropriate_variable_type(types)
         else:
             return type_
+
+
+def _single_owner_class(attributes: Iterable[Attribute]) -> Type:
+    """
+    :param attributes: The attributes a probabilistic query (``marginal(...)``,
+        ``probability(...)``, ``conditional(...)``, ``truncated(...)``,
+        ``moment(...)``) was given.
+    :return: The single class every attribute is reached from.
+    :raises JointQueryAcrossClassesNotSupported: If the attributes are reached from
+        more than one owner class -- every :class:`ModelRegistry
+        <krrood.parametrization.model_registries.ModelRegistry>` resolves a single
+        model per class, so a query joining several classes' models is not supported.
+    """
+    owner_classes = {attribute._owner_class_ for attribute in attributes}
+    if len(owner_classes) != 1:
+        raise JointQueryAcrossClassesNotSupported(owner_classes)
+    return owner_classes.pop()
+
+
+@dataclass
+class SelectedAttributesParameters:
+    """
+    A class that extracts all necessary information from a bare selection of
+    attributes and binds it together.
+
+    This serves the same role as :class:`UnderspecifiedParameters` does for
+    :class:`~krrood.entity_query_language.query.match.Match` -- glue between
+    `ProbabilisticModel` and EQL -- but for constructs that select attributes directly
+    rather than a structural match, since there are no where conditions, literal
+    assignments or cause/confounder markers to extract. Used by
+    {py:class}`~krrood.entity_query_language.operators.marginal.Marginal` and
+    {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Moment`.
+    """
+
+    attributes: tuple[Attribute, ...]
+    """
+    The attributes to extract information from.
+    """
+
+    @cached_property
+    def queried_class(self) -> Type:
+        """
+        :return: The single class every selected attribute is reached from.
+        :raises JointQueryAcrossClassesNotSupported: If the selected attributes are
+            reached from more than one owner class.
+        """
+        return _single_owner_class(self.attributes)
+
+    @cached_property
+    def variables(self) -> dict[str, random_events.variable.Variable]:
+        """
+        :return: A dictionary that maps variable names to random events variables for
+            the selected attributes.
+        """
+        return {
+            attribute._name_: variable_from_name_and_type(
+                attribute._name_, attribute._type_
+            )
+            for attribute in self.attributes
+        }
+
+
+@dataclass
+class ConditionParameters:
+    """
+    A class that extracts all necessary information from a condition expression given
+    to {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Probability`
+    or {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Truncated`
+    and binds it together, reusing the same
+    :class:`~krrood.parametrization.random_events_translator.WhereExpressionToRandomEventTranslator`
+    a ``Match``'s ``where`` conditions are already translated with.
+    """
+
+    condition: ConditionType
+    """
+    The condition to extract information from.
+    """
+
+    @cached_property
+    def _translator(self) -> WhereExpressionToRandomEventTranslator:
+        return WhereExpressionToRandomEventTranslator(self.condition)
+
+    @cached_property
+    def event(self) -> Event:
+        """
+        :return: The random event the condition translates to.
+        """
+        return self._translator.translate()
+
+    @cached_property
+    def variables(self) -> dict[str, random_events.variable.Variable]:
+        """
+        :return: A dictionary that maps variable names to random events variables that
+            appear in the condition.
+        """
+        return {v.name: v for v in self._translator.variables.values()}
+
+    @cached_property
+    def queried_class(self) -> Type:
+        """
+        :return: The single class every variable in the condition is reached from.
+        :raises JointQueryAcrossClassesNotSupported: If the condition constrains
+            attributes reached from more than one owner class.
+        """
+        return _single_owner_class(self._translator.variables.keys())

--- a/krrood/src/krrood/parametrization/parameterizer.py
+++ b/krrood/src/krrood/parametrization/parameterizer.py
@@ -662,16 +662,19 @@ class UnderspecifiedParameters:
 
 def _single_owner_class(attributes: Iterable[Attribute]) -> Type:
     """
-    :param attributes: The attributes a probabilistic query (``marginal(...)``,
-        ``probability(...)``, ``conditional(...)``, ``truncated(...)``,
-        ``moment(...)``) was given.
-    :return: The single class every attribute is reached from.
+    :param attributes: The attributes a probabilistic query (``distribution_of(...)``,
+        ``probability_of(...)``, ``average(...)``) was given.
+    :return: The single class every attribute is reached from -- the class of each
+        attribute chain's root ``variable(...)``, not its immediate parent (so a
+        multi-hop chain like ``x.arm.battery`` resolves to ``x``'s class, matching what
+        every :class:`ModelRegistry <krrood.parametrization.model_registries.ModelRegistry>`
+        is keyed on, not ``Arm``).
     :raises JointQueryAcrossClassesNotSupported: If the attributes are reached from
         more than one owner class -- every :class:`ModelRegistry
         <krrood.parametrization.model_registries.ModelRegistry>` resolves a single
         model per class, so a query joining several classes' models is not supported.
     """
-    owner_classes = {attribute._owner_class_ for attribute in attributes}
+    owner_classes = {attribute._chain_root_._type_ for attribute in attributes}
     if len(owner_classes) != 1:
         raise JointQueryAcrossClassesNotSupported(owner_classes)
     return owner_classes.pop()
@@ -687,9 +690,9 @@ class SelectedAttributesParameters:
     :class:`~krrood.entity_query_language.query.match.Match` -- glue between
     `ProbabilisticModel` and EQL -- but for constructs that select attributes directly
     rather than a structural match, since there are no where conditions, literal
-    assignments or cause/confounder markers to extract. Used by
-    {py:class}`~krrood.entity_query_language.operators.marginal.Marginal` and
-    {py:class}`~krrood.entity_query_language.operators.probabilistic_queries.Moment`.
+    assignments or cause/confounder markers to extract. Used to resolve a bare
+    ``average(...)`` selection under
+    :class:`~krrood.entity_query_language.backends.ProbabilisticBackend`.
     """
 
     attributes: tuple[Attribute, ...]

--- a/krrood/src/krrood/parametrization/random_events_translator.py
+++ b/krrood/src/krrood/parametrization/random_events_translator.py
@@ -30,11 +30,6 @@ from random_events.interval import closed_open, closed, open
 from random_events.product_algebra import Event, SimpleEvent
 
 if TYPE_CHECKING:
-    # ConditionType is only ever a dataclass field annotation here (see
-    # WhereExpressionToRandomEventTranslator.conditions_root below) -- never
-    # constructed -- so importing krrood.entity_query_language.factories at runtime
-    # (which would cycle back through operators/probabilistic_queries.py, which
-    # factories.py imports Distribution/Probability from) isn't needed.
     from krrood.entity_query_language.factories import ConditionType
 
 # %% translating a where expression into a random event

--- a/krrood/src/krrood/parametrization/random_events_translator.py
+++ b/krrood/src/krrood/parametrization/random_events_translator.py
@@ -4,7 +4,7 @@ import itertools
 import operator
 from dataclasses import dataclass
 from functools import cached_property
-from typing import assert_never, Dict
+from typing import assert_never, Dict, TYPE_CHECKING
 
 import numpy as np
 
@@ -17,7 +17,6 @@ from krrood.entity_query_language.core.base_expressions import (
 from krrood.entity_query_language.operators.causal import CausesEffect
 from krrood.entity_query_language.core.mapped_variable import MappedVariable
 from krrood.entity_query_language.core.variable import Literal
-from krrood.entity_query_language.factories import ConditionType
 from krrood.entity_query_language.operators.comparator import Comparator
 from krrood.entity_query_language.operators.core_logical_operators import OR, AND, Not
 from krrood.entity_query_language.operators.logical_quantifiers import (
@@ -29,6 +28,14 @@ from krrood.parametrization.exceptions import (
 )
 from random_events.interval import closed_open, closed, open
 from random_events.product_algebra import Event, SimpleEvent
+
+if TYPE_CHECKING:
+    # ConditionType is only ever a dataclass field annotation here (see
+    # WhereExpressionToRandomEventTranslator.conditions_root below) -- never
+    # constructed -- so importing krrood.entity_query_language.factories at runtime
+    # (which would cycle back through operators/probabilistic_queries.py, which
+    # factories.py imports Distribution/Probability from) isn't needed.
+    from krrood.entity_query_language.factories import ConditionType
 
 # %% translating a where expression into a random event
 

--- a/test/krrood_test/test_eql/test_probabilistic_queries/_fixtures.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/_fixtures.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from probabilistic_model.distributions.uniform import UniformDistribution
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit,
+    ProductUnit,
+    leaf,
+)
+from random_events.interval import closed
+from random_events.variable import Continuous
+
+
+@dataclass
+class Coin:
+    a: float
+    b: float
+    c: float
+
+
+@dataclass
+class OtherClass:
+    d: float
+
+
+def build_three_independent_variables_circuit() -> tuple:
+    """
+    A circuit over three mutually independent uniformly distributed variables:
+
+        Coin.a ~ Uniform([0, 1])
+        Coin.b ~ Uniform([0, 2])
+        Coin.c ~ Uniform([0, 3])
+
+    Since the variables are independent, any operation on `a`/`b` alone must not depend
+    on `c`, and vice versa -- used throughout test_probabilistic_queries/ to check EQL
+    results against the same operation called directly on the circuit.
+    """
+    var_a = Continuous("Coin.a")
+    var_b = Continuous("Coin.b")
+    var_c = Continuous("Coin.c")
+
+    circuit = ProbabilisticCircuit()
+    root = ProductUnit(probabilistic_circuit=circuit)
+    root.add_subcircuit(leaf(UniformDistribution(variable=var_a, interval=closed(0, 1).simple_sets[0]), circuit))
+    root.add_subcircuit(leaf(UniformDistribution(variable=var_b, interval=closed(0, 2).simple_sets[0]), circuit))
+    root.add_subcircuit(leaf(UniformDistribution(variable=var_c, interval=closed(0, 3).simple_sets[0]), circuit))
+    return circuit, var_a, var_b, var_c

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_average.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_average.py
@@ -1,0 +1,43 @@
+import pytest
+
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.exceptions import (
+    GenerativeBackendQueryIsNotUnderspecifiedVariable,
+)
+from krrood.entity_query_language.factories import average, variable
+from krrood.parametrization.model_registries import DictRegistry
+
+from ._fixtures import Coin, build_three_independent_variables_circuit
+
+
+def test_average_resolves_to_the_expectation_under_probabilistic_backend():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    x = variable(Coin)
+
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+    # midpoints of Uniform([0, 1]) and Uniform([0, 2]) -- computed in closed form via
+    # ProbabilisticModel.moment, not by sampling and averaging rows
+    assert average(x.a).first(backend=backend) == pytest.approx(0.5)
+    assert average(x.b).first(backend=backend) == pytest.approx(1.0)
+
+
+def test_average_still_works_natively():
+    heights = [1, 2, 3, 4, 5]
+    heights_var = variable(int, domain=heights)
+
+    assert average(heights_var).first() == pytest.approx(sum(heights) / len(heights))
+
+
+def test_average_with_grouping_is_not_reinterpreted_probabilistically():
+    circuit, var_a, _, _ = build_three_independent_variables_circuit()
+    x = variable(Coin)
+
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+    # ProbabilisticBackend only shortcuts a bare average(...) selection -- one grouped
+    # (or filtered/ordered) needs enumerated data to group over, which a bare
+    # variable(...) has none of, so it falls through to the ordinary generative-backend
+    # error rather than silently ignoring the grouping.
+    with pytest.raises(GenerativeBackendQueryIsNotUnderspecifiedVariable):
+        average(x.a).grouped_by(x).first(backend=backend)

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_bug_fixes.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_bug_fixes.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+
+import pytest
+from probabilistic_model.distributions.uniform import UniformDistribution
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit,
+    ProductUnit,
+    leaf,
+)
+from random_events.interval import closed
+from random_events.variable import Continuous
+
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.exceptions import ProbabilityConditionNotVerbalizable
+from krrood.entity_query_language.factories import average, probability_of, variable
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
+from krrood.parametrization.exceptions import RelationalCircuitRegistryRequiresMatch
+from krrood.parametrization.model_registries import DictRegistry, RelationalCircuitRegistry
+
+
+@dataclass
+class Arm:
+    battery: float
+
+
+@dataclass
+class Robot:
+    arm: Arm
+
+
+def _build_robot_circuit():
+    """
+    A circuit for the multi-hop attribute `Robot.arm.battery`, named to match exactly
+    what that chain resolves to (see Attribute._name_) -- not `Robot.battery`, which a
+    single-hop-only class resolution would incorrectly look for.
+    """
+    x = variable(Robot)
+    var_battery = Continuous(x.arm.battery._name_)
+    circuit = ProbabilisticCircuit()
+    root = ProductUnit(probabilistic_circuit=circuit)
+    root.add_subcircuit(
+        leaf(UniformDistribution(variable=var_battery, interval=closed(0, 100).simple_sets[0]), circuit)
+    )
+    return circuit, var_battery
+
+
+def test_multi_hop_attribute_resolves_to_root_class():
+    """
+    probability_of/average must key the model registry lookup by the attribute
+    chain's root class (Robot), not its immediate parent (Arm) -- a Robot is what's
+    registered in the ModelRegistry, an Arm never is.
+    """
+    circuit, _ = _build_robot_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Robot: circuit}))
+
+    x = variable(Robot)
+    assert probability_of(x.arm.battery < 50).first(backend=backend) == pytest.approx(0.5)
+
+    x2 = variable(Robot)
+    assert average(x2.arm.battery).first(backend=backend) == pytest.approx(50.0)
+
+
+def test_average_distinct_falls_through_to_native_evaluation():
+    """
+    average(..., distinct=True) must not silently take the probabilistic closed-form
+    shortcut: native evaluation deduplicates values before averaging, which the
+    closed-form expectation has no notion of.
+    """
+    circuit, _ = _build_robot_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Robot: circuit}))
+
+    x = variable(Robot)
+    with pytest.raises(Exception):
+        average(x.arm.battery, distinct=True).first(backend=backend)
+
+
+def test_probability_of_bool_condition_raises_clear_error_on_verbalization():
+    with pytest.raises(ProbabilityConditionNotVerbalizable):
+        verbalize_expression(probability_of(True))
+
+
+def test_relational_circuit_registry_rejects_non_match_parameters():
+    circuit, _ = _build_robot_circuit()
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=None)
+    backend = ProbabilisticBackend(model_registry=registry)
+
+    x = variable(Robot)
+    with pytest.raises(RelationalCircuitRegistryRequiresMatch):
+        probability_of(x.arm.battery < 50).first(backend=backend)

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_bug_fixes.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_bug_fixes.py
@@ -11,10 +11,12 @@ from random_events.interval import closed
 from random_events.variable import Continuous
 
 from krrood.entity_query_language.backends import ProbabilisticBackend
-from krrood.entity_query_language.exceptions import ProbabilityConditionNotVerbalizable
 from krrood.entity_query_language.factories import average, probability_of, variable
 from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
-from krrood.parametrization.exceptions import RelationalCircuitRegistryRequiresMatch
+from krrood.parametrization.exceptions import (
+    JointQueryAcrossClassesNotSupported,
+    RelationalCircuitRegistryRequiresMatch,
+)
 from krrood.parametrization.model_registries import DictRegistry, RelationalCircuitRegistry
 
 
@@ -74,9 +76,20 @@ def test_average_distinct_falls_through_to_native_evaluation():
         average(x.arm.battery, distinct=True).first(backend=backend)
 
 
-def test_probability_of_bool_condition_raises_clear_error_on_verbalization():
-    with pytest.raises(ProbabilityConditionNotVerbalizable):
-        verbalize_expression(probability_of(True))
+def test_probability_of_bool_condition_verbalizes_but_does_not_evaluate():
+    """
+    probability_of(True)'s condition is normalized to a Literal on construction (the
+    same normalization and_/or_/not_ already apply to a bare-bool operand), so it
+    verbalizes cleanly like any other condition -- but it still can't evaluate: a
+    content-free condition names no class, so there is no model to resolve it against.
+    """
+    text = verbalize_expression(probability_of(True))
+    assert text == "the probability that True"
+
+    circuit, _ = _build_robot_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Robot: circuit}))
+    with pytest.raises(JointQueryAcrossClassesNotSupported):
+        probability_of(True).first(backend=backend)
 
 
 def test_relational_circuit_registry_rejects_non_match_parameters():

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_distribution.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_distribution.py
@@ -1,0 +1,57 @@
+import pytest
+from random_events.interval import closed
+from random_events.product_algebra import SimpleEvent
+
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.factories import a, distribution_of, variable
+from krrood.parametrization.model_registries import DictRegistry
+
+from ._fixtures import Coin, build_three_independent_variables_circuit
+
+
+def test_distribution_conditions_and_truncates():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+    x = a(Coin)(a=..., b=..., c=1.5)
+    x.where(x.variable.a > 0.2)
+    result = distribution_of(x).first(backend=backend)
+
+    # a=..., b=... are free; c=1.5 conditions the circuit (a point mass at 1.5, not
+    # dropped from the model's variables); a > 0.2 truncates
+    assert {v.name for v in result.variables} == {"Coin.a", "Coin.b", "Coin.c"}
+
+    a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()
+    assert result.probability(a_range) == pytest.approx(1.0)
+
+    # b is independent of a/c, so truncating/conditioning on them leaves it unchanged
+    b_range = SimpleEvent.from_data({var_b: closed(0, 1)}).as_composite_set()
+    assert result.probability(b_range) == pytest.approx(0.5)
+
+    c_point = SimpleEvent.from_data({var_c: closed(1.5, 1.5)}).as_composite_set()
+    assert result.probability(c_point) == pytest.approx(1.0)
+
+
+def test_distribution_narrowed_to_selected_variables():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+    x = a(Coin)(a=..., b=..., c=1.5)
+    x.where(x.variable.a > 0.2)
+    result = distribution_of(x, x.variable.a).first(backend=backend)
+
+    assert {v.name for v in result.variables} == {"Coin.a"}
+    a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()
+    assert result.probability(a_range) == pytest.approx(1.0)
+
+
+def test_distribution_no_conditions_or_where_is_the_full_joint():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+
+    x = a(Coin)(a=..., b=..., c=...)
+    result = distribution_of(x).first(backend=backend)
+
+    assert {v.name for v in result.variables} == {"Coin.a", "Coin.b", "Coin.c"}
+    a_range = SimpleEvent.from_data({var_a: closed(0, 0.5)}).as_composite_set()
+    assert result.probability(a_range) == pytest.approx(0.5)

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_distribution.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_distribution.py
@@ -38,7 +38,7 @@ def test_distribution_narrowed_to_selected_variables():
 
     x = a(Coin)(a=..., b=..., c=1.5)
     x.where(x.variable.a > 0.2)
-    result = distribution_of(x, x.variable.a).first(backend=backend)
+    result = distribution_of(x, marginalize_for=(x.variable.a,)).first(backend=backend)
 
     assert {v.name for v in result.variables} == {"Coin.a"}
     a_range = SimpleEvent.from_data({var_a: closed(0.2, 1)}).as_composite_set()

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_native_evaluation_rejected.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_native_evaluation_rejected.py
@@ -2,29 +2,21 @@ import pytest
 
 from krrood.entity_query_language.backends import EntityQueryLanguageBackend
 from krrood.entity_query_language.exceptions import BackendCannotEvaluateProbabilisticQuery
-from krrood.entity_query_language.factories import a, distribution_of, probability_of, variable
+from krrood.entity_query_language.factories import a, distribution_of
 
 from ._fixtures import Coin
 
-# Every ProbabilisticQuery subclass shares the same _evaluate_natively_/backend-rejection
-# behavior (defined once on the ProbabilisticQuery base), so one parametrized test covers
-# both rather than duplicating the same three assertions per construct. average(...) is
-# NOT a ProbabilisticQuery -- it has an ordinary native meaning (a per-row average) and
-# is only reinterpreted probabilistically by ProbabilisticBackend, so it belongs in
-# test_average.py, not here.
-CONSTRUCTORS = [
-    lambda x, match: distribution_of(match),
-    lambda x, match: probability_of(x.a > 0.5),
-]
+# distribution_of never resolves natively -- there's no row-based equivalent for a
+# whole distribution the way probability_of has counting (see test_probability.py's
+# native-evaluation tests). average(...) isn't covered here either: it's not a
+# ProbabilisticQuery -- it has an ordinary native meaning (a per-row average) and is
+# only reinterpreted probabilistically by ProbabilisticBackend, so it belongs in
+# test_average.py.
 
 
-@pytest.mark.parametrize(
-    "construct", CONSTRUCTORS, ids=["distribution_of", "probability_of"]
-)
-def test_native_evaluation_rejected(construct):
-    x = variable(Coin)
+def test_distribution_of_native_evaluation_rejected():
     match = a(Coin)(a=..., b=..., c=...)
-    query = construct(x, match)
+    query = distribution_of(match)
 
     with pytest.raises(BackendCannotEvaluateProbabilisticQuery):
         list(query._evaluate_natively_())

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_native_evaluation_rejected.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_native_evaluation_rejected.py
@@ -1,0 +1,36 @@
+import pytest
+
+from krrood.entity_query_language.backends import EntityQueryLanguageBackend
+from krrood.entity_query_language.exceptions import BackendCannotEvaluateProbabilisticQuery
+from krrood.entity_query_language.factories import a, distribution_of, probability_of, variable
+
+from ._fixtures import Coin
+
+# Every ProbabilisticQuery subclass shares the same _evaluate_natively_/backend-rejection
+# behavior (defined once on the ProbabilisticQuery base), so one parametrized test covers
+# both rather than duplicating the same three assertions per construct. average(...) is
+# NOT a ProbabilisticQuery -- it has an ordinary native meaning (a per-row average) and
+# is only reinterpreted probabilistically by ProbabilisticBackend, so it belongs in
+# test_average.py, not here.
+CONSTRUCTORS = [
+    lambda x, match: distribution_of(match),
+    lambda x, match: probability_of(x.a > 0.5),
+]
+
+
+@pytest.mark.parametrize(
+    "construct", CONSTRUCTORS, ids=["distribution_of", "probability_of"]
+)
+def test_native_evaluation_rejected(construct):
+    x = variable(Coin)
+    match = a(Coin)(a=..., b=..., c=...)
+    query = construct(x, match)
+
+    with pytest.raises(BackendCannotEvaluateProbabilisticQuery):
+        list(query._evaluate_natively_())
+
+    with pytest.raises(BackendCannotEvaluateProbabilisticQuery):
+        query.first()
+
+    with pytest.raises(BackendCannotEvaluateProbabilisticQuery):
+        query.first(backend=EntityQueryLanguageBackend())

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_probability.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_probability.py
@@ -2,12 +2,23 @@ import pytest
 from random_events.interval import closed
 from random_events.product_algebra import SimpleEvent
 
-from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.backends import EntityQueryLanguageBackend, ProbabilisticBackend
 from krrood.entity_query_language.factories import and_, probability_of, variable
 from krrood.parametrization.exceptions import JointQueryAcrossClassesNotSupported
 from krrood.parametrization.model_registries import DictRegistry
 
 from ._fixtures import Coin, OtherClass, build_three_independent_variables_circuit
+
+# A small, hand-picked domain (not sampled) so the expected fraction is exact, not an
+# approximation -- 4 out of 6 coins have a < 0.5.
+_COIN_DOMAIN = [
+    Coin(a=0.1, b=1.0, c=1.0),
+    Coin(a=0.2, b=1.0, c=1.0),
+    Coin(a=0.3, b=0.5, c=1.0),
+    Coin(a=0.4, b=0.5, c=1.0),
+    Coin(a=0.6, b=1.0, c=1.0),
+    Coin(a=0.9, b=1.0, c=1.0),
+]
 
 
 def test_probability_matches_direct_computation():
@@ -44,3 +55,35 @@ def test_probability_rejects_cross_class():
         probability_of(and_(x.a < 0.5, y.d < 0.5)).first(
             backend=ProbabilisticBackend(model_registry=DictRegistry({}))
         )
+
+
+def test_probability_evaluates_natively_by_counting_matching_rows():
+    """
+    Unlike distribution_of, probability_of also has a native evaluation strategy: a
+    probability is definitionally the fraction of a domain's rows the condition holds
+    for, so it's counted directly -- no ProbabilisticBackend/fitted model needed, just
+    an enumerable domain.
+    """
+    x = variable(Coin, domain=_COIN_DOMAIN)
+    result = probability_of(x.a < 0.5).first()  # no backend -> defaults to native
+
+    assert result == pytest.approx(4 / 6)
+
+
+def test_probability_native_evaluation_explicit_backend_and_conjunction():
+    x = variable(Coin, domain=_COIN_DOMAIN)
+    result = probability_of(and_(x.a < 0.5, x.b < 1)).first(
+        backend=EntityQueryLanguageBackend()
+    )
+
+    # 2 of 6 coins have both a < 0.5 and b < 1 (a=0.3,b=0.5 and a=0.4,b=0.5)
+    assert result == pytest.approx(2 / 6)
+
+
+def test_probability_of_true_rejected_natively_too():
+    """
+    A content-free condition names no class either way -- there's neither a model to
+    resolve (ProbabilisticBackend) nor a domain to count over (native).
+    """
+    with pytest.raises(JointQueryAcrossClassesNotSupported):
+        probability_of(True).first()

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_probability.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_probability.py
@@ -1,0 +1,46 @@
+import pytest
+from random_events.interval import closed
+from random_events.product_algebra import SimpleEvent
+
+from krrood.entity_query_language.backends import ProbabilisticBackend
+from krrood.entity_query_language.factories import and_, probability_of, variable
+from krrood.parametrization.exceptions import JointQueryAcrossClassesNotSupported
+from krrood.parametrization.model_registries import DictRegistry
+
+from ._fixtures import Coin, OtherClass, build_three_independent_variables_circuit
+
+
+def test_probability_matches_direct_computation():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    x = variable(Coin)
+
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+    result = probability_of(x.a < 0.5).first(backend=backend)
+
+    expected = circuit.probability(
+        SimpleEvent.from_data({var_a: closed(0, 0.5)}).as_composite_set()
+    )
+    assert result == pytest.approx(expected)
+    # a is independent of b/c and uniform on [0, 1], so P(a < 0.5) == 0.5 regardless
+    assert result == pytest.approx(0.5)
+
+
+def test_probability_of_conjunction():
+    circuit, var_a, var_b, var_c = build_three_independent_variables_circuit()
+    x = variable(Coin)
+
+    backend = ProbabilisticBackend(model_registry=DictRegistry({Coin: circuit}))
+    result = probability_of(and_(x.a < 0.5, x.b < 1)).first(backend=backend)
+
+    # independent uniforms: P(a < 0.5) * P(b < 1) == 0.5 * 0.5
+    assert result == pytest.approx(0.25)
+
+
+def test_probability_rejects_cross_class():
+    x = variable(Coin)
+    y = variable(OtherClass)
+
+    with pytest.raises(JointQueryAcrossClassesNotSupported):
+        probability_of(and_(x.a < 0.5, y.d < 0.5)).first(
+            backend=ProbabilisticBackend(model_registry=DictRegistry({}))
+        )

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_verbalization.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_verbalization.py
@@ -1,0 +1,57 @@
+from krrood.entity_query_language.factories import a, and_, distribution_of, probability_of, variable
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
+
+from ._fixtures import Coin
+
+
+def test_verbalize_distribution_of_match():
+    match = a(Coin)(a=..., b=..., c=1.5)
+    match.where(match.variable.a > 0.2)
+
+    text = verbalize_expression(distribution_of(match))
+
+    # a and b are underspecified -- the distribution's free variables by default, so
+    # they're not named explicitly ("the distribution over a Coin" already means "over
+    # every attribute not given"), and definitely not "predicted", the match's
+    # generative-sampling framing, which doesn't fit a distribution query at all
+    assert text.startswith("The distribution over a Coin")
+    assert "predict" not in text
+    assert "given that its c is 1.5" in text
+    assert "where its a is greater than 0.2" in text
+
+
+def test_verbalize_distribution_of_select_all():
+    match = a(Coin)(a=..., b=..., c=...)
+
+    text = verbalize_expression(distribution_of(match))
+
+    assert text == "The distribution over a Coin"
+
+
+def test_verbalize_distribution_of_narrowed_to_variables():
+    match = a(Coin)(a=..., b=..., c=1.5)
+
+    text = verbalize_expression(distribution_of(match, match.variable.a))
+
+    # marginalization narrows which variable(s) the joint is over -- named directly in
+    # the subject, not a trailing "restricted to" qualifier (that reads like a
+    # truncation, a where-style condition, not a choice of variables)
+    assert text.startswith("The distribution over the a of a Coin")
+
+
+def test_verbalize_probability_of_condition():
+    x = variable(Coin)
+
+    text = verbalize_expression(probability_of(x.a < 0.5))
+
+    assert text == "the probability that the a of a Coin is less than 0.5"
+
+
+def test_verbalize_probability_of_conjunction():
+    x = variable(Coin)
+
+    text = verbalize_expression(probability_of(and_(x.a < 0.5, x.b < 1)))
+
+    assert text.startswith("the probability that")
+    assert "the a of a Coin is less than 0.5" in text
+    assert "the b of the Coin is less than 1" in text

--- a/test/krrood_test/test_eql/test_probabilistic_queries/test_verbalization.py
+++ b/test/krrood_test/test_eql/test_probabilistic_queries/test_verbalization.py
@@ -31,7 +31,7 @@ def test_verbalize_distribution_of_select_all():
 def test_verbalize_distribution_of_narrowed_to_variables():
     match = a(Coin)(a=..., b=..., c=1.5)
 
-    text = verbalize_expression(distribution_of(match, match.variable.a))
+    text = verbalize_expression(distribution_of(match, marginalize_for=(match.variable.a,)))
 
     # marginalization narrows which variable(s) the joint is over -- named directly in
     # the subject, not a trailing "restricted to" qualifier (that reads like a


### PR DESCRIPTION
## Summary

Two new EQL query constructs for querying a probabilistic model directly instead of enumerating rows, both evaluable only under `ProbabilisticBackend`:

- **`distribution_of(match, *variables)`** — the probabilistic interpretation of `a()`/`an()`/`the()`: reuses a `Match`'s existing conditioning (literal-valued kwargs) and truncation (`.where(...)`) semantics, returning the resulting `ProbabilisticModel` directly instead of sampling instances from it. Optional `*variables` marginalize the result to a subset of the match's free variables.
- **`probability_of(condition)`** — the probability of any condition a `.where(...)` clause already accepts, resolved via `ProbabilisticModel.probability`.

No new construct for the expectation: `ProbabilisticBackend` now recognizes a *bare* `average(...)` selection (the existing aggregator, unmodified) and resolves it in closed form via `ProbabilisticModel.moment` instead of sampling and averaging rows — same call, correct answer under either backend.

Both new constructs are also verbalizable via `verbalize_expression`, e.g.:

```
The distribution over a Coin given that its c is 1.5, where its a is greater than 0.2
```

## Shared plumbing

- `UnderspecifiedParameters.resolve_conditioned_and_truncated_model`/`.apply_krrood_variable_truncation` extract the conditioning/truncation sequence `ProbabilisticBackend` already applied to a sampled `Match`, refactored out so `distribution_of` reuses it too.
- `ModelRegistry`'s parameter type (`ModelResolutionParameters`) is widened to also accept the new `SelectedAttributesParameters`/`ConditionParameters` shapes `probability_of`/`average` use.
- New `grammar/probabilistic_queries/rules.py` (auto-registered — no other verbalization wiring needed) adds `DistributionRule`/`ProbabilityRule`, reusing the match assembler's `given that`/`where` grammar under a new `Directive.DISTRIBUTION_OVER` header instead of the imperative `Find`/`Generate`.

## Test plan

- [x] New test suite `test/krrood_test/test_eql/test_probabilistic_queries/` (distribution, probability, average, native-evaluation-rejection, verbalization)
- [x] Full `test_eql/` + `test_feature_extraction/` regression suite green (1319 passed, 3 skipped)
- [x] Full `test_verbalization/` suite green, including the registry-completeness check and auto-discovered doctests on the new rules
- [x] Every doc example in `krrood/doc/eql/user/probabilistic_queries.md` verified by actually running it