### PR TITLE
Add rollback system for world modification history

### DIFF
--- a/krrood/src/krrood/adapters/json_serializer.py
+++ b/krrood/src/krrood/adapters/json_serializer.py
@@ -332,7 +332,11 @@ def _compute_attribute_diff(
     if not isinstance(original_values, list_like_classes):
         if original_values == new_values:
             return None
-        return JSONAttributeDiff(attribute_name=key, added_values=[new_values])
+        return JSONAttributeDiff(
+            attribute_name=key,
+            added_values=[new_values],
+            removed_values=[original_values],
+        )
 
     add = [new_value for new_value in new_values if new_value not in original_values]
     remove = [

--- a/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
@@ -327,6 +327,32 @@ class InsufficientModificationHistoryError(WorldValidationError):
 
 
 @dataclass
+class InvalidRollbackVersionError(WorldValidationError):
+    """
+    Raised when attempting to roll back to a version the world has not (yet) reached.
+    """
+
+    target_version: int
+    """
+    The version that was requested.
+    """
+
+    current_version: int
+    """
+    The version the world is currently at.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"Cannot roll back to version {self.target_version}: the world is "
+            f"currently at version {self.current_version}."
+        )
+
+    def suggest_correction(self) -> str:
+        return "pass a version between 0 and the world's current version."
+
+
+@dataclass
 class WorldContainsOrphanedDegreeOfFreedom(WorldValidationError):
     """
     Raised when the kinematic structure of the world contains orphaned degrees of

--- a/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/exceptions.py
@@ -300,6 +300,33 @@ class BrokenWorldModificationHistoryError(WorldValidationError):
 
 
 @dataclass
+class InsufficientModificationHistoryError(WorldValidationError):
+    """
+    Raised when attempting to roll back more modification blocks than the world's
+    history contains.
+    """
+
+    requested_count: int
+    """
+    The number of modification blocks that were requested to be rolled back.
+    """
+
+    available_count: int
+    """
+    The number of modification blocks actually available in the world's history.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"Cannot roll back {self.requested_count} modification block(s): the "
+            f"world's history only contains {self.available_count}."
+        )
+
+    def suggest_correction(self) -> str:
+        return "reduce the requested count to at most the number of available modification blocks."
+
+
+@dataclass
 class WorldContainsOrphanedDegreeOfFreedom(WorldValidationError):
     """
     Raised when the kinematic structure of the world contains orphaned degrees of
@@ -941,6 +968,7 @@ class DuplicateWorldEntityError(UsageError):
             "PrefixedName with the desired prefix, or use the plural get_..._by_name variant "
             "to retrieve all matches."
         )
+
 
 @dataclass
 class DuplicateRobotAssignmentsError(UsageError):

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -59,6 +59,7 @@ from semantic_digital_twin.exceptions import (
     WorldContainsOrphanedDegreeOfFreedom,
     BrokenWorldModificationHistoryError,
     MismatchingWorld,
+    InsufficientModificationHistoryError,
 )
 from semantic_digital_twin.mixin import HasSimulatorProperties
 from semantic_digital_twin.spatial_computations.forward_kinematics import (
@@ -2612,6 +2613,36 @@ class World(HasSimulatorProperties):
 
     def get_world_model_manager(self) -> WorldModelManager:
         return self._model_manager
+
+    def rollback_modification_blocks(
+        self, count: int = 1
+    ) -> List[WorldModelModificationBlock]:
+        """
+        Undo the most recently completed modification blocks, restoring the world to the
+        state it was in before they were applied.
+
+        Undoing a block is itself recorded as a new modification block (see
+        :meth:`WorldModification.undo`), so the history retains a full account of what
+        happened, including the rollback.
+
+        :param count: How many of the most recently completed modification blocks to
+            undo, starting with the most recent.
+        :return: The modification blocks that were rolled back, most recent first.
+        :raises InsufficientModificationHistoryError: If the history contains fewer than
+            ``count`` completed modification blocks.
+        """
+        model_modification_blocks = self._model_manager.model_modification_blocks
+        if count > len(model_modification_blocks):
+            raise InsufficientModificationHistoryError(
+                world=self,
+                requested_count=count,
+                available_count=len(model_modification_blocks),
+            )
+        blocks_to_roll_back = list(reversed(model_modification_blocks[-count:]))
+        for block in blocks_to_roll_back:
+            with self.modify_world():
+                block.undo(self)
+        return blocks_to_roll_back
 
     @cached_property
     def ray_tracer(self) -> RayTracer:

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -2618,15 +2618,15 @@ class World(HasSimulatorProperties):
         self, count: int = 1
     ) -> List[WorldModelModificationBlock]:
         """
-        Undo the most recently completed modification blocks, restoring the world to the
-        state it was in before they were applied.
+        Revert the most recently completed modification blocks, restoring the world to
+        the state it was in before they were applied.
 
-        Undoing a block is itself recorded as a new modification block (see
-        :meth:`WorldModification.undo`), so the history retains a full account of what
+        Reverting a block is itself recorded as a new modification block (see
+        :meth:`WorldModification.revert`), so the history retains a full account of what
         happened, including the rollback.
 
         :param count: How many of the most recently completed modification blocks to
-            undo, starting with the most recent.
+            revert, starting with the most recent.
         :return: The modification blocks that were rolled back, most recent first.
         :raises InsufficientModificationHistoryError: If the history contains fewer than
             ``count`` completed modification blocks.
@@ -2641,7 +2641,7 @@ class World(HasSimulatorProperties):
         blocks_to_roll_back = list(reversed(model_modification_blocks[-count:]))
         for block in blocks_to_roll_back:
             with self.modify_world():
-                block.undo(self)
+                block.revert(self)
         return blocks_to_roll_back
 
     @cached_property

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -60,6 +60,7 @@ from semantic_digital_twin.exceptions import (
     BrokenWorldModificationHistoryError,
     MismatchingWorld,
     InsufficientModificationHistoryError,
+    InvalidRollbackVersionError,
 )
 from semantic_digital_twin.mixin import HasSimulatorProperties
 from semantic_digital_twin.spatial_computations.forward_kinematics import (
@@ -2638,11 +2639,35 @@ class World(HasSimulatorProperties):
                 requested_count=count,
                 available_count=len(model_modification_blocks),
             )
-        blocks_to_roll_back = list(reversed(model_modification_blocks[-count:]))
+        # count == 0 has to be handled explicitly: model_modification_blocks[-0:] is
+        # model_modification_blocks[0:], i.e. the whole list, not an empty slice.
+        blocks_to_roll_back = (
+            list(reversed(model_modification_blocks[-count:])) if count else []
+        )
         for block in blocks_to_roll_back:
             with self.modify_world():
                 block.revert(self)
         return blocks_to_roll_back
+
+    def rollback_to_version(self, version: int) -> List[WorldModelModificationBlock]:
+        """
+        Roll back the world's modification history to the given version, undoing every
+        modification block completed since.
+
+        :param version: The target :attr:`WorldModelManager.version` to roll back to,
+            e.g. taken from an earlier :attr:`WorldModelManager.revision`.
+        :return: The modification blocks that were rolled back, most recent first.
+        :raises InvalidRollbackVersionError: If ``version`` is not a version the world
+            has already reached.
+        """
+        current_version = self._model_manager.version
+        if not 0 <= version <= current_version:
+            raise InvalidRollbackVersionError(
+                world=self,
+                target_version=version,
+                current_version=current_version,
+            )
+        return self.rollback_modification_blocks(current_version - version)
 
     @cached_property
     def ray_tracer(self) -> RayTracer:

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
@@ -63,12 +63,12 @@ class WorldModification(ABC):
         """
 
     @abstractmethod
-    def undo(self, world: World):
+    def revert(self, world: World):
         """
         Apply the inverse of this change to the given world, restoring it to the state
         it was in before this modification was applied.
 
-        Like :meth:`apply`, undoing a modification is itself recorded in the world's
+        Like :meth:`apply`, reverting a modification is itself recorded in the world's
         modification history, so the history retains a full account of what happened.
 
         :param world: The world to modify.
@@ -150,7 +150,7 @@ class AddKinematicStructureEntityModification(
             )
         world.add_kinematic_structure_entity(self.kinematic_structure_entity)
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.remove_kinematic_structure_entity(self.kinematic_structure_entity)
 
     def update_reference_for_world(self, world: World) -> Self:
@@ -172,7 +172,7 @@ class RemoveKinematicStructureEntityModification(WorldModification):
         default=None, repr=False
     )
     """
-    The body that was removed, kept so this modification can be undone.
+    The body that was removed, kept so this modification can be reverted.
     """
 
     @classmethod
@@ -185,7 +185,7 @@ class RemoveKinematicStructureEntityModification(WorldModification):
             world.get_kinematic_structure_entity_by_id(self.kinematic_structure_id)
         )
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.add_kinematic_structure_entity(self.kinematic_structure_entity)
 
 
@@ -223,7 +223,7 @@ class AddConnectionModification(WorldModificationWithWorldEntityReference):
             )
         world.add_connection(self.connection.copy_for_world(world))
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.remove_connection(self.connection)
 
     def update_reference_for_world(self, world: World) -> Self:
@@ -248,7 +248,7 @@ class RemoveConnectionModification(WorldModification):
 
     connection: Optional[Connection] = field(default=None, repr=False)
     """
-    The connection that was removed, kept so this modification can be undone.
+    The connection that was removed, kept so this modification can be reverted.
     """
 
     @classmethod
@@ -261,7 +261,7 @@ class RemoveConnectionModification(WorldModification):
         child = world.get_kinematic_structure_entity_by_id(self.child_id)
         world.remove_connection(world.get_connection(parent, child))
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.add_connection(self.connection)
 
 
@@ -294,7 +294,7 @@ class AddDegreeOfFreedomModification(WorldModificationWithWorldEntityReference):
             )
         world.add_degree_of_freedom(self.degree_of_freedom)
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.remove_degree_of_freedom(self.degree_of_freedom)
 
     def update_reference_for_world(self, world: World) -> Self:
@@ -304,22 +304,24 @@ class AddDegreeOfFreedomModification(WorldModificationWithWorldEntityReference):
 @dataclass
 class RemoveDegreeOfFreedomModification(WorldModification):
 
-    dof_id: UUID
+    degree_of_freedom_id: UUID
 
     degree_of_freedom: Optional[DegreeOfFreedom] = field(default=None, repr=False)
     """
-    The degree of freedom that was removed, kept so this modification can be undone.
+    The degree of freedom that was removed, kept so this modification can be reverted.
     """
 
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
         dof = kwargs["dof"]
-        return cls(dof_id=dof.id, degree_of_freedom=dof)
+        return cls(degree_of_freedom_id=dof.id, degree_of_freedom=dof)
 
     def apply(self, world: World):
-        world.remove_degree_of_freedom(world.get_degree_of_freedom_by_id(self.dof_id))
+        world.remove_degree_of_freedom(
+            world.get_degree_of_freedom_by_id(self.degree_of_freedom_id)
+        )
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.add_degree_of_freedom(self.degree_of_freedom)
 
 
@@ -330,7 +332,7 @@ class AddSemanticAnnotationModification(WorldModification, SubclassJSONSerialize
     semantic_annotation_id: Optional[UUID] = field(default=None)
     """
     The ID of the semantic annotation that was added, kept so this modification can be
-    undone.
+    reverted.
     """
 
     @classmethod
@@ -355,7 +357,7 @@ class AddSemanticAnnotationModification(WorldModification, SubclassJSONSerialize
             from_json(self.semantic_annotation_json, **kwargs)
         )
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.remove_semantic_annotation(
             world.get_semantic_annotation_by_id(self.semantic_annotation_id)
         )
@@ -382,7 +384,7 @@ class RemoveSemanticAnnotationModification(WorldModification, SubclassJSONSerial
 
     semantic_annotation_json: Optional[JSONData] = field(default=None)
     """
-    The semantic annotation that was removed, kept so this modification can be undone.
+    The semantic annotation that was removed, kept so this modification can be reverted.
     """
 
     @classmethod
@@ -398,7 +400,7 @@ class RemoveSemanticAnnotationModification(WorldModification, SubclassJSONSerial
             world.get_semantic_annotation_by_id(self.semantic_annotation_id)
         )
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         tracker = WorldEntityWithIDKwargsTracker.from_world(world)
         kwargs = tracker.create_kwargs()
         world.add_semantic_annotation(
@@ -443,7 +445,7 @@ class AddActuatorModification(WorldModificationWithWorldEntityReference):
 
         world.add_actuator(self.actuator)
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.remove_actuator(self.actuator)
 
     def update_reference_for_world(self, world: World) -> Self:
@@ -456,7 +458,7 @@ class RemoveActuatorModification(WorldModification):
 
     actuator: Optional[Actuator] = field(default=None, repr=False)
     """
-    The actuator that was removed, kept so this modification can be undone.
+    The actuator that was removed, kept so this modification can be reverted.
     """
 
     @classmethod
@@ -467,7 +469,7 @@ class RemoveActuatorModification(WorldModification):
     def apply(self, world: World):
         world.remove_actuator(world.get_actuator_by_id(self.actuator_id))
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         world.add_actuator(self.actuator)
 
 
@@ -487,15 +489,15 @@ class WorldModelModificationBlock:
         for modification in self.modifications:
             modification.apply(world)
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         """
-        Undo all modifications in this block, most recently applied first, restoring the
-        world to the state it was in before this block was applied.
+        Revert all modifications in this block, most recently applied first, restoring
+        the world to the state it was in before this block was applied.
 
         :param world: The world to modify.
         """
         for modification in reversed(self.modifications):
-            modification.undo(world)
+            modification.revert(world)
 
     def update_references_for_world_and_apply(self, world: World):
         """
@@ -563,7 +565,7 @@ class SetDofHasHardwareInterface(WorldModification):
     )
     """
     The ``has_hardware_interface`` value of every affected degree of freedom before this
-    modification was applied, kept so this modification can be undone.
+    modification was applied, kept so this modification can be reverted.
     """
 
     def apply(self, world: World):
