### PR TITLE
Added shutdown procedure for Giskard, when using KeyboardInterrupt

### DIFF
--- a/giskardpy/src/giskardpy/middleware/ros2/giskard.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/giskard.py
@@ -16,6 +16,7 @@ from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.feedback_publisher import ActionFeedbackPublisher
+from giskardpy.middleware.ros2.graceful_shutdown import GracefulShutdownSignals
 from giskardpy.middleware.ros2.cycle_counter import CycleCounter
 from giskardpy.middleware.ros2.input_synchronization import WorldStateInputs
 from giskardpy.middleware.ros2.motion_server import MotionServer
@@ -257,13 +258,16 @@ class Giskard:
         """
         Start Giskard and wait for goals until ROS shuts down.
         """
-        try:
-            self.setup()
-            self.motion_server.live()
-            rospy.spinner_thread.join()
-        except Exception:
-            traceback.print_exc()
-        finally:
-            self.close_world_model_ros_interface()
-            if rclpy.ok():
-                rclpy.try_shutdown()
+        with GracefulShutdownSignals():
+            try:
+                self.setup()
+                self.motion_server.live()
+                rospy.spinner_thread.join()
+            except KeyboardInterrupt:
+                rospy.node.get_logger().info("Giskard was interrupted, shutting down.")
+            except Exception:
+                traceback.print_exc()
+            finally:
+                self.close_world_model_ros_interface()
+                if rclpy.ok():
+                    rclpy.try_shutdown()

--- a/giskardpy/src/giskardpy/middleware/ros2/graceful_shutdown.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/graceful_shutdown.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import signal
-from collections.abc import Callable
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from types import FrameType
+from typing import TYPE_CHECKING
 
-_SignalHandler = Callable[[int, FrameType | None], None] | int | None
+if TYPE_CHECKING:
+    from signal import _HANDLER as SignalHandler
 
 
 @dataclass
-class GracefulShutdownSignals:
+class GracefulShutdownSignals(AbstractContextManager):
     """
     Turns SIGINT and SIGTERM into a :class:`KeyboardInterrupt` for the duration of a
     ``with`` block, and restores whatever handlers were installed before on exit.
@@ -19,12 +21,12 @@ class GracefulShutdownSignals:
     regardless of which one arrives.
     """
 
-    _original_sigint_handler: _SignalHandler = field(init=False, default=None)
+    _original_sigint_handler: SignalHandler = field(init=False, default=None)
     """
     The SIGINT handler that was installed before entering the ``with`` block.
     """
 
-    _original_sigterm_handler: _SignalHandler = field(init=False, default=None)
+    _original_sigterm_handler: SignalHandler = field(init=False, default=None)
     """
     The SIGTERM handler that was installed before entering the ``with`` block.
     """
@@ -38,10 +40,9 @@ class GracefulShutdownSignals:
         )
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
+    def __exit__(self, exception_type, exception, traceback) -> None:
         signal.signal(signal.SIGINT, self._original_sigint_handler)
         signal.signal(signal.SIGTERM, self._original_sigterm_handler)
-        return False
 
     @staticmethod
     def _raise_keyboard_interrupt(signum: int, frame: FrameType | None) -> None:

--- a/giskardpy/src/giskardpy/middleware/ros2/graceful_shutdown.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/graceful_shutdown.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import signal
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from types import FrameType
+
+_SignalHandler = Callable[[int, FrameType | None], None] | int | None
+
+
+@dataclass
+class GracefulShutdownSignals:
+    """
+    Turns SIGINT and SIGTERM into a :class:`KeyboardInterrupt` for the duration of a
+    ``with`` block, and restores whatever handlers were installed before on exit.
+
+    A ROS2 launch file sends SIGINT first and escalates to SIGTERM if the process does
+    not exit in time. Handling both the same way lets the robot stop the same way
+    regardless of which one arrives.
+    """
+
+    _original_sigint_handler: _SignalHandler = field(init=False, default=None)
+    """
+    The SIGINT handler that was installed before entering the ``with`` block.
+    """
+
+    _original_sigterm_handler: _SignalHandler = field(init=False, default=None)
+    """
+    The SIGTERM handler that was installed before entering the ``with`` block.
+    """
+
+    def __enter__(self) -> GracefulShutdownSignals:
+        self._original_sigint_handler = signal.signal(
+            signal.SIGINT, self._raise_keyboard_interrupt
+        )
+        self._original_sigterm_handler = signal.signal(
+            signal.SIGTERM, self._raise_keyboard_interrupt
+        )
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        signal.signal(signal.SIGINT, self._original_sigint_handler)
+        signal.signal(signal.SIGTERM, self._original_sigterm_handler)
+        return False
+
+    @staticmethod
+    def _raise_keyboard_interrupt(signum: int, frame: FrameType | None) -> None:
+        raise KeyboardInterrupt

