### PR TITLE
Fix -inf log-likelihood for symbolic distributions (double hash)

### DIFF
--- a/probabilistic_model/src/probabilistic_model/distributions/distributions.py
+++ b/probabilistic_model/src/probabilistic_model/distributions/distributions.py
@@ -310,7 +310,7 @@ class DiscreteDistribution(UnivariateDistribution):
         events = np.array([hash(e) for e in events])
         result = np.full(len(events), -np.inf)
         for x, p in self.probabilities.items():
-            result[events == hash(x)] = np.log(p)
+            result[events == x] = np.log(p)
         return result
 
     def fit(self, data: npt.NDArray) -> Self:

--- a/test/probabilistic_model_test/test_distributions/test_distributions.py
+++ b/test/probabilistic_model_test/test_distributions/test_distributions.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from enum import IntEnum
 
@@ -172,6 +173,31 @@ class SymbolicDistributionTestCase(unittest.TestCase):
 
         prob = self.model.probability(event)
         self.assertEqual(prob, 1)
+
+    def test_likelihood_survives_a_category_whose_hash_exceeds_the_modulus(self):
+        """A category still scores its true probability when its Python `hash()`
+        falls outside `sys.hash_info.modulus`.
+
+        `probabilities` is keyed by `hash(category)`; `log_likelihood` used to hash
+        that already-hashed key a second time. `int.__hash__` reduces any value
+        outside the modulus, so for such a category the second hash silently produced
+        a different key than the one stored, and the category's likelihood came back
+        -inf instead of its true probability.
+        """
+        modulus = sys.hash_info.modulus
+        category = next(
+            candidate
+            for candidate in (f"category_{index}" for index in range(1000))
+            if abs(hash(candidate)) >= modulus
+        )
+        x = Symbolic("category", domain=Set.from_iterable([category, "other"]))
+        probabilities = MissingDict(float, {hash(category): 1.0})
+        model = SymbolicDistribution(variable=x, probabilities=probabilities)
+
+        log_likelihood = model.log_likelihood(np.array([category]).reshape(-1, 1))
+
+        self.assertTrue(np.isfinite(log_likelihood[0]))
+        self.assertAlmostEqual(log_likelihood[0], 0.0)
 
 
 class DiracDeltaDistributionTestCase(unittest.TestCase):


### PR DESCRIPTION
`SymbolicDistribution.log_likelihood` returns `-inf` for categories that are actually present.

the stored probability keys are already `hash(symbol)`. `log_likelihood` hashes them a second time (`hash(x)`), and for symbolic objects the string-hash exceeds 2^61−1, so the second hash reduces it to a different integer — the lookup misses and the category gets `-inf` instead of its real likelihood.

fix: compare against the stored key directly (`result[events == x]`), since it is already a hash. added a test that fits a symbolic distribution on a category whose hash exceeds the modulus and asserts the log-likelihood is finite — it fails on the original line and passes with the fix.