@@ -572,7 +574,7 @@ class SetDofHasHardwareInterface(WorldModification):
                 self.value
             )
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         dofs_by_previous_value: Dict[bool, List[DegreeOfFreedom]] = {}
         for previous_value in self.previous_values:
             dof = world.get_degree_of_freedom_by_id(previous_value.degree_of_freedom_id)
@@ -657,7 +659,7 @@ class AttributeUpdateModification(WorldModification, SubclassJSONSerializer):
                 setattr(entity, diff.attribute_name, obj)
         world._model_manager.current_model_modification_block.append(self)
 
-    def undo(self, world: World):
+    def revert(self, world: World):
         tracker = WorldEntityWithIDKwargsTracker.from_world(world)
         kwargs = tracker.create_kwargs()
         entity = world.get_world_entity_with_id_by_id(self.entity_id)

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
@@ -62,6 +62,18 @@ class WorldModification(ABC):
         :param world: The world to modify.
         """
 
+    @abstractmethod
+    def undo(self, world: World):
+        """
+        Apply the inverse of this change to the given world, restoring it to the state
+        it was in before this modification was applied.
+
+        Like :meth:`apply`, undoing a modification is itself recorded in the world's
+        modification history, so the history retains a full account of what happened.
+
+        :param world: The world to modify.
+        """
+
     @classmethod
     @abstractmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]) -> Self:
@@ -138,6 +150,9 @@ class AddKinematicStructureEntityModification(
             )
         world.add_kinematic_structure_entity(self.kinematic_structure_entity)
 
+    def undo(self, world: World):
+        world.remove_kinematic_structure_entity(self.kinematic_structure_entity)
+
     def update_reference_for_world(self, world: World) -> Self:
         return self.__class__(self.kinematic_structure_entity.copy_for_world(world))
 
@@ -153,14 +168,25 @@ class RemoveKinematicStructureEntityModification(WorldModification):
     The UUID of the body that was removed.
     """
 
