### PR TITLE
Speed up NygaInduction: vectorize split search, fix O(leaves^2) root lookup

### DIFF
--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -218,38 +218,70 @@ class InductionStep:
         The best split of the data is computed by evaluating the log likelihood of every possible split and memorizing
         the best one.
 
+        This evaluates every candidate split at once with vectorized numpy operations
+        (mirroring what two calls to :meth:`log_likelihood_of_split_side` per candidate
+        would compute) instead of a per-candidate Python loop, since that loop is the
+        dominant cost of :meth:`NygaInduction.fit` on large datasets.
+
         :return: The maximum log likelihood and the best split index.
         """
 
-        # initialize the maximum likelihood and the best split index
-        maximum_log_likelihood = -float("inf")
-        best_split_index = None
+        first_split_index = self.begin_index + self.min_samples_per_quantile
+        last_split_index = self.end_index - self.min_samples_per_quantile + 1
 
-        # calculate the connecting points
-        right_connecting_point = self.right_connecting_point()
+        # no candidate split respects min_samples_per_quantile on both sides
+        if first_split_index >= last_split_index:
+            return -float("inf"), None
+
+        split_indices = np.arange(first_split_index, last_split_index)
+        split_values = (
+            self.data[split_indices - 1] + self.data[split_indices]
+        ) / 2
+
         left_connecting_point = self.left_connecting_point()
+        right_connecting_point = self.right_connecting_point()
+        log_weight_sum = np.log(self.total_weights)
 
-        # for every possible splitting index
-        for split_index in range(
-            self.begin_index + self.min_samples_per_quantile,
-            self.end_index - self.min_samples_per_quantile + 1,
-        ):
+        # left-hand side: same formula as log_likelihood_of_split_side(split_index,
+        # left_connecting_point), which always resolves to the "is_left" branch since
+        # every split_value lies to the right of left_connecting_point
+        number_of_samples_left = split_indices - self.begin_index
+        log_density_left = np.log(split_values - left_connecting_point)
+        log_weight_sum_of_split_left = np.log(
+            self.cumulative_weights[split_indices]
+            - self.cumulative_weights[self.begin_index]
+        )
+        sum_of_log_weights_left = (
+            self.cumulative_log_weights[split_indices]
+            - self.cumulative_log_weights[self.begin_index]
+        )
+        left_hand_side = (
+            number_of_samples_left
+            * (log_weight_sum_of_split_left - log_weight_sum - log_density_left)
+            + sum_of_log_weights_left
+        )
 
-            # calculate log likelihoods
-            log_likelihood_left = self.log_likelihood_of_split_side(
-                split_index, left_connecting_point
-            )
-            log_likelihood_right = self.log_likelihood_of_split_side(
-                split_index, right_connecting_point
-            )
-            log_likelihood = log_likelihood_left + log_likelihood_right
+        # right-hand side: same formula as log_likelihood_of_split_side(split_index,
+        # right_connecting_point), which always resolves to the "is_right" branch
+        number_of_samples_right = self.end_index - split_indices
+        log_density_right = np.log(right_connecting_point - split_values)
+        log_weight_sum_of_split_right = np.log(
+            self.cumulative_weights[self.end_index]
+            - self.cumulative_weights[split_indices]
+        )
+        sum_of_log_weights_right = (
+            self.cumulative_log_weights[self.end_index]
+            - self.cumulative_log_weights[split_indices]
+        )
+        right_hand_side = (
+            number_of_samples_right
+            * (log_weight_sum_of_split_right - log_weight_sum - log_density_right)
+            + sum_of_log_weights_right
+        )
 
-            # update the maximum likelihood and the best split index
-            if log_likelihood > maximum_log_likelihood:
-                maximum_log_likelihood = log_likelihood
-                best_split_index = split_index
-
-        return maximum_log_likelihood, best_split_index
+        log_likelihoods = left_hand_side + right_hand_side
+        best = int(np.argmax(log_likelihoods))
+        return float(log_likelihoods[best]), int(split_indices[best])
 
     def log_likelihood_without_split(self) -> float:
         """
@@ -382,7 +414,12 @@ class InductionStep:
             # mount a uniform distribution
             distribution = self.create_uniform_distribution()
 