--- a/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
@@ -121,11 +121,21 @@ class MotionServer:
     def live(self) -> None:
         """
         Run the idle loop until ROS shuts down.
+
+        A KeyboardInterrupt is raised when the process is asked to shut down (see
+        :class:`~giskardpy.middleware.ros2.graceful_shutdown.GracefulShutdownSignals`),
+        whether that happens while idle or while a goal is running. Either way the robot
+        is stopped before the interrupt is allowed to propagate further.
         """
         rospy.node.get_logger().info("giskard is ready")
-        while rclpy.ok():
-            self.run_idle_cycle()
-            self.idle_pacer.sleep()
+        try:
+            while rclpy.ok():
+                self.run_idle_cycle()
+                self.idle_pacer.sleep()
+        except KeyboardInterrupt:
+            rospy.node.get_logger().info("Interrupted, stopping the robot.")
+            self.control_loop.stop()
+            raise
 
     def run_idle_cycle(self) -> None:
         """

--- a/test/giskardpy_test/test_ros2_stuff/test_graceful_shutdown.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_graceful_shutdown.py
@@ -4,13 +4,12 @@ import pytest
 
 from giskardpy.middleware.ros2.graceful_shutdown import GracefulShutdownSignals
 
-# %% signal to KeyboardInterrupt conversion
-
 
 class TestSignalsBecomeKeyboardInterrupt:
     """