+    kinematic_structure_entity: Optional[KinematicStructureEntity] = field(
+        default=None, repr=False
+    )
+    """
+    The body that was removed, kept so this modification can be undone.
+    """
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(kwargs["kinematic_structure_entity"].id)
+        kinematic_structure_entity = kwargs["kinematic_structure_entity"]
+        return cls(kinematic_structure_entity.id, kinematic_structure_entity)
 
     def apply(self, world: World):
         world.remove_kinematic_structure_entity(
             world.get_kinematic_structure_entity_by_id(self.kinematic_structure_id)
         )
+
+    def undo(self, world: World):
+        world.add_kinematic_structure_entity(self.kinematic_structure_entity)
 
 
 @dataclass
@@ -197,6 +223,9 @@ class AddConnectionModification(WorldModificationWithWorldEntityReference):
             )
         world.add_connection(self.connection.copy_for_world(world))
 
+    def undo(self, world: World):
+        world.remove_connection(self.connection)
+
     def update_reference_for_world(self, world: World) -> Self:
         return self.__class__(self.connection.copy_for_world(world))
 
@@ -217,14 +246,23 @@ class RemoveConnectionModification(WorldModification):
     The UUIDs of the entities connected by the removed connection.
     """
 
+    connection: Optional[Connection] = field(default=None, repr=False)
+    """
+    The connection that was removed, kept so this modification can be undone.
+    """
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(kwargs["connection"].parent.id, kwargs["connection"].child.id)
+        connection = kwargs["connection"]
+        return cls(connection.parent.id, connection.child.id, connection)
 
     def apply(self, world: World):
         parent = world.get_kinematic_structure_entity_by_id(self.parent_id)
         child = world.get_kinematic_structure_entity_by_id(self.child_id)
         world.remove_connection(world.get_connection(parent, child))
+
+    def undo(self, world: World):
+        world.add_connection(self.connection)
 
 
 @dataclass
@@ -256,6 +294,9 @@ class AddDegreeOfFreedomModification(WorldModificationWithWorldEntityReference):
             )
         world.add_degree_of_freedom(self.degree_of_freedom)
 
+    def undo(self, world: World):
+        world.remove_degree_of_freedom(self.degree_of_freedom)
+
     def update_reference_for_world(self, world: World) -> Self:
         return self.__class__(self.degree_of_freedom.copy_for_world(world))
 
@@ -265,27 +306,99 @@ class RemoveDegreeOfFreedomModification(WorldModification):
 
     dof_id: UUID
 
+    degree_of_freedom: Optional[DegreeOfFreedom] = field(default=None, repr=False)
+    """
+    The degree of freedom that was removed, kept so this modification can be undone.
+    """
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(dof_id=kwargs["dof"].id)
+        dof = kwargs["dof"]
+        return cls(dof_id=dof.id, degree_of_freedom=dof)
 
     def apply(self, world: World):
         world.remove_degree_of_freedom(world.get_degree_of_freedom_by_id(self.dof_id))
+
+    def undo(self, world: World):
+        world.add_degree_of_freedom(self.degree_of_freedom)
 
 
 @dataclass
 class AddSemanticAnnotationModification(WorldModification, SubclassJSONSerializer):
     semantic_annotation_json: JSONData
 
+    semantic_annotation_id: Optional[UUID] = field(default=None)
+    """
+    The ID of the semantic annotation that was added, kept so this modification can be
+    undone.
+    """
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(semantic_annotation_json=to_json(kwargs["semantic_annotation"]))
+        semantic_annotation = kwargs["semantic_annotation"]
+        return cls(
+            semantic_annotation_json=to_json(semantic_annotation),
+            semantic_annotation_id=semantic_annotation.id,
+        )
 
     @classmethod
     def from_domain_object(cls, domain_object: SemanticAnnotation):
-        return cls(semantic_annotation_json=to_json(domain_object))
+        return cls(
+            semantic_annotation_json=to_json(domain_object),
+            semantic_annotation_id=domain_object.id,
+        )
 
     def apply(self, world: World):
+        tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+        kwargs = tracker.create_kwargs()
+        world.add_semantic_annotation(
+            from_json(self.semantic_annotation_json, **kwargs)
+        )
+
+    def undo(self, world: World):
+        world.remove_semantic_annotation(
+            world.get_semantic_annotation_by_id(self.semantic_annotation_id)
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            **super().to_json(),
+            "semantic_annotation_json": self.semantic_annotation_json,
+            "semantic_annotation_id": to_json(self.semantic_annotation_id),
+        }
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
+        return cls(
+            semantic_annotation_json=data["semantic_annotation_json"],
+            semantic_annotation_id=from_json(data["semantic_annotation_id"], **kwargs),
+        )
+
+
+@dataclass
+class RemoveSemanticAnnotationModification(WorldModification, SubclassJSONSerializer):
+
+    semantic_annotation_id: UUID
+
+    semantic_annotation_json: Optional[JSONData] = field(default=None)
+    """
+    The semantic annotation that was removed, kept so this modification can be undone.
+    """
+
+    @classmethod
+    def from_kwargs(cls, kwargs: Dict[str, Any]):
+        semantic_annotation = kwargs["semantic_annotation"]
+        return cls(
+            semantic_annotation_id=semantic_annotation.id,
+            semantic_annotation_json=to_json(semantic_annotation),
+        )
+
+    def apply(self, world: World):
+        world.remove_semantic_annotation(
+            world.get_semantic_annotation_by_id(self.semantic_annotation_id)
+        )
+
+    def undo(self, world: World):
         tracker = WorldEntityWithIDKwargsTracker.from_world(world)
         kwargs = tracker.create_kwargs()
         world.add_semantic_annotation(
@@ -295,26 +408,15 @@ class AddSemanticAnnotationModification(WorldModification, SubclassJSONSerialize
     def to_json(self) -> Dict[str, Any]:
         return {
             **super().to_json(),
+            "semantic_annotation_id": to_json(self.semantic_annotation_id),
             "semantic_annotation_json": self.semantic_annotation_json,
         }
 
     @classmethod
     def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
-        return cls(semantic_annotation_json=data["semantic_annotation_json"])
-
-
-@dataclass
-class RemoveSemanticAnnotationModification(WorldModification):
-
-    semantic_annotation_id: UUID
-
-    @classmethod
-    def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(semantic_annotation_id=kwargs["semantic_annotation"].id)
-
-    def apply(self, world: World):
-        world.remove_semantic_annotation(
-            world.get_semantic_annotation_by_id(self.semantic_annotation_id)
+        return cls(
+            semantic_annotation_id=from_json(data["semantic_annotation_id"], **kwargs),
+            semantic_annotation_json=data["semantic_annotation_json"],
         )
 
 
@@ -341,6 +443,9 @@ class AddActuatorModification(WorldModificationWithWorldEntityReference):
 
         world.add_actuator(self.actuator)
 
+    def undo(self, world: World):
+        world.remove_actuator(self.actuator)
+
     def update_reference_for_world(self, world: World) -> Self:
         return self.__class__(self.actuator.copy_for_world(world))
 
@@ -349,12 +454,21 @@ class AddActuatorModification(WorldModificationWithWorldEntityReference):
 class RemoveActuatorModification(WorldModification):
     actuator_id: UUID
 
+    actuator: Optional[Actuator] = field(default=None, repr=False)
+    """
+    The actuator that was removed, kept so this modification can be undone.
+    """
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]):
-        return cls(actuator_id=kwargs["actuator"].id)
+        actuator = kwargs["actuator"]
+        return cls(actuator_id=actuator.id, actuator=actuator)
 
     def apply(self, world: World):
         world.remove_actuator(world.get_actuator_by_id(self.actuator_id))
+
+    def undo(self, world: World):
+        world.add_actuator(self.actuator)
 
 
 @dataclass
@@ -372,6 +486,16 @@ class WorldModelModificationBlock:
     def apply(self, world: World):
         for modification in self.modifications:
             modification.apply(world)
+
+    def undo(self, world: World):
+        """
+        Undo all modifications in this block, most recently applied first, restoring the
+        world to the state it was in before this block was applied.
+
+        :param world: The world to modify.
+        """
+        for modification in reversed(self.modifications):
+            modification.undo(world)
 
     def update_references_for_world_and_apply(self, world: World):
         """
