### PR TITLE
Add alternative package for treon dependency docopt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,16 @@ doc = [
     "jupytext",
 ]
 
+[tool.uv]
+# make treon require docopt-ng instead of the unmaintained docopt
+override-dependencies = [
+    { package = { name = "treon" }, dependencies = ["docopt-ng"] },
+]
+exclude-dependencies = [
+    { package = { name = "treon" }, dependencies = ["docopt"] },
+    "pathlib",
+]
+
 [tool.uv.workspace]
 members = [
   "coraplex",


### PR DESCRIPTION
This PR replaces docopt with docopt-ng since docopt is unmaintained. It also excludes pathlib from the dependencies since it's included in stdlib since Python 3.4 and can create issues on some setups with redundant package files.

The specific error that it creates looks like this and occurs after installing packages using `uv sync --active`

```bash
$ pip --version                                                       
Traceback (most recent call last):                                                                                                                                                                  
  File "/home/jesch/ros2_ws/venv/bin/pip", line 10, in <module>                                                                                                                                     
    sys.exit(main())                                                                                                                                                                                
             ^^^^^^                                                                                                                                                                                 
  File "/home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pip/_internal/cli/main.py", line 47, in main                                                                                          
    from pip._internal.cli.autocompletion import autocomplete                                                                                                                                       
  File "/home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py", line 12, in <module>                                                                            
    from pip._internal.cli.main_parser import create_main_parser                                                                                                                                    
  File "/home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pip/_internal/cli/main_parser.py", line 11, in <module>                                                                               
    from pip._internal.cli import cmdoptions                                                                                                                                                        
  File "/home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pip/_internal/cli/cmdoptions.py", line 16, in <module>                                                                                
    import pathlib                                                                                                                                                                                  
  File "/home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pathlib.py", line 10, in <module>                                                                                                     
    from collections import Sequence                                                                                                                                                                
ImportError: cannot import name 'Sequence' from 'collections' (/usr/lib/python3.12/collections/__init__.py)
```

uv also installs pathlib and shadows already included files. Manually removing the package files from the virtualenv like this temporarily solves the issue and the virtualenv setup didn't show an error despite pathlib being removed from the virtualenv. The issue reappears after updating or reinstalling packages using uv.

```bash
rm -rf /home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pathlib.py
rm -rf /home/jesch/ros2_ws/venv/lib/python3.12/site-packages/pathlib-*.dist-info
```