-    Inside the ``with`` block, SIGINT and SIGTERM both raise KeyboardInterrupt, so a ROS2
-    launch file's SIGINT-then-SIGTERM escalation is handled the same way either time.
+    Inside the ``with`` block, SIGINT and SIGTERM both raise KeyboardInterrupt, so a
+    ROS2 launch file's SIGINT-then-SIGTERM escalation is handled the same way either
+    time.
     """
 
     def test_sigint_raises_keyboard_interrupt(self):
@@ -22,9 +21,6 @@ class TestSignalsBecomeKeyboardInterrupt:
         with pytest.raises(KeyboardInterrupt):
             with GracefulShutdownSignals():
                 signal.raise_signal(signal.SIGTERM)
-
-
-# %% handler restoration
 
 
 class TestOriginalHandlersAreRestored:
@@ -53,3 +49,14 @@ class TestOriginalHandlersAreRestored:
 
         assert signal.getsignal(signal.SIGINT) == original_sigint_handler
         assert signal.getsignal(signal.SIGTERM) == original_sigterm_handler
+
+
+class TestLeavingWithoutASignalIsQuiet:
+    """
+    Restoring the previous handlers only installs them; it never delivers the signals
+    they handle, so a block that no signal arrived in exits silently.
+    """
+
+    def test_leaving_the_block_raises_nothing_when_no_signal_arrived(self):
+        with GracefulShutdownSignals():
+            pass

--- a/test/giskardpy_test/test_ros2_stuff/test_graceful_shutdown.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_graceful_shutdown.py
@@ -1,0 +1,55 @@
+import signal
+
+import pytest
+
+from giskardpy.middleware.ros2.graceful_shutdown import GracefulShutdownSignals
+
+# %% signal to KeyboardInterrupt conversion
+
+
+class TestSignalsBecomeKeyboardInterrupt:
+    """
+    Inside the ``with`` block, SIGINT and SIGTERM both raise KeyboardInterrupt, so a ROS2
+    launch file's SIGINT-then-SIGTERM escalation is handled the same way either time.
+    """
+
+    def test_sigint_raises_keyboard_interrupt(self):
+        with pytest.raises(KeyboardInterrupt):
+            with GracefulShutdownSignals():
+                signal.raise_signal(signal.SIGINT)
+
+    def test_sigterm_raises_keyboard_interrupt(self):
+        with pytest.raises(KeyboardInterrupt):
+            with GracefulShutdownSignals():
+                signal.raise_signal(signal.SIGTERM)
+
+
+# %% handler restoration
+
+
+class TestOriginalHandlersAreRestored:
+    """
+    Leaving the ``with`` block puts back whatever handled SIGINT/SIGTERM before, so
+    nothing outside this feature is left with handlers it never installed.
+    """
+
+    def test_handlers_are_restored_after_a_normal_exit(self):
+        original_sigint_handler = signal.getsignal(signal.SIGINT)
+        original_sigterm_handler = signal.getsignal(signal.SIGTERM)
+
+        with GracefulShutdownSignals():
+            pass
+
+        assert signal.getsignal(signal.SIGINT) == original_sigint_handler
+        assert signal.getsignal(signal.SIGTERM) == original_sigterm_handler
+
+    def test_handlers_are_restored_after_the_block_raised(self):
+        original_sigint_handler = signal.getsignal(signal.SIGINT)
+        original_sigterm_handler = signal.getsignal(signal.SIGTERM)
+
+        with pytest.raises(KeyboardInterrupt):
+            with GracefulShutdownSignals():
+                signal.raise_signal(signal.SIGINT)
+
+        assert signal.getsignal(signal.SIGINT) == original_sigint_handler
+        assert signal.getsignal(signal.SIGTERM) == original_sigterm_handler

--- a/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
@@ -322,6 +322,17 @@ class BrokenInputError(Exception):
 
 
 @dataclass
+class InterruptingInputSynchronizer(InputSynchronizer):
+    """
+    Raises KeyboardInterrupt while reading its input, standing in for a process
+    interrupted mid-goal.
+    """
+
+    def apply(self) -> bool:
+        raise KeyboardInterrupt
+
+
+@dataclass
 class CycleWatchingGoalCanceler(InputSynchronizer):
     """
     Watches the completed cycles from inside the control loop and cancels the goal once
@@ -941,6 +952,41 @@ class TestStopClearsCommands:
 
     def test_publishers_are_stopped(self, motion_server: MotionServerFixture):
         motion_server.control_loop.stop()
+
+        assert motion_server.command_publisher.stop_count == 1
+
+
+class TestRobotIsStoppedOnInterrupt:
+    """
+    A KeyboardInterrupt (raised when the process is asked to shut down) always stops the
+    robot before it is allowed to propagate, whether it arrives while idle or mid-goal.
+    """
+
+    def test_the_robot_is_stopped_when_interrupted_while_idle(
+        self, motion_server: MotionServerFixture, monkeypatch: pytest.MonkeyPatch
+    ):
+        def raise_keyboard_interrupt() -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(
+            motion_server.motion_server, "run_idle_cycle", raise_keyboard_interrupt
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            motion_server.motion_server.live()
+
+        assert motion_server.command_publisher.stop_count == 1
+
+    def test_the_robot_is_stopped_when_interrupted_during_a_goal(
+        self, motion_server: MotionServerFixture
+    ):
+        motion_server.control_loop.inputs.synchronizers = [
+            InterruptingInputSynchronizer(world=motion_server.executor.context.world)
+        ]
+        motion_server.action_server.goal_json = create_goal_json()
+
+        with pytest.raises(KeyboardInterrupt):
+            motion_server.motion_server.run_idle_cycle()
 
         assert motion_server.command_publisher.stop_count == 1
 


### PR DESCRIPTION
- GracefulShutdownSignals: Handles signal replacement. Replaces old signals on entry into with-Block and changes back on exit.
- Giskard: Uses GracefulShutdownSignals to replace standard ROS2 signal handlers.
- MotionServer: Handles KeyboardInterrupt by shutting down ControlLoop, which stops robot as well.