@@ -413,9 +537,34 @@ class WorldModelModificationBlock:
 
 
 @dataclass
+class DegreeOfFreedomHardwareInterfaceValue:
+    """
+    The ``has_hardware_interface`` flag one degree of freedom had at some point in time.
+    """
+
+    degree_of_freedom_id: UUID
+    """
+    The UUID of the degree of freedom.
+    """
+
+    has_hardware_interface: bool
+    """
+    Whether the degree of freedom had a hardware interface.
+    """
+
+
+@dataclass
 class SetDofHasHardwareInterface(WorldModification):
     degree_of_freedom_ids: List[UUID]
     value: bool
+
+    previous_values: List[DegreeOfFreedomHardwareInterfaceValue] = field(
+        default_factory=list
+    )
+    """
+    The ``has_hardware_interface`` value of every affected degree of freedom before this
+    modification was applied, kept so this modification can be undone.
+    """
 
     def apply(self, world: World):
         for dof_id in self.degree_of_freedom_ids:
@@ -423,11 +572,29 @@ class SetDofHasHardwareInterface(WorldModification):
                 self.value
             )
 
+    def undo(self, world: World):
+        dofs_by_previous_value: Dict[bool, List[DegreeOfFreedom]] = {}
+        for previous_value in self.previous_values:
+            dof = world.get_degree_of_freedom_by_id(previous_value.degree_of_freedom_id)
+            dofs_by_previous_value.setdefault(
+                previous_value.has_hardware_interface, []
+            ).append(dof)
+        for value, dofs in dofs_by_previous_value.items():
+            world.set_dofs_has_hardware_interface(dofs, value)
+
     @classmethod
     def from_kwargs(cls, kwargs: Dict[str, Any]) -> Self:
-        dofs = kwargs["dofs"]
-        degree_of_freedom_ids = [dof.id for dof in dofs]
-        return cls(degree_of_freedom_ids=degree_of_freedom_ids, value=kwargs["value"])
+        dofs = list(kwargs["dofs"])
+        return cls(
+            degree_of_freedom_ids=[dof.id for dof in dofs],
+            value=kwargs["value"],
+            previous_values=[
+                DegreeOfFreedomHardwareInterfaceValue(
+                    dof.id, dof.has_hardware_interface
+                )
+                for dof in dofs
+            ],
+        )
 
     def to_json(self) -> Dict[str, Any]:
         return {
@@ -436,6 +603,7 @@ class SetDofHasHardwareInterface(WorldModification):
                 to_json(dof_id) for dof_id in self.degree_of_freedom_ids
             ],
             "value": self.value,
+            "previous_values": to_json(self.previous_values),
         }
 
     @classmethod
@@ -445,6 +613,7 @@ class SetDofHasHardwareInterface(WorldModification):
                 from_json(_id) for _id in data["degree_of_freedom_ids"]
             ],
             value=data["value"],
+            previous_values=from_json(data["previous_values"], **kwargs),
         )
 
 
@@ -484,6 +653,26 @@ class AttributeUpdateModification(WorldModification, SubclassJSONSerializer):
             else:
                 obj = self._resolve_item(
                     world, from_json(diff.added_values[0], **kwargs)
+                )
+                setattr(entity, diff.attribute_name, obj)
+        world._model_manager.current_model_modification_block.append(self)
+
+    def undo(self, world: World):
+        tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+        kwargs = tracker.create_kwargs()
+        entity = world.get_world_entity_with_id_by_id(self.entity_id)
+        for diff in self.updated_kwargs_json_list:
+            current_value = getattr(entity, diff.attribute_name)
+            if isinstance(current_value, list_like_classes):
+                inverse_diff = JSONAttributeDiff(
+                    attribute_name=diff.attribute_name,
+                    added_values=diff.removed_values,
+                    removed_values=diff.added_values,
+                )
+                self._apply_to_list(current_value, inverse_diff, **kwargs)
+            else:
+                obj = self._resolve_item(
+                    world, from_json(diff.removed_values[0], **kwargs)
                 )
                 setattr(entity, diff.attribute_name, obj)
         world._model_manager.current_model_modification_block.append(self)

--- a/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
@@ -333,14 +333,14 @@ def test_design_09_failed_atomic_modification_is_not_recorded():
         )
 
 
-# %% undo and rollback
+# %% revert and rollback
 
 
 def _last_modification_block(world: World) -> WorldModelModificationBlock:
     return world.get_world_model_manager().model_modification_blocks[-1]
 
 
-def test_undo_add_kinematic_structure_entity():
+def test_revert_add_kinematic_structure_entity():
     world = World()
     body = Body(name=PrefixedName("body"))
     with world.modify_world():
@@ -350,12 +350,12 @@ def test_undo_add_kinematic_structure_entity():
     assert isinstance(modification, AddKinematicStructureEntityModification)
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert not world.is_kinematic_structure_entity_in_world(body)
 
 
-def test_undo_remove_kinematic_structure_entity():
+def test_revert_remove_kinematic_structure_entity():
     world = World()
     body = Body(name=PrefixedName("body"))
     with world.modify_world():
@@ -367,15 +367,15 @@ def test_undo_remove_kinematic_structure_entity():
     assert isinstance(modification, RemoveKinematicStructureEntityModification)
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert world.is_kinematic_structure_entity_in_world(body)
 
 
-def test_undo_add_connection():
+def test_revert_add_connection():
     # world.is_connection_in_world() is not used here: Connection.add_to_world()
     # never registers connections in the world's entity-hash table, so that check is
-    # always False regardless of undo. Membership in world.connections is the
+    # always False regardless of revert. Membership in world.connections is the
     # meaningful check, matching how the rest of this file verifies connections.
     world = World()
     with world.modify_world():
@@ -393,8 +393,8 @@ def test_undo_add_connection():
     )
 
     with world.modify_world():
-        modification.undo(world)
-        # undoing the connection alone leaves b2 disconnected from the world's single
+        modification.revert(world)
+        # reverting the connection alone leaves b2 disconnected from the world's single
         # root, which a modify_world block may not exit with; remove it too.
         world.remove_kinematic_structure_entity(b2)
 
@@ -402,7 +402,7 @@ def test_undo_add_connection():
     assert not world.is_kinematic_structure_entity_in_world(b2)
 
 
-def test_undo_remove_connection():
+def test_revert_remove_connection():
     world = World()
     with world.modify_world():
         b1 = Body(name=PrefixedName("b1"))
@@ -424,16 +424,16 @@ def test_undo_remove_connection():
     )
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert connection in world.connections
     assert world.is_kinematic_structure_entity_in_world(b2)
 
 
-def test_undo_add_degree_of_freedom():
+def test_revert_add_degree_of_freedom():
     # A degree of freedom not used by any connection is deleted automatically as an
     # orphan when the modify_world block that adds it closes (World.delete_orphaned_dofs),
-    # so it has to be attached to a connection to observe undo() removing it deliberately.
+    # so it has to be attached to a connection to observe revert() removing it deliberately.
     world = World()
     with world.modify_world():
         b1 = Body(name=PrefixedName("b1"))
@@ -458,12 +458,12 @@ def test_undo_add_degree_of_freedom():
         # compilation fails with a dangling reference to the removed dof.
         world.remove_connection(connection)
         world.remove_kinematic_structure_entity(b2)
-        modification.undo(world)
+        modification.revert(world)
 
     assert not world.is_degree_of_freedom_in_world(dof)
 
 
-def test_undo_remove_degree_of_freedom():
+def test_revert_remove_degree_of_freedom():
     world = World()
     with world.modify_world():
         b1 = Body(name=PrefixedName("b1"))
@@ -490,7 +490,7 @@ def test_undo_remove_degree_of_freedom():
     )
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
         # re-attach the dof so the block does not exit with it orphaned again.
         world.add_kinematic_structure_entity(b2)
         world.add_connection(connection)
@@ -498,7 +498,7 @@ def test_undo_remove_degree_of_freedom():
     assert world.is_degree_of_freedom_in_world(dof)
 
 
-def test_undo_add_semantic_annotation():
+def test_revert_add_semantic_annotation():
     world = World()
     with world.modify_world():
         body = Body(name=PrefixedName("body"))
@@ -512,12 +512,12 @@ def test_undo_add_semantic_annotation():
     assert handle.id in {a.id for a in world.semantic_annotations}
 
     with world.modify_world():
-        add_handle.undo(world)
+        add_handle.revert(world)
 
     assert handle.id not in {a.id for a in world.semantic_annotations}
 
 
-def test_undo_remove_semantic_annotation():
+def test_revert_remove_semantic_annotation():
     world = World()
     with world.modify_world():
         body = Body(name=PrefixedName("body"))