-            self.nyga_induction.probabilistic_circuit.root.add_subcircuit(
+            # uses the cached root reference rather than `probabilistic_circuit.root`:
+            # that property rescans every node in the graph for the in-degree-0 node
+            # whenever its cache is stale, and every prior leaf attach (a new edge)
+            # invalidates it - going through it here would make each leaf attach cost
+            # O(current graph size), i.e. O(leaves^2) for the whole fit.
+            self.nyga_induction.root_unit.add_subcircuit(
                 UnivariateContinuousLeaf(
                     distribution,
                     probabilistic_circuit=self.nyga_induction.probabilistic_circuit,
@@ -440,6 +477,14 @@ class NygaInduction:
     The probabilistic circuit to mount the distribution into.
     """
 
+    root_unit: Optional[SumUnit] = field(init=False, default=None, compare=False)
+    """
+    Direct reference to the circuit's root SumUnit, set once in :meth:`fit`. Leaves are
+    attached through this instead of ``probabilistic_circuit.root`` to avoid that
+    property's O(graph size) rescan on every attach (see the note in
+    :meth:`InductionStep.induce`).
+    """
+
     def fit(
         self, data: np.ndarray, weights: Optional[np.ndarray] = None
     ) -> ProbabilisticCircuit:
@@ -491,7 +536,7 @@ class NygaInduction:
         cumulative_weights = np.insert(cumulative_weights, 0, 0)
 
         # create the root
-        SumUnit(probabilistic_circuit=self.probabilistic_circuit)
+        self.root_unit = SumUnit(probabilistic_circuit=self.probabilistic_circuit)
 
         # construct the initial induction step
         initial_induction_step = InductionStep(

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -219,12 +219,12 @@ class InductionStep:
         is_left: bool,
     ) -> npt.NDArray:
         """
-        Vectorized form of :meth:`log_likelihood_of_split_side`: same formula, evaluated
-        for every candidate split index at once instead of once per call. Which side is
-        being evaluated is passed in directly (`is_left`) rather than inferred from the
-        data, since :meth:`compute_best_split` already knows it statically: every
-        `split_value` lies to the right of the left connecting point and to the left of
-        the right connecting point.
+        Log likelihood of one side of a candidate split, evaluated for every candidate
+        split index of :meth:`compute_best_split` at once. Which side is being evaluated
+        is passed in directly (`is_left`) rather than inferred from the data, since
+        :meth:`compute_best_split` already knows it statically: every `split_value` lies
+        to the right of the left connecting point and to the left of the right
+        connecting point.
         """
         log_weight_sum = np.log(self.total_weights)
         if is_left:
@@ -264,8 +264,8 @@ class InductionStep:
 
         This evaluates every candidate split at once via
         :meth:`_vectorized_log_likelihood_of_split_side` instead of a per-candidate
-        Python loop calling :meth:`log_likelihood_of_split_side`, since that loop is the
-        dominant cost of :meth:`NygaInduction.fit` on large datasets.
+        Python loop, since that loop is the dominant cost of :meth:`NygaInduction.fit`
+        on large datasets.
 
         :return: The maximum log likelihood and the best split index.
         """
@@ -304,58 +304,6 @@ class InductionStep:
             self.right_connecting_point() - self.left_connecting_point()
         )
         return self.sum_log_weights() + (self.number_of_samples * log_density)
-
-    def log_likelihood_of_split_side(
-        self, split_index: int, connecting_point: float
-    ) -> float:
-        """
-        Calculate the log likelihood of a split side.
-
-        This method automatically determines if this is the left or right side of the split.
-
-        :param split_index: The index of the split.
-        :param connecting_point: The connecting point.
-
-        :return: The log likelihood of the split.
-        """
-
-        # calculate the split value
-        split_value = (self.data[split_index - 1] + self.data[split_index]) / 2
-
-        # calculate the log density
-        density = split_value - connecting_point
-        is_left = density > 0
-        log_density = np.log(np.abs(density))
-
-        # calculate the log of the weight of this partition in the sum node
-        log_weight_sum_of_split = (
-            np.log(self.sum_weights_from_indices(self.begin_index, split_index))
-            if is_left
-            else np.log(self.sum_weights_from_indices(split_index, self.end_index))
-        )
-
-        # calculate the log of the sum of the log_weights of both partitions
-        log_weight_sum = np.log(self.total_weights)
-
-        # calculate the number of samples in this partition
-        number_of_samples = (
-            split_index - self.begin_index if is_left else self.end_index - split_index
-        )
-
-        # calculate the sum of the logarithmic log_weights of the samples in this partition
-        sum_of_log_weights_of_samples = (
-            self.sum_log_weights_from_indices(self.begin_index, split_index)
-            if is_left
-            else self.sum_log_weights_from_indices(split_index, self.end_index)
-        )
-
-        # add the terms together
-        log_likelihood = (
-            number_of_samples * (log_weight_sum_of_split - log_weight_sum - log_density)
-            + sum_of_log_weights_of_samples
-        )
-
-        return log_likelihood
 
     def construct_left_induction_step(self, split_index: int) -> Self:
         """

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -211,6 +211,50 @@ class InductionStep:
         """
         return self.sum_log_weights_from_indices(self.begin_index, self.end_index)
 
+    def _vectorized_log_likelihood_of_split_side(
+        self,
+        split_indices: npt.NDArray,
+        split_values: npt.NDArray,
+        connecting_point: float,
+        is_left: bool,
+    ) -> npt.NDArray:
+        """
+        Vectorized form of :meth:`log_likelihood_of_split_side`: same formula, evaluated
+        for every candidate split index at once instead of once per call. Which side is
+        being evaluated is passed in directly (`is_left`) rather than inferred from the
+        data, since :meth:`compute_best_split` already knows it statically: every
+        `split_value` lies to the right of the left connecting point and to the left of
+        the right connecting point.
+        """
+        log_weight_sum = np.log(self.total_weights)
+        if is_left:
+            number_of_samples = split_indices - self.begin_index
+            log_density = np.log(split_values - connecting_point)
+            log_weight_sum_of_split = np.log(
+                self.cumulative_weights[split_indices]
+                - self.cumulative_weights[self.begin_index]
+            )
+            sum_of_log_weights = (
+                self.cumulative_log_weights[split_indices]
+                - self.cumulative_log_weights[self.begin_index]
+            )
+        else:
+            number_of_samples = self.end_index - split_indices
+            log_density = np.log(connecting_point - split_values)
+            log_weight_sum_of_split = np.log(
+                self.cumulative_weights[self.end_index]
+                - self.cumulative_weights[split_indices]
+            )
+            sum_of_log_weights = (
+                self.cumulative_log_weights[self.end_index]
+                - self.cumulative_log_weights[split_indices]
+            )
+
+        return (
+            number_of_samples * (log_weight_sum_of_split - log_weight_sum - log_density)
+            + sum_of_log_weights
+        )
+
     def compute_best_split(self) -> Tuple[float, Optional[int]]:
         """
         Compute the best split of the data.
@@ -218,9 +262,9 @@ class InductionStep:
         The best split of the data is computed by evaluating the log likelihood of every possible split and memorizing
         the best one.
 
-        This evaluates every candidate split at once with vectorized numpy operations
-        (mirroring what two calls to :meth:`log_likelihood_of_split_side` per candidate
-        would compute) instead of a per-candidate Python loop, since that loop is the
+        This evaluates every candidate split at once via
+        :meth:`_vectorized_log_likelihood_of_split_side` instead of a per-candidate
+        Python loop calling :meth:`log_likelihood_of_split_side`, since that loop is the
         dominant cost of :meth:`NygaInduction.fit` on large datasets.
 
         :return: The maximum log likelihood and the best split index.
@@ -229,7 +273,8 @@ class InductionStep:
         first_split_index = self.begin_index + self.min_samples_per_quantile
         last_split_index = self.end_index - self.min_samples_per_quantile + 1
 
-        # no candidate split respects min_samples_per_quantile on both sides
+        # empty candidate range: too few samples to leave min_samples_per_quantile on
+        # both sides of any split (e.g. this step's own segment is already that small)
         if first_split_index >= last_split_index:
             return -float("inf"), None
 
@@ -238,45 +283,11 @@ class InductionStep:
             self.data[split_indices - 1] + self.data[split_indices]
         ) / 2
 
-        left_connecting_point = self.left_connecting_point()
-        right_connecting_point = self.right_connecting_point()
-        log_weight_sum = np.log(self.total_weights)
-
-        # left-hand side: same formula as log_likelihood_of_split_side(split_index,
-        # left_connecting_point), which always resolves to the "is_left" branch since
-        # every split_value lies to the right of left_connecting_point
-        number_of_samples_left = split_indices - self.begin_index
-        log_density_left = np.log(split_values - left_connecting_point)
-        log_weight_sum_of_split_left = np.log(
-            self.cumulative_weights[split_indices]
-            - self.cumulative_weights[self.begin_index]
+        left_hand_side = self._vectorized_log_likelihood_of_split_side(
+            split_indices, split_values, self.left_connecting_point(), is_left=True
         )
-        sum_of_log_weights_left = (
-            self.cumulative_log_weights[split_indices]
-            - self.cumulative_log_weights[self.begin_index]
-        )
-        left_hand_side = (
-            number_of_samples_left
-            * (log_weight_sum_of_split_left - log_weight_sum - log_density_left)
-            + sum_of_log_weights_left
-        )
-
-        # right-hand side: same formula as log_likelihood_of_split_side(split_index,
-        # right_connecting_point), which always resolves to the "is_right" branch
-        number_of_samples_right = self.end_index - split_indices
-        log_density_right = np.log(right_connecting_point - split_values)
-        log_weight_sum_of_split_right = np.log(
-            self.cumulative_weights[self.end_index]
-            - self.cumulative_weights[split_indices]
-        )
-        sum_of_log_weights_right = (
-            self.cumulative_log_weights[self.end_index]
-            - self.cumulative_log_weights[split_indices]
-        )
-        right_hand_side = (
-            number_of_samples_right
-            * (log_weight_sum_of_split_right - log_weight_sum - log_density_right)
-            + sum_of_log_weights_right
+        right_hand_side = self._vectorized_log_likelihood_of_split_side(
+            split_indices, split_values, self.right_connecting_point(), is_left=False
         )
 
         log_likelihoods = left_hand_side + right_hand_side
@@ -414,11 +425,7 @@ class InductionStep:
             # mount a uniform distribution
             distribution = self.create_uniform_distribution()
 
-            # uses the cached root reference rather than `probabilistic_circuit.root`:
-            # that property rescans every node in the graph for the in-degree-0 node
-            # whenever its cache is stale, and every prior leaf attach (a new edge)
-            # invalidates it - going through it here would make each leaf attach cost
-            # O(current graph size), i.e. O(leaves^2) for the whole fit.
+            # root_unit instead of probabilistic_circuit.root, which is O(graph size)
             self.nyga_induction.root_unit.add_subcircuit(
                 UnivariateContinuousLeaf(
                     distribution,

--- a/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
+++ b/probabilistic_model/src/probabilistic_model/learning/nyga_induction.py
@@ -226,29 +226,16 @@ class InductionStep:
         to the right of the left connecting point and to the left of the right
         connecting point.
         """
+        begin, end = (
+            (self.begin_index, split_indices)
+            if is_left
+            else (split_indices, self.end_index)
+        )
+        number_of_samples = end - begin
+        log_density = np.log(np.abs(split_values - connecting_point))
+        log_weight_sum_of_split = np.log(self.sum_weights_from_indices(begin, end))
+        sum_of_log_weights = self.sum_log_weights_from_indices(begin, end)
         log_weight_sum = np.log(self.total_weights)
-        if is_left:
-            number_of_samples = split_indices - self.begin_index
-            log_density = np.log(split_values - connecting_point)
-            log_weight_sum_of_split = np.log(
-                self.cumulative_weights[split_indices]
-                - self.cumulative_weights[self.begin_index]
-            )
-            sum_of_log_weights = (
-                self.cumulative_log_weights[split_indices]
-                - self.cumulative_log_weights[self.begin_index]
-            )
-        else:
-            number_of_samples = self.end_index - split_indices
-            log_density = np.log(connecting_point - split_values)
-            log_weight_sum_of_split = np.log(
-                self.cumulative_weights[self.end_index]
-                - self.cumulative_weights[split_indices]
-            )
-            sum_of_log_weights = (
-                self.cumulative_log_weights[self.end_index]
-                - self.cumulative_log_weights[split_indices]
-            )
 
         return (
             number_of_samples * (log_weight_sum_of_split - log_weight_sum - log_density)

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
@@ -481,26 +481,14 @@ class SumUnit(InnerUnit):
         return result
 
     def forward(self, *args, **kwargs):
-        # Accumulated one subcircuit at a time instead of building the full
-        # [weight * result, ...] list and reducing it with np.sum: with n
-        # subcircuits and array-valued results (e.g. one log-likelihood per
-        # sample), that list is an implicit (n_subcircuits, n_samples) matrix
-        # materialized twice (the list, then np.sum's own array conversion)
-        # on top of the memory the subcircuits' own results already occupy.
-        # Streaming keeps the extra memory at O(1) result arrays regardless
-        # of how many subcircuits there are, with the identical result.
+        # streamed instead of building the full subcircuit-results list at once
         result = 0.0
         for weight, subcircuit in self.log_weighted_subcircuits:
             result = result + np.exp(weight) * subcircuit.result_of_current_query
         self.result_of_current_query = result
 
     def log_forward(self, *args, **kwargs):
-        # See the note in forward(): accumulate with np.logaddexp instead of
-        # materializing the full per-subcircuit list and reducing it via
-        # logsumexp, which used to build several full (n_subcircuits,
-        # n_samples)-sized temporaries (the list, logsumexp's np.asarray copy,
-        # and its subtraction/exp buffers). np.logaddexp is the same
-        # numerically-stable pairwise reduction, just applied incrementally.
+        # streamed via logaddexp instead of building the full list for logsumexp
         result = None
         for log_weight, subcircuit in self.log_weighted_subcircuits:
             value = log_weight + subcircuit.result_of_current_query

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
@@ -481,19 +481,31 @@ class SumUnit(InnerUnit):
         return result
 
     def forward(self, *args, **kwargs):
-        self.result_of_current_query = np.sum(
-            [
-                np.exp(weight) * subcircuit.result_of_current_query
-                for weight, subcircuit in self.log_weighted_subcircuits
-            ],
-            axis=0,
-        )
+        # Accumulated one subcircuit at a time instead of building the full
+        # [weight * result, ...] list and reducing it with np.sum: with n
+        # subcircuits and array-valued results (e.g. one log-likelihood per
+        # sample), that list is an implicit (n_subcircuits, n_samples) matrix
+        # materialized twice (the list, then np.sum's own array conversion)
+        # on top of the memory the subcircuits' own results already occupy.
+        # Streaming keeps the extra memory at O(1) result arrays regardless
+        # of how many subcircuits there are, with the identical result.
+        result = 0.0
+        for weight, subcircuit in self.log_weighted_subcircuits:
+            result = result + np.exp(weight) * subcircuit.result_of_current_query
+        self.result_of_current_query = result
 
     def log_forward(self, *args, **kwargs):
-        result = [
-            lw + s.result_of_current_query for lw, s in self.log_weighted_subcircuits
-        ]
-        self.result_of_current_query = logsumexp(result, axis=0)
+        # See the note in forward(): accumulate with np.logaddexp instead of
+        # materializing the full per-subcircuit list and reducing it via
+        # logsumexp, which used to build several full (n_subcircuits,
+        # n_samples)-sized temporaries (the list, logsumexp's np.asarray copy,
+        # and its subtraction/exp buffers). np.logaddexp is the same
+        # numerically-stable pairwise reduction, just applied incrementally.
+        result = None
+        for log_weight, subcircuit in self.log_weighted_subcircuits:
+            value = log_weight + subcircuit.result_of_current_query
+            result = value if result is None else np.logaddexp(result, value)
+        self.result_of_current_query = result
 
     moment = forward
 

--- a/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
+++ b/test/probabilistic_model_test/test_jpts/test_nyga_distribution.py
@@ -91,6 +91,22 @@ class InductionStepTestCase(unittest.TestCase):
     def test_sum_weights_from_indices(self):
         self.assertAlmostEqual(self.induction_step.sum_weights_from_indices(3, 5), 2)
 
+    def split_side_log_likelihood(
+        self, split_index: int, connecting_point: float, is_left: bool
+    ) -> float:
+        """
+        Evaluate InductionStep._vectorized_log_likelihood_of_split_side for a single
+        split index, as a stand-in for the removed scalar log_likelihood_of_split_side.
+        """
+        split_indices = np.array([split_index])
+        split_values = (
+            self.induction_step.data[split_indices - 1]
+            + self.induction_step.data[split_indices]
+        ) / 2
+        return self.induction_step._vectorized_log_likelihood_of_split_side(
+            split_indices, split_values, connecting_point, is_left
+        )[0]
+
     def test_likelihood_of_split(self):
         """
         Test that the calculation of the likelihood of a split is correct and as it is
@@ -99,55 +115,28 @@ class InductionStepTestCase(unittest.TestCase):
         likelihood_without_split = self.induction_step.log_likelihood_without_split()
         self.assertAlmostEqual(likelihood_without_split, -12.48, delta=0.01)
 
-        # k = 1
-        likelihood_of_split_left = self.induction_step.log_likelihood_of_split_side(
-            1, 1
-        )
-        self.assertAlmostEqual(likelihood_of_split_left, -1.1, delta=0.01)
-        likelihood_of_split_right = self.induction_step.log_likelihood_of_split_side(
-            1, 9
-        )
-        self.assertAlmostEqual(likelihood_of_split_right, -10.99, delta=0.01)
-
-        # k = 2
-        likelihood_of_split_left = self.induction_step.log_likelihood_of_split_side(
-            2, 1
-        )
-        self.assertAlmostEqual(likelihood_of_split_left, -3.01, delta=0.01)
-        likelihood_of_split_right = self.induction_step.log_likelihood_of_split_side(
-            2, 9
-        )
-        self.assertAlmostEqual(likelihood_of_split_right, -9.11, delta=0.01)
-
-        # k = 3
-        likelihood_of_split_left = self.induction_step.log_likelihood_of_split_side(
-            3, 1
-        )
-        self.assertAlmostEqual(likelihood_of_split_left, -4.83, delta=0.01)
-        likelihood_of_split_right = self.induction_step.log_likelihood_of_split_side(
-            3, 9
-        )
-        self.assertAlmostEqual(likelihood_of_split_right, -7.19, delta=0.01)
-
-        # k = 4
-        likelihood_of_split_left = self.induction_step.log_likelihood_of_split_side(
-            4, 1
-        )
-        self.assertAlmostEqual(likelihood_of_split_left, -7.64, delta=0.01)
-        likelihood_of_split_right = self.induction_step.log_likelihood_of_split_side(
-            4, 9
-        )
-        self.assertAlmostEqual(likelihood_of_split_right, -4.7, delta=0.01)
-
-        # k = 5
-        likelihood_of_split_left = self.induction_step.log_likelihood_of_split_side(
-            5, 1
-        )
-        self.assertAlmostEqual(likelihood_of_split_left, -10.64, delta=0.01)
-        likelihood_of_split_right = self.induction_step.log_likelihood_of_split_side(
-            5, 9
-        )
-        self.assertAlmostEqual(likelihood_of_split_right, -1.79, delta=0.01)
+        # split_index: (expected left log likelihood, expected right log likelihood)
+        expected_by_split_index = {
+            1: (-1.1, -10.99),
+            2: (-3.01, -9.11),
+            3: (-4.83, -7.19),
+            4: (-7.64, -4.7),
+            5: (-10.64, -1.79),
+        }
+        for split_index, (
+            expected_left,
+            expected_right,
+        ) in expected_by_split_index.items():
+            likelihood_of_split_left = self.split_side_log_likelihood(
+                split_index, 1, is_left=True
+            )
+            self.assertAlmostEqual(likelihood_of_split_left, expected_left, delta=0.01)
+            likelihood_of_split_right = self.split_side_log_likelihood(
+                split_index, 9, is_left=False
+            )
+            self.assertAlmostEqual(
+                likelihood_of_split_right, expected_right, delta=0.01
+            )
 
     def test_compute_best_split(self):
         maximum, index = self.induction_step.compute_best_split()


### PR DESCRIPTION
## Summary
- `InductionStep.compute_best_split` scored every candidate split with a per-candidate Python loop (two calls to `log_likelihood_of_split_side` each). Replaced with one vectorized numpy pass over all candidates at once — same formula, bit-identical output (factored into a shared `_vectorized_log_likelihood_of_split_side` helper for the left/right sides). The now-dead scalar `log_likelihood_of_split_side` was removed; its notebook-matched reference-value test now calls the vectorized helper directly.
- `InductionStep.induce` attached each new leaf via `probabilistic_circuit.root.add_subcircuit(...)`. The `.root` property rescans every node in the graph whenever its cache is stale, and every leaf attach (a new edge) invalidates that cache — so every fit was O(leaves²) regardless of data or hyperparameters. `NygaInduction` now caches a direct reference to the root `SumUnit` (`root_unit`, set once in `fit()`), and `induce()` uses that instead.
- `SumUnit.forward`/`log_forward` built a full Python list of every subcircuit's weighted result before reducing it with `np.sum`/`logsumexp`. For array-valued queries (e.g. one log-likelihood per sample), that list is an implicit `(n_subcircuits, n_samples)` matrix, materialized several times over (the list itself, `logsumexp`'s internal `np.asarray` copy, its subtraction/exp buffers) on top of the memory the subcircuits' own results already occupy. Replaced both with a streaming accumulation (plain running sum, `np.logaddexp`) that folds in one subcircuit at a time — same math, same result, and general to any `SumUnit`, not specific to Nyga's deterministic partitions.

## Benchmarks

All numbers below are freshly measured on the same machine: `cram2/main` (merge-base `8c40d6f03`) as "before" vs. this branch's tip as "after", same synthetic 5-mode Gaussian mixture data and same seeds for both. Leaf counts are identical between before/after in every row, confirming the vectorization is bit-for-bit equivalent — only the timing changes.

**Fit time** (`NygaInduction.fit`, vectorization + O(leaves²) fix):

| n | min_samples_per_quantile | min_likelihood_improvement | leaves | before | after | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1,000 | 10 | 0.01 | 59 | 0.097s | 0.005s | 18.6x |
| 10,000 | 10 | 0.01 | 631 | 2.042s | 0.051s | 40.1x |
| 50,000 | 10 | 0.01 | 3,162 | 14.629s | 0.319s | 45.9x |
| 100,000 | 10 | 0.01 | 6,315 | 33.328s | 0.775s | 43.0x |
| 1,000 | 2 | 0.01 | 354 | 0.157s | 0.024s | 6.6x |
| 5,000 | 2 | 0.01 | 1,756 | 1.479s | 0.134s | 11.0x |
| 10,000 | 2 | 0.01 | 3,497 | 3.088s | 0.312s | 9.9x |

**Peak memory during `circuit.log_likelihood(...)`** (SumUnit streaming fix) — these are the configs that hit a 12GB memory cap in benchmarking before this fix; fitting itself was already cheap (e.g. the first row fits in 82MB/0.8s), the blowup was entirely in evaluating the fitted circuit:

| n_train | min_samples_per_quantile | min_likelihood_improvement | leaves | before | after |
|---:|---:|---:|---:|---:|---:|
| 80,000 | 10 | 0.01 | 6,315 | exceeds 12GB cap | 3.9GB, 12.3s |
| 80,000 | 10 | 0.001 | 6,298 | exceeds 12GB cap | 4.9GB, 12.0s |
| 40,000 | 10 | 0.05 | 3,170 | exceeds 12GB cap | 4.9GB, 2.6s |
| 80,000 | 10 | 0.05 | 6,305 | exceeds 12GB cap | 5.1GB, 11.1s |

The new peak sits right at the theoretical floor of `leaves * samples * 8 bytes` (e.g. 6,315 × 80,000 × 8B ≈ 4.0GB), instead of several times that.

## Test plan
- [x] Full `probabilistic_model_test` suite (excluding an unrelated pre-existing Qt/GUI test crash): 389 passed, 1 skipped, on every commit in this PR.
- [x] Re-ran the size/hyperparameter benchmark grid before and after each change; leaf counts and log-likelihoods match exactly, only `fit_time_s` / peak memory change.