@@ -533,12 +533,12 @@ def test_undo_remove_semantic_annotation():
     assert handle.id not in {a.id for a in world.semantic_annotations}
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert handle.id in {a.id for a in world.semantic_annotations}
 
 
-def test_undo_add_actuator():
+def test_revert_add_actuator():
     world = World()
     actuator = Actuator(name=PrefixedName("actuator"))
     with world.modify_world():
@@ -546,12 +546,12 @@ def test_undo_add_actuator():
 
     modification = _last_modification_block(world)[0]
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert actuator not in world.actuators
 
 
-def test_undo_remove_actuator():
+def test_revert_remove_actuator():
     world = World()
     actuator = Actuator(name=PrefixedName("actuator"))
     with world.modify_world():
@@ -563,12 +563,12 @@ def test_undo_remove_actuator():
     assert isinstance(modification, RemoveActuatorModification)
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert actuator in world.actuators
 
 
-def test_undo_set_dofs_has_hardware_interface_restores_per_dof_previous_value():
+def test_revert_set_dofs_has_hardware_interface_restores_per_dof_previous_value():
     # dof1 and dof2 are each attached to a connection so neither is deleted as an
     # orphan when the modify_world block that adds it closes.
     world = World()
@@ -606,13 +606,13 @@ def test_undo_set_dofs_has_hardware_interface_restores_per_dof_previous_value():
     assert isinstance(modification, SetDofHasHardwareInterface)
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert dof1.has_hardware_interface is True
     assert dof2.has_hardware_interface is False
 
 
-def test_undo_attribute_update_scalar():
+def test_revert_attribute_update_scalar():
     world = World()
     body = Body(name=PrefixedName("body"))
     with world.modify_world():
@@ -628,12 +628,12 @@ def test_undo_attribute_update_scalar():
     assert isinstance(modification, AttributeUpdateModification)
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert body.name == original_name
 
 
-def test_undo_attribute_update_list():
+def test_revert_attribute_update_list():
     world = World()
     with world.modify_world():
         oven_body = Body(name=PrefixedName("oven_body"))
@@ -661,12 +661,12 @@ def test_undo_attribute_update_list():
     assert door in oven.doors
 
     with world.modify_world():
-        modification.undo(world)
+        modification.revert(world)
 
     assert door not in oven.doors
 
 
-def test_world_model_modification_block_undo_restores_removed_branch():
+def test_world_model_modification_block_revert_restores_removed_branch():
     world = World()
     with world.modify_world():
         root = Body(name=PrefixedName("root"))
@@ -682,13 +682,13 @@ def test_world_model_modification_block_undo_restores_removed_branch():
 
     block = _last_modification_block(world)
     with world.modify_world():
-        block.undo(world)
+        block.revert(world)
 
     assert world.is_kinematic_structure_entity_in_world(child)
     assert connection in world.connections
 
 
-def test_world_rollback_modification_blocks_undoes_most_recent_block():
+def test_world_rollback_modification_blocks_reverts_most_recent_block():
     # b2 is connected to b1 so the world stays a single connected tree at the end of
     # each modify_world block, as required.
     world = World()
@@ -713,7 +713,7 @@ def test_world_rollback_modification_blocks_undoes_most_recent_block():
     assert add_body_modification.kinematic_structure_entity is b2
 
 
-def test_world_rollback_modification_blocks_undoes_several_blocks_in_order():
+def test_world_rollback_modification_blocks_reverts_several_blocks_in_order():
     world = World()
     with world.modify_world():
         b1 = Body(name=PrefixedName("b1"))

--- a/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
@@ -4,14 +4,16 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from krrood.adapters.json_serializer import from_json, to_json
+from krrood.adapters.json_serializer import from_json, to_json, shallow_diff_json
 from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
     WorldEntityWithIDKwargsTracker,
 )
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
+from semantic_digital_twin.exceptions import InsufficientModificationHistoryError
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Handle,
     Door,
+    Oven,
 )
 from semantic_digital_twin.spatial_types.spatial_types import (
     Vector3,
@@ -32,10 +34,16 @@ from semantic_digital_twin.world_description.world_entity import Body, Actuator
 from semantic_digital_twin.world_description.world_modification import (
     WorldModelModificationBlock,
     AddKinematicStructureEntityModification,
+    RemoveKinematicStructureEntityModification,
     AddConnectionModification,
+    RemoveConnectionModification,
     AddDegreeOfFreedomModification,
+    RemoveDegreeOfFreedomModification,
     AddSemanticAnnotationModification,
     RemoveSemanticAnnotationModification,
+    RemoveActuatorModification,
+    SetDofHasHardwareInterface,
+    AttributeUpdateModification,
 )
 
 
@@ -323,6 +331,414 @@ def test_design_09_failed_atomic_modification_is_not_recorded():
             "a failed atomic modification was recorded in the history: "
             f"{block.modifications}"
         )
+
+
+# %% undo and rollback
+
+
+def _last_modification_block(world: World) -> WorldModelModificationBlock:
+    return world.get_world_model_manager().model_modification_blocks[-1]
+
+
+def test_undo_add_kinematic_structure_entity():
+    world = World()
+    body = Body(name=PrefixedName("body"))
+    with world.modify_world():
+        world.add_kinematic_structure_entity(body)
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, AddKinematicStructureEntityModification)
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert not world.is_kinematic_structure_entity_in_world(body)
+
+
+def test_undo_remove_kinematic_structure_entity():
+    world = World()
+    body = Body(name=PrefixedName("body"))
+    with world.modify_world():
+        world.add_kinematic_structure_entity(body)
+    with world.modify_world():
+        world.remove_kinematic_structure_entity(body)
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, RemoveKinematicStructureEntityModification)
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert world.is_kinematic_structure_entity_in_world(body)
+
+
+def test_undo_add_connection():
+    # world.is_connection_in_world() is not used here: Connection.add_to_world()
+    # never registers connections in the world's entity-hash table, so that check is
+    # always False regardless of undo. Membership in world.connections is the
+    # meaningful check, matching how the rest of this file verifies connections.
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b1)
+        world.add_kinematic_structure_entity(b2)
+        connection = FixedConnection(b1, b2)
+        world.add_connection(connection)
+
+    modification = next(
+        m
+        for m in _last_modification_block(world)
+        if isinstance(m, AddConnectionModification)
+    )
+
+    with world.modify_world():
+        modification.undo(world)
+        # undoing the connection alone leaves b2 disconnected from the world's single
+        # root, which a modify_world block may not exit with; remove it too.
+        world.remove_kinematic_structure_entity(b2)
+
+    assert connection not in world.connections
+    assert not world.is_kinematic_structure_entity_in_world(b2)
+
+
+def test_undo_remove_connection():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b1)
+        world.add_kinematic_structure_entity(b2)
+        connection = FixedConnection(b1, b2)
+        world.add_connection(connection)
+    with world.modify_world():
+        # removing the connection alone would leave b2 disconnected from the world's
+        # single root, which a modify_world block may not exit with; remove it too.
+        world.remove_connection(connection)
+        world.remove_kinematic_structure_entity(b2)
+
+    modification = next(
+        m
+        for m in _last_modification_block(world)
+        if isinstance(m, RemoveConnectionModification)
+    )
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert connection in world.connections
+    assert world.is_kinematic_structure_entity_in_world(b2)
+
+
+def test_undo_add_degree_of_freedom():
+    # A degree of freedom not used by any connection is deleted automatically as an
+    # orphan when the modify_world block that adds it closes (World.delete_orphaned_dofs),
+    # so it has to be attached to a connection to observe undo() removing it deliberately.
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b1)
+        world.add_kinematic_structure_entity(b2)
+        dof = DegreeOfFreedom(name=PrefixedName("dof"))
+        world.add_degree_of_freedom(dof)
+        connection = RevoluteConnection(
+            b1, b2, axis=Vector3.from_iterable([0, 0, 1]), raw_dof=dof
+        )
+        world.add_connection(connection)
+
+    modification = next(
+        m
+        for m in _last_modification_block(world)
+        if isinstance(m, AddDegreeOfFreedomModification)
+    )
+
+    with world.modify_world():
+        # the connection using this dof has to go too, otherwise forward kinematics
+        # compilation fails with a dangling reference to the removed dof.
+        world.remove_connection(connection)
+        world.remove_kinematic_structure_entity(b2)
+        modification.undo(world)
+
+    assert not world.is_degree_of_freedom_in_world(dof)
+
+
+def test_undo_remove_degree_of_freedom():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b1)
+        world.add_kinematic_structure_entity(b2)
+        dof = DegreeOfFreedom(name=PrefixedName("dof"))
+        world.add_degree_of_freedom(dof)
+        connection = RevoluteConnection(
+            b1, b2, axis=Vector3.from_iterable([0, 0, 1]), raw_dof=dof
+        )
+        world.add_connection(connection)
+    with world.modify_world():
+        # removing the connection first makes the explicit dof removal legal (a dof
+        # still used by a connection cannot safely be removed on its own).
+        world.remove_connection(connection)
+        world.remove_degree_of_freedom(dof)
+        world.remove_kinematic_structure_entity(b2)
+
+    modification = next(
+        m
+        for m in _last_modification_block(world)
+        if isinstance(m, RemoveDegreeOfFreedomModification)
+    )
+
+    with world.modify_world():
+        modification.undo(world)
+        # re-attach the dof so the block does not exit with it orphaned again.
+        world.add_kinematic_structure_entity(b2)
+        world.add_connection(connection)
+
+    assert world.is_degree_of_freedom_in_world(dof)
+
+
+def test_undo_add_semantic_annotation():
+    world = World()
+    with world.modify_world():
+        body = Body(name=PrefixedName("body"))
+        world.add_kinematic_structure_entity(body)
+    handle = Handle(root=body)
+
+    add_handle = AddSemanticAnnotationModification.from_domain_object(handle)
+    with world.modify_world():
+        add_handle.apply(world)
+
+    assert handle.id in {a.id for a in world.semantic_annotations}
+
+    with world.modify_world():
+        add_handle.undo(world)
+
+    assert handle.id not in {a.id for a in world.semantic_annotations}
+
+
+def test_undo_remove_semantic_annotation():
+    world = World()
+    with world.modify_world():
+        body = Body(name=PrefixedName("body"))
+        world.add_kinematic_structure_entity(body)
+    handle = Handle(root=body)
+    with world.modify_world():
+        world.add_semantic_annotation(handle)
+    with world.modify_world():
+        world.remove_semantic_annotation(handle)
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, RemoveSemanticAnnotationModification)
+    assert handle.id not in {a.id for a in world.semantic_annotations}
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert handle.id in {a.id for a in world.semantic_annotations}
+
+
+def test_undo_add_actuator():
+    world = World()
+    actuator = Actuator(name=PrefixedName("actuator"))
+    with world.modify_world():
+        world.add_actuator(actuator)
+
+    modification = _last_modification_block(world)[0]
+    with world.modify_world():
+        modification.undo(world)
+
+    assert actuator not in world.actuators
+
+
+def test_undo_remove_actuator():
+    world = World()
+    actuator = Actuator(name=PrefixedName("actuator"))
+    with world.modify_world():
+        world.add_actuator(actuator)
+    with world.modify_world():
+        world.remove_actuator(actuator)
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, RemoveActuatorModification)
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert actuator in world.actuators
+
+
+def test_undo_set_dofs_has_hardware_interface_restores_per_dof_previous_value():
+    # dof1 and dof2 are each attached to a connection so neither is deleted as an
+    # orphan when the modify_world block that adds it closes.
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        b2 = Body(name=PrefixedName("b2"))
+        b3 = Body(name=PrefixedName("b3"))
+        world.add_kinematic_structure_entity(b1)
+        world.add_kinematic_structure_entity(b2)
+        world.add_kinematic_structure_entity(b3)
+        dof1 = DegreeOfFreedom(name=PrefixedName("dof1"))
+        dof2 = DegreeOfFreedom(name=PrefixedName("dof2"))
+        world.add_degree_of_freedom(dof1)
+        world.add_degree_of_freedom(dof2)
+        world.add_connection(
+            RevoluteConnection(
+                b1, b2, axis=Vector3.from_iterable([0, 0, 1]), raw_dof=dof1
+            )
+        )
+        world.add_connection(
+            RevoluteConnection(
+                b2, b3, axis=Vector3.from_iterable([0, 0, 1]), raw_dof=dof2
+            )
+        )
+    with world.modify_world():
+        world.set_dofs_has_hardware_interface([dof1], True)
+
+    assert dof1.has_hardware_interface is True
+    assert dof2.has_hardware_interface is False
+
+    with world.modify_world():
+        world.set_dofs_has_hardware_interface([dof1, dof2], True)
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, SetDofHasHardwareInterface)
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert dof1.has_hardware_interface is True
+    assert dof2.has_hardware_interface is False
+
+
+def test_undo_attribute_update_scalar():
+    world = World()
+    body = Body(name=PrefixedName("body"))
+    with world.modify_world():
+        world.add_kinematic_structure_entity(body)
+
+    original_name = body.name
+    with world.modify_world():
+        body.update_name(PrefixedName("renamed"))
+
+    assert body.name == PrefixedName("renamed")
+
+    modification = _last_modification_block(world)[0]
+    assert isinstance(modification, AttributeUpdateModification)
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert body.name == original_name
+
+
+def test_undo_attribute_update_list():
+    world = World()
+    with world.modify_world():
+        oven_body = Body(name=PrefixedName("oven_body"))
+        door_body = Body(name=PrefixedName("door_body"))
+        world.add_kinematic_structure_entity(oven_body)
+        world.add_kinematic_structure_entity(door_body)
+        # a world must stay a single connected tree across modify_world blocks.
+        world.add_connection(FixedConnection(oven_body, door_body))
+
+    oven = Oven(root=oven_body)
+    door = Door(root=door_body)
+    with world.modify_world():
+        world.add_semantic_annotation(oven)
+        world.add_semantic_annotation(door)
+
+    tracker_kwargs = WorldEntityWithIDKwargsTracker.from_world(world).create_kwargs()
+    before_json = to_json(oven)
+    oven.doors.append(door)
+    after_json = to_json(oven)
+    diff = shallow_diff_json(before_json, after_json, **tracker_kwargs)
+
+    modification = AttributeUpdateModification(
+        entity_id=oven.id, updated_kwargs_json_list=diff
+    )
+    assert door in oven.doors
+
+    with world.modify_world():
+        modification.undo(world)
+
+    assert door not in oven.doors
+
+
+def test_world_model_modification_block_undo_restores_removed_branch():
+    world = World()
+    with world.modify_world():
+        root = Body(name=PrefixedName("root"))
+        child = Body(name=PrefixedName("child"))
+        world.add_kinematic_structure_entity(root)
+        world.add_kinematic_structure_entity(child)
+        connection = FixedConnection(root, child)
+        world.add_connection(connection)
+
+    world.remove_branch_from_world(child)
+    assert not world.is_kinematic_structure_entity_in_world(child)
+    assert connection not in world.connections
+
+    block = _last_modification_block(world)
+    with world.modify_world():
+        block.undo(world)
+
+    assert world.is_kinematic_structure_entity_in_world(child)
+    assert connection in world.connections
+
+
+def test_world_rollback_modification_blocks_undoes_most_recent_block():
+    # b2 is connected to b1 so the world stays a single connected tree at the end of
+    # each modify_world block, as required.
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+    with world.modify_world():
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b2)
+        world.add_connection(FixedConnection(b1, b2))
+
+    rolled_back = world.rollback_modification_blocks()
+
+    assert world.is_kinematic_structure_entity_in_world(b1)
+    assert not world.is_kinematic_structure_entity_in_world(b2)
+    assert len(rolled_back) == 1
+    add_body_modification = next(
+        m
+        for m in rolled_back[0]
+        if isinstance(m, AddKinematicStructureEntityModification)
+    )
+    assert add_body_modification.kinematic_structure_entity is b2
+
+
+def test_world_rollback_modification_blocks_undoes_several_blocks_in_order():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+    with world.modify_world():
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b2)
+        world.add_connection(FixedConnection(b1, b2))
+
+    world.rollback_modification_blocks(count=2)
+
+    assert not world.is_kinematic_structure_entity_in_world(b1)
+    assert not world.is_kinematic_structure_entity_in_world(b2)
+
+
+def test_world_rollback_modification_blocks_raises_when_insufficient_history():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+
+    with pytest.raises(InsufficientModificationHistoryError):
+        world.rollback_modification_blocks(count=2)
+
+    assert world.is_kinematic_structure_entity_in_world(b1)
 
 
 if __name__ == "__main__":

--- a/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
@@ -9,7 +9,10 @@ from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
     WorldEntityWithIDKwargsTracker,
 )
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
-from semantic_digital_twin.exceptions import InsufficientModificationHistoryError
+from semantic_digital_twin.exceptions import (
+    InsufficientModificationHistoryError,
+    InvalidRollbackVersionError,
+)
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Handle,
     Door,
@@ -739,6 +742,63 @@ def test_world_rollback_modification_blocks_raises_when_insufficient_history():
         world.rollback_modification_blocks(count=2)
 
     assert world.is_kinematic_structure_entity_in_world(b1)
+
+
+def test_world_rollback_to_version_reverts_blocks_after_it():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+    version_after_b1 = world.get_world_model_manager().version
+
+    with world.modify_world():
+        b2 = Body(name=PrefixedName("b2"))
+        world.add_kinematic_structure_entity(b2)
+        world.add_connection(FixedConnection(b1, b2))
+    with world.modify_world():
+        b3 = Body(name=PrefixedName("b3"))
+        world.add_kinematic_structure_entity(b3)
+        world.add_connection(FixedConnection(b2, b3))
+
+    rolled_back = world.rollback_to_version(version_after_b1)
+
+    assert world.is_kinematic_structure_entity_in_world(b1)
+    assert not world.is_kinematic_structure_entity_in_world(b2)
+    assert not world.is_kinematic_structure_entity_in_world(b3)
+    assert len(rolled_back) == 2
+
+
+def test_world_rollback_to_version_is_noop_at_current_version():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+    current_version = world.get_world_model_manager().version
+
+    rolled_back = world.rollback_to_version(current_version)
+
+    assert rolled_back == []
+    assert world.is_kinematic_structure_entity_in_world(b1)
+
+
+def test_world_rollback_to_version_raises_for_version_ahead_of_current():
+    world = World()
+    with world.modify_world():
+        b1 = Body(name=PrefixedName("b1"))
+        world.add_kinematic_structure_entity(b1)
+    current_version = world.get_world_model_manager().version
+
+    with pytest.raises(InvalidRollbackVersionError):
+        world.rollback_to_version(current_version + 1)
+
+    assert world.is_kinematic_structure_entity_in_world(b1)
+
+
+def test_world_rollback_to_version_raises_for_negative_version():
+    world = World()
+
+    with pytest.raises(InvalidRollbackVersionError):
+        world.rollback_to_version(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Every WorldModification subclass gains an undo() method that reverses its effect (Add<->Remove pairs, per-dof hardware-interface state, and generic attribute diffs), and WorldModelModificationBlock.undo() runs them in reverse order. World.rollback_modification_blocks() undoes the most recently completed blocks using this, raising InsufficientModificationHistoryError if the history is too short.

Several Remove*Modification classes now also keep a reference to the removed entity (previously only the id) so they can be re-added by undo(). SetDofHasHardwareInterface now records each affected dof's previous value. AttributeUpdateModification.undo() reverses the recorded diff; for scalar attributes this required krrood's shallow-diff helper to also record the previous value, which it previously discarded.

Made with the help of Claude.