### PR TITLE
Do() is in a Relationship

### DIFF
--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -74,14 +74,16 @@ class RelationalCircuitRegistry(ModelRegistry):
     :class:`~krrood.parametrization.exceptions.RelationalCircuitRegistryRequiresMatch`
     rather than failing on a missing attribute.
 
-    When the query also declares ``cause``/``causes_effect``/``confounder`` markers,
-    grounding uses :attr:`causal_grounding_mode` instead of
+    When the query also declares a ``cause`` marker, grounding uses
+    :attr:`causal_grounding_mode` instead of
     :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.PREDICTIVE`,
-    so the aggregation latents those markers name survive grounding instead of being
+    so the aggregation latents that marker names survive grounding instead of being
     integrated out, and the result is wrapped as a verified
     :class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
     instead of a plain circuit -- one more kind of cause this same registry can answer
-    about, not a parallel system. Non-causal queries are unaffected.
+    about, not a parallel system. Any accompanying ``causes_effect``/``confounder``
+    markers are read later, by ``ProbabilisticBackend``, once it has this
+    ``CausalCircuit`` in hand. Non-causal queries are unaffected.
     """
 
     relational_probabilistic_circuit: RelationalProbabilisticCircuit

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -10,8 +10,10 @@ from krrood.parametrization.parameterizer import (
 from krrood.utils import get_class_and_attribute_name
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
+    MarginalDeterminismTreeNode,
 )
 from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    GroundingMode,
     RelationalProbabilisticCircuit,
 )
 from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized
@@ -71,6 +73,15 @@ class RelationalCircuitRegistry(ModelRegistry):
     parameter classes don't carry -- resolving one of those raises
     :class:`~krrood.parametrization.exceptions.RelationalCircuitRegistryRequiresMatch`
     rather than failing on a missing attribute.
+
+    When the query also declares ``cause``/``causes_effect``/``confounder`` markers,
+    grounding uses :attr:`causal_grounding_mode` instead of
+    :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.PREDICTIVE`,
+    so the aggregation latents those markers name survive grounding instead of being
+    integrated out, and the result is wrapped as a verified
+    :class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
+    instead of a plain circuit -- one more kind of cause this same registry can answer
+    about, not a parallel system. Non-causal queries are unaffected.
     """
 
     relational_probabilistic_circuit: RelationalProbabilisticCircuit
@@ -78,10 +89,23 @@ class RelationalCircuitRegistry(ModelRegistry):
     The trained relational probabilistic circuit to ground.
     """
 
+    causal_grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED
+    """
+    Grounding mode used only when the query declares
+    ``cause``/``causes_effect``/``confounder`` markers. Non-causal queries always
+    ground with ``GroundingMode.PREDICTIVE``, unchanged from before.
+    """
+
     def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         if not isinstance(parameters, UnderspecifiedParameters):
             raise RelationalCircuitRegistryRequiresMatch(parameters)
-        grounded = self.relational_probabilistic_circuit.ground(parameters.statement)
+        is_causal_query = bool(parameters.search_cause_variables)
+        grounding_mode = (
+            self.causal_grounding_mode if is_causal_query else GroundingMode.PREDICTIVE
+        )
+        grounded = self.relational_probabilistic_circuit.ground(
+            parameters.statement, grounding_mode
+        )
         class_prefix = self.relational_probabilistic_circuit.class_.__name__
         rename_map = {}
         for circuit_var in grounded.variables:
@@ -91,7 +115,18 @@ class RelationalCircuitRegistry(ModelRegistry):
             if qualified_name in parameters.variables:
                 rename_map[circuit_var] = parameters.variables[qualified_name]
         grounded.update_variables(rename_map)
-        return grounded
+        if not is_causal_query:
+            return grounded
+
+        effect_variables = list(parameters.effect_variables_from_causes_effect)
+        tree = MarginalDeterminismTreeNode.from_causal_graph(
+            parameters.search_cause_variables, effect_variables
+        )
+        causal_circuit = CausalCircuit.from_probabilistic_circuit(
+            grounded, tree, parameters.search_cause_variables, effect_variables
+        )
+        causal_circuit.verify_support_determinism()
+        return causal_circuit
 
 
 @dataclass

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -10,13 +10,18 @@ from krrood.parametrization.parameterizer import (
 from krrood.utils import get_class_and_attribute_name
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
-    MarginalDeterminismTreeNode,
+)
+from probabilistic_model.probabilistic_circuit.relational.causal import (
+    RelationalCausalCircuit,
 )
 from probabilistic_model.probabilistic_circuit.relational.rspn import (
     GroundingMode,
     RelationalProbabilisticCircuit,
 )
 from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit,
+)
 from probabilistic_model.probabilistic_model import ProbabilisticModel
 
 
@@ -74,16 +79,16 @@ class RelationalCircuitRegistry(ModelRegistry):
     :class:`~krrood.parametrization.exceptions.RelationalCircuitRegistryRequiresMatch`
     rather than failing on a missing attribute.
 
-    When the query also declares a ``cause`` marker, grounding uses
-    :attr:`causal_grounding_mode` instead of
-    :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.PREDICTIVE`,
-    so the aggregation latents that marker names survive grounding instead of being
-    integrated out, and the result is wrapped as a verified
+    Every query grounds the same way, with :attr:`grounding_mode`: undetermined
+    aggregation latents are always retained, never integrated out. Whether the query
+    also declares a ``cause`` marker only decides what happens to the grounded circuit
+    afterward -- a postprocessing step, not a different way of grounding. A causal
+    query is wrapped as a verified
     :class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
-    instead of a plain circuit -- one more kind of cause this same registry can answer
-    about, not a parallel system. Any accompanying ``causes_effect``/``confounder``
+    registering the marked variables; any accompanying ``causes_effect``/``confounder``
     markers are read later, by ``ProbabilisticBackend``, once it has this
-    ``CausalCircuit`` in hand. Non-causal queries are unaffected.
+    ``CausalCircuit`` in hand. A non-causal query gets the grounded circuit back
+    unchanged, retained latents included.
     """
 
     relational_probabilistic_circuit: RelationalProbabilisticCircuit
@@ -91,22 +96,34 @@ class RelationalCircuitRegistry(ModelRegistry):
     The trained relational probabilistic circuit to ground.
     """
 
-    causal_grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED
+    grounding_mode: GroundingMode = GroundingMode.SAMPLED
     """
-    Grounding mode used only when the query declares
-    ``cause``/``causes_effect``/``confounder`` markers. Non-causal queries always
-    ground with ``GroundingMode.PREDICTIVE``, unchanged from before.
+    How undetermined aggregation latents are represented during grounding.
+
+    See
+    :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
     """
 
     def get_model(self, parameters: ModelQueryParameters) -> ProbabilisticModel:
         if not isinstance(parameters, UnderspecifiedParameters):
             raise RelationalCircuitRegistryRequiresMatch(parameters)
-        is_causal_query = bool(parameters.search_cause_variables)
-        grounding_mode = (
-            self.causal_grounding_mode if is_causal_query else GroundingMode.PREDICTIVE
-        )
+        grounded = self._ground_and_rename(parameters)
+        if not parameters.search_cause_variables:
+            return grounded
+        return self._as_causal_circuit(grounded, parameters)
+
+    def _ground_and_rename(
+        self, parameters: UnderspecifiedParameters
+    ) -> ProbabilisticCircuit:
+        """
+        Ground the relational circuit for ``parameters.statement`` and align its
+        variable names to the ``UnderspecifiedParameters`` convention.
+
+        :param parameters: The parameters extracted from the queried statement.
+        :return: The grounded, renamed circuit.
+        """
         grounded = self.relational_probabilistic_circuit.ground(
-            parameters.statement, grounding_mode
+            parameters.statement, self.grounding_mode
         )
         class_prefix = self.relational_probabilistic_circuit.class_.__name__
         rename_map = {}
@@ -117,18 +134,26 @@ class RelationalCircuitRegistry(ModelRegistry):
             if qualified_name in parameters.variables:
                 rename_map[circuit_var] = parameters.variables[qualified_name]
         grounded.update_variables(rename_map)
-        if not is_causal_query:
-            return grounded
+        return grounded
 
-        effect_variables = list(parameters.effect_variables_from_causes_effect)
-        tree = MarginalDeterminismTreeNode.from_causal_graph(
-            parameters.search_cause_variables, effect_variables
+    @staticmethod
+    def _as_causal_circuit(
+        grounded: ProbabilisticCircuit, parameters: UnderspecifiedParameters
+    ) -> CausalCircuit:
+        """
+        Wrap an already-grounded, already-renamed circuit as a verified
+        ``CausalCircuit`` registering the query's declared cause and effect variables.
+
+        :param grounded: The grounded, renamed circuit to wrap.
+        :param parameters: The parameters extracted from the queried statement, carrying
+            the declared cause and effect variables.
+        :return: A verified, support-deterministic ``CausalCircuit``.
+        """
+        return RelationalCausalCircuit.from_grounded_circuit(
+            grounded,
+            parameters.search_cause_variables,
+            list(parameters.effect_variables_from_causes_effect),
         )
-        causal_circuit = CausalCircuit.from_probabilistic_circuit(
-            grounded, tree, parameters.search_cause_variables, effect_variables
-        )
-        causal_circuit.verify_support_determinism()
-        return causal_circuit
 
 
 @dataclass

--- a/krrood/src/krrood/parametrization/model_registries.py
+++ b/krrood/src/krrood/parametrization/model_registries.py
@@ -149,7 +149,7 @@ class RelationalCircuitRegistry(ModelRegistry):
             the declared cause and effect variables.
         :return: A verified, support-deterministic ``CausalCircuit``.
         """
-        return RelationalCausalCircuit.from_grounded_circuit(
+        return RelationalCausalCircuit().from_grounded_circuit(
             grounded,
             parameters.search_cause_variables,
             list(parameters.effect_variables_from_causes_effect),

--- a/probabilistic_model/doc/_toc.yml
+++ b/probabilistic_model/doc/_toc.yml
@@ -13,6 +13,7 @@ parts:
     chapters:
     - file: probability_theory
     - file: queries
+    - file: causal_reasoning
   - caption: Probabilistic Models
     chapters:
     - file: graphical_models

--- a/probabilistic_model/doc/causal_reasoning.md
+++ b/probabilistic_model/doc/causal_reasoning.md
@@ -49,7 +49,7 @@ an adjustment set on a `CausalCircuit` is the analyst's assertion, from domain k
 that such a $G$ exists and that the chosen adjustment set satisfies the backdoor criterion
 relative to it. What the package verifies instead is the circuit-side precondition the next
 section's polytime algorithm depends on -- support determinism -- which is a property of the
-probabilistic circuit itself, not of $G$; it is unrelated to the vtree used later for
+probabilistic circuit itself, not of $G$; it is unrelated to the variable tree used later for
 tractability, and to the `MarginalDeterminismTreeNode` structure introduced below, which only
 groups query variables for that check and does not represent $G$'s edges.
 
@@ -78,20 +78,21 @@ Evaluating the backdoor formula requires computing $P(Y \mid X = x, Z = z)$ for 
 $z$ in the adjustment set's domain, and summing. On an arbitrary joint distribution this can
 be as expensive as the domain of $Z$ is large.
 
-````{prf:definition} Vtree
-:label: def-vtree
+````{prf:definition} Variable Tree
+:label: def-variable-tree
 
-A vtree over a variable set $X$ is a full, rooted binary tree whose leaves are in
+A variable tree over a variable set $X$ is a full, rooted binary tree whose leaves are in
 one-to-one correspondence with the variables in $X$. Each internal node corresponds to
 the subset of $X$ at the leaves beneath it, partitioned by that node's two children into
-disjoint left and right subsets {cite}`kisa2014probabilistic`.
+disjoint left and right subsets ({cite}`kisa2014probabilistic`, where it is termed a
+*vtree*).
 ````
 
 {cite}`wang2023compositional` shows that on a *structured-decomposable* probabilistic
 circuit -- one where every product unit's children partition the scope along a shared,
-recursively fixed {prf:ref}`def-vtree` -- backdoor adjustment is tractable in the size of
-the circuit whenever the circuit satisfies one additional structural property for the
-relevant variables: **support determinism**.
+recursively fixed {prf:ref}`def-variable-tree` -- backdoor adjustment is tractable in the
+size of the circuit whenever the circuit satisfies one additional structural property for
+the relevant variables: **support determinism**.
 
 ````{prf:definition} Support Determinism
 :label: def-support-determinism
@@ -109,12 +110,14 @@ already partition the world by the value those variables take -- so answering "w
 $P(Y \mid X = x, Z = z)$ under this branch" never requires mixing across branches, and the
 backdoor sum becomes a single weighted pass over the circuit rather than one circuit
 evaluation per $(x, z)$ pair. {cite}`wang2023compositional` formalizes the circuit family
-that guarantees this -- *marginal-deterministic vtrees* (*md-vtrees*), a generalization of
-probabilistic sentential decision diagrams {cite}`kisa2014probabilistic` -- and derives the
-first polytime algorithm for backdoor adjustment on such circuits.
-This package does not require an md-vtree-typed circuit outright; instead it *verifies* the
-support-determinism property directly on whatever structured-decomposable circuit it is
-given, which is the property the polytime algorithm actually depends on.
+that guarantees this -- *marginal-deterministic variable trees* (termed *md-vtrees* in
+{cite}`wang2023compositional`), a generalization of probabilistic sentential decision
+diagrams {cite}`kisa2014probabilistic` -- and derives the first polytime algorithm for
+backdoor adjustment on such circuits.
+This package does not require a marginal-deterministic-variable-tree-typed circuit
+outright; instead it *verifies* the support-determinism property directly on whatever
+structured-decomposable circuit it is given, which is the property the polytime algorithm
+actually depends on.
 
 ### Implementation: `CausalCircuit`
 
@@ -203,7 +206,7 @@ single flat circuit has "object count" as one of its variables ahead of time -- 
 set depends on which scene is being described.
 
 `RelationalProbabilisticCircuit` ({cite}`nath2015rspn`, "Relational Sum-Product Networks",
-and KRRUESER by David Prüser, extended here onto circuits with the query system
+and {cite}`prueser2026knowledge`, extended here onto circuits with the query system
 `probabilistic_model.probabilistic_circuit.relational` bridges into `krrood`) resolves this
 by *grounding*: given a query describing one concrete
 scene, it stamps out one instance of a fitted template circuit per object the query
@@ -312,18 +315,19 @@ grounded.
 
 | Work | Relational | Causal | Substrate | Tractability mechanism |
 |---|---|---|---|---|
-| {cite}`nath2015rspn` (RSPN) | Yes | No | Sum-product network | Templated grounding |
-| {cite}`wang2023compositional` (md-vtrees) | No | Yes | Structured-decomposable circuit | Support determinism $\to$ polytime backdoor adjustment |
+| {cite}`nath2015rspn` (Relational Sum-Product Networks) | Yes | No | Sum-product network | Templated grounding |
+| {cite}`wang2023compositional` (marginal-deterministic variable trees) | No | Yes | Structured-decomposable circuit | Support determinism $\to$ polytime backdoor adjustment |
 | {cite}`luttermann2024lifted` (Lifted Causal Inference) | Yes | Yes | Parametric factor graphs | Domain-lifted: polynomial in domain size for a bounded-logvar fragment, non-grounding queries only |
-| This package | Yes | Yes | RSPN grounded onto a structured-decomposable circuit | Cause/effect registration: free (additive to circuit size). Adjustment registration: guarded against Cartesian-product blowup |
+| This package | Yes | Yes | Relational Sum-Product Network grounded onto a structured-decomposable circuit | Cause/effect registration: free (additive to circuit size). Adjustment registration: guarded against Cartesian-product blowup |
 
-No prior work was found combining md-vtree-style circuit causal inference with relational
-grounding directly; {cite}`luttermann2024lifted` is the closest bridge, but on a different
-substrate (parametric factor graphs, not circuits) with its own, differently scoped
-tractability class (lifted over object symmetry, rather than exact per-query grounding).
+No prior work was found combining marginal-deterministic-variable-tree-style circuit causal
+inference with relational grounding directly; {cite}`luttermann2024lifted` is the closest
+bridge, but on a different substrate (parametric factor graphs, not circuits) with its own,
+differently scoped tractability class (lifted over object symmetry, rather than exact
+per-query grounding).
 This package stays fully grounded per query rather than lifted: it answers exact causal
-queries at RSPN's existing per-query grounding granularity, not population-scale inference
-over many symmetric objects at once.
+queries at the relational sum-product network's existing per-query grounding granularity,
+not population-scale inference over many symmetric objects at once.
 
 ```{bibliography}
 ```

--- a/probabilistic_model/doc/causal_reasoning.md
+++ b/probabilistic_model/doc/causal_reasoning.md
@@ -32,17 +32,26 @@ from conditioning, $P(Y \mid X = x)$, whenever $X$ and $Y$ share a common cause:
 $X = x$ also tells you something about that common cause, which then leaks into what you
 infer about $Y$; intervening on $X$ does not.
 
-The backdoor criterion below is stated over a causal graph: a directed acyclic graph
-$G = (V, E)$ whose edges represent direct causal influence, with $X$, $Y$, and every
-candidate adjustment variable among its nodes $V$. This package neither constructs nor
-verifies $G$: registering `causal_variables`, `effect_variables`, and an adjustment set on
-a `CausalCircuit` is the analyst's assertion, from domain knowledge, that such a $G$ exists
-and that the chosen adjustment set satisfies the backdoor criterion relative to it. What the
-package verifies instead is the circuit-side precondition the next section's polytime
-algorithm depends on -- support determinism -- which is a property of the probabilistic
-circuit itself, not of $G$; it is unrelated to the vtree used later for tractability, and to
-the `MarginalDeterminismTreeNode` structure introduced below, which only groups query
-variables for that check and does not represent $G$'s edges.
+The backdoor criterion below is stated over a causal graph:
+
+````{prf:definition} Causal Graph
+:label: def-causal-graph
+
+A causal graph is a directed acyclic graph $G = (V, E)$ whose nodes $V$ are random
+variables and whose edges $E$ represent direct causal influence: an edge $U \to W$
+means $U$ is a direct cause of $W$. A node $Z$ is a *descendant* of $X$ in $G$ if $G$
+contains a directed path from $X$ to $Z$.
+````
+
+with $X$, $Y$, and every candidate adjustment variable among $G$'s nodes $V$. This package
+neither constructs nor verifies $G$: registering `causal_variables`, `effect_variables`, and
+an adjustment set on a `CausalCircuit` is the analyst's assertion, from domain knowledge,
+that such a $G$ exists and that the chosen adjustment set satisfies the backdoor criterion
+relative to it. What the package verifies instead is the circuit-side precondition the next
+section's polytime algorithm depends on -- support determinism -- which is a property of the
+probabilistic circuit itself, not of $G$; it is unrelated to the vtree used later for
+tractability, and to the `MarginalDeterminismTreeNode` structure introduced below, which only
+groups query variables for that check and does not represent $G$'s edges.
 
 ````{prf:definition} Backdoor Criterion
 :label: def-backdoor-criterion
@@ -67,11 +76,22 @@ interventional and observational distributions coincide.
 
 Evaluating the backdoor formula requires computing $P(Y \mid X = x, Z = z)$ for every value
 $z$ in the adjustment set's domain, and summing. On an arbitrary joint distribution this can
-be as expensive as the domain of $Z$ is large. {cite}`wang2023compositional` shows that on a
-*structured-decomposable* probabilistic circuit -- one where every product unit's children
-partition the scope along a shared, recursively fixed variable tree (a vtree) -- backdoor
-adjustment is tractable in the size of the circuit whenever the circuit satisfies one
-additional structural property for the relevant variables: **support determinism**.
+be as expensive as the domain of $Z$ is large.
+
+````{prf:definition} Vtree
+:label: def-vtree
+
+A vtree over a variable set $X$ is a full, rooted binary tree whose leaves are in
+one-to-one correspondence with the variables in $X$. Each internal node corresponds to
+the subset of $X$ at the leaves beneath it, partitioned by that node's two children into
+disjoint left and right subsets {cite}`kisa2014probabilistic`.
+````
+
+{cite}`wang2023compositional` shows that on a *structured-decomposable* probabilistic
+circuit -- one where every product unit's children partition the scope along a shared,
+recursively fixed {prf:ref}`def-vtree` -- backdoor adjustment is tractable in the size of
+the circuit whenever the circuit satisfies one additional structural property for the
+relevant variables: **support determinism**.
 
 ````{prf:definition} Support Determinism
 :label: def-support-determinism
@@ -89,8 +109,9 @@ already partition the world by the value those variables take -- so answering "w
 $P(Y \mid X = x, Z = z)$ under this branch" never requires mixing across branches, and the
 backdoor sum becomes a single weighted pass over the circuit rather than one circuit
 evaluation per $(x, z)$ pair. {cite}`wang2023compositional` formalizes the circuit family
-that guarantees this (*md-vtrees*, a generalization of probabilistic sentential decision
-diagrams) and derives the first polytime algorithm for backdoor adjustment on such circuits.
+that guarantees this -- *marginal-deterministic vtrees* (*md-vtrees*), a generalization of
+probabilistic sentential decision diagrams {cite}`kisa2014probabilistic` -- and derives the
+first polytime algorithm for backdoor adjustment on such circuits.
 This package does not require an md-vtree-typed circuit outright; instead it *verifies* the
 support-determinism property directly on whatever structured-decomposable circuit it is
 given, which is the property the polytime algorithm actually depends on.

--- a/probabilistic_model/doc/causal_reasoning.md
+++ b/probabilistic_model/doc/causal_reasoning.md
@@ -32,6 +32,18 @@ from conditioning, $P(Y \mid X = x)$, whenever $X$ and $Y$ share a common cause:
 $X = x$ also tells you something about that common cause, which then leaks into what you
 infer about $Y$; intervening on $X$ does not.
 
+The backdoor criterion below is stated over a causal graph: a directed acyclic graph
+$G = (V, E)$ whose edges represent direct causal influence, with $X$, $Y$, and every
+candidate adjustment variable among its nodes $V$. This package neither constructs nor
+verifies $G$: registering `causal_variables`, `effect_variables`, and an adjustment set on
+a `CausalCircuit` is the analyst's assertion, from domain knowledge, that such a $G$ exists
+and that the chosen adjustment set satisfies the backdoor criterion relative to it. What the
+package verifies instead is the circuit-side precondition the next section's polytime
+algorithm depends on -- support determinism -- which is a property of the probabilistic
+circuit itself, not of $G$; it is unrelated to the vtree used later for tractability, and to
+the `MarginalDeterminismTreeNode` structure introduced below, which only groups query
+variables for that check and does not represent $G$'s edges.
+
 ````{prf:definition} Backdoor Criterion
 :label: def-backdoor-criterion
 
@@ -108,6 +120,59 @@ fitted `ProbabilisticCircuit` together with:
   one, it additionally weights each cause-region branch by $P(Z = z)$ and sums, using the
   region structure `verify_support_determinism` already confirmed is disjoint.
 
+### Worked example: a confounded discrete circuit
+
+Take a scene with three discrete variables: `season` $\in \{$WARM, COLD$\}$ (a confounder),
+`treatment` $\in \{$HIGH, LOW$\}$, and `outcome` $\in \{$GOOD, BAD$\}$. `treatment` has no
+causal effect of its own; every difference in `outcome` is actually driven by `season`, which
+also happens to influence which `treatment` gets chosen -- the classic Simpson's-paradox
+shape. The fitted circuit is a root `SumUnit` over two strata:
+
+$$
+\begin{aligned}
+\text{Warm stratum } (w = 0.6): \quad & P(\texttt{treatment}=\text{HIGH}) = 0.8, \quad \texttt{outcome} = \text{GOOD (deterministic)} \\
+\text{Cold stratum } (w = 0.4): \quad & P(\texttt{treatment}=\text{HIGH}) = 0.3, \quad \texttt{outcome} = \text{BAD (deterministic)}
+\end{aligned}
+$$
+
+Structurally, each stratum is a `ProductUnit` of three independent factors: a point-mass leaf
+on `season`, a two-leaf `SumUnit` over `treatment`, and a point-mass leaf on `outcome`. The
+root splits on `season` with disjoint branches (WARM vs. COLD) -- support-deterministic over
+`season` by construction. Each stratum's inner `SumUnit` splits on `treatment` with disjoint
+HIGH/LOW leaves -- support-deterministic over `treatment` too. The root itself is *not* a
+split node for `treatment`: both strata give `treatment` positive probability on both HIGH and
+LOW, so their marginal supports on `treatment` overlap rather than partition it, and
+`_check_sum_unit_for_variable`'s split-detection correctly leaves it out of the check.
+`CausalCircuit.verify_support_determinism()` passes with `causal_variables = [treatment,
+season]`, `effect_variables = [outcome]`.
+
+Conditioning naively on `treatment = HIGH` recovers the spurious correlation:
+
+$$P(\texttt{outcome}=\text{GOOD} \mid \texttt{treatment}=\text{HIGH}) = 0.8,$$
+
+the same number `backdoor_adjustment(treatment, outcome)` returns with an empty adjustment
+set, since an empty $Z$ cannot separate the confound from the effect. Registering `season` as
+the adjustment variable instead runs the general path,
+`_compute_interventional_circuit_with_adjustment`: it extracts `season`'s two disjoint
+regions as $Z$-partitions, and for each `treatment` region builds a `ProductUnit` whose effect
+side is a fresh `SumUnit` over $P(\texttt{outcome} \mid \texttt{treatment}=x, \texttt{season}=z)$
+weighted by $P(\texttt{season}=z)$ -- the backdoor sum from
+{prf:ref}`def-backdoor-criterion` evaluated stratum by stratum:
+
+$$
+P(\texttt{outcome}=\text{GOOD} \mid do(\texttt{treatment}=\text{HIGH})) =
+\underbrace{0.6}_{P(\text{WARM})} \cdot \underbrace{1.0}_{P(\text{GOOD}\mid \text{HIGH}, \text{WARM})}
++ \underbrace{0.4}_{P(\text{COLD})} \cdot \underbrace{0.0}_{P(\text{GOOD}\mid \text{HIGH}, \text{COLD})}
+= 0.6,
+$$
+
+and the same $0.6$ for `treatment = LOW`, revealing what conditioning hid: `treatment` has no
+causal effect on `outcome` at all. The `ProductUnit` for each `treatment` region is itself
+weighted by that region's own marginal probability -- $P(\texttt{treatment}=\text{HIGH}) =
+0.6 \cdot 0.8 + 0.4 \cdot 0.3 = 0.6$ -- which is what keeps the returned circuit a valid joint
+distribution over $(\texttt{treatment}, \texttt{outcome})$ rather than four disconnected
+numbers.
+
 ## Relational causal reasoning
 
 The circuits above assume a fixed variable set, decided once and for all when the circuit
@@ -117,8 +182,9 @@ single flat circuit has "object count" as one of its variables ahead of time -- 
 set depends on which scene is being described.
 
 `RelationalProbabilisticCircuit` ({cite}`nath2015rspn`, "Relational Sum-Product Networks",
-extended here onto circuits with the query system `probabilistic_model.probabilistic_circuit.relational`
-bridges into `krrood`) resolves this by *grounding*: given a query describing one concrete
+and KRRUESER by David Prüser, extended here onto circuits with the query system
+`probabilistic_model.probabilistic_circuit.relational` bridges into `krrood`) resolves this
+by *grounding*: given a query describing one concrete
 scene, it stamps out one instance of a fitted template circuit per object the query
 mentions, and combines the instances into a single circuit over that scene's actual
 variables. Where the query leaves some *aggregation statistic* undetermined -- e.g. it asks
@@ -127,13 +193,12 @@ child instances to stamp out and how to combine them, which requires resolving t
 statistic to a concrete value or distribution over values (the "undetermined latent") before
 grounding the exchangeable part.
 
-Prior to this package, that undetermined latent was resolved by marginalizing it out
-immediately: grounding blended over every possible object count and discarded the
-count itself, leaving no variable behind to register as a cause or an effect. That is fine
-for prediction (the blended answer is what you want, if you don't care why), but it removes
-exactly the variable a causal query about it would need. `GroundingMode` gives grounding two
-alternative representations that *retain* the latent as a variable of the grounded circuit
-instead:
+Resolving that undetermined latent by marginalizing it out immediately would blend over
+every possible object count and discard the count itself, leaving no variable behind to
+register as a cause or an effect. That is fine for prediction (the blended answer is what
+you want, if you don't care why), but it removes exactly the variable a causal query about
+it would need. `GroundingMode` instead gives grounding two representations that *retain*
+the latent as a variable of the grounded circuit:
 
 - `GroundingMode.SAMPLED`: draw `monte_carlo_sample_count` values of the latent from the
   conditioned circuit, ground one child instance per distinct sampled value, and retain each
@@ -176,23 +241,23 @@ differ, and it is not free for the exact-partition case:
   disjoint regardless of what the underlying distribution over $L$ looks like. This is why
   `SAMPLED` always succeeds: disjointness of single points needs no assumption about the
   fitted model.
-- **`EXACT`** instead needs the fitted `JointProbabilityTree` {cite}`nyga2023joint` to have
-  *actually split* on $L$: a JPT is only guaranteed deterministic
-  ({cite}`choi2020probabilistic`) over variables it chose to split on, and does not retain
-  which those were after fitting. $L$ being one of the tree's *targets* rather than a
-  *feature* it split on can leave `circuit.marginal(undetermined_latents)`'s root as a
-  single, undifferentiated branch (trivially "one region", not a genuine partition) or, in
-  principle, with overlapping branches -- either of which would violate the theorem's
-  hypothesis while still superficially looking like "a sum unit over $L$".
+- **`EXACT`** instead needs the fitted circuit to have *actually partitioned* on $L$: a sum
+  unit is only guaranteed support-deterministic ({prf:ref}`def-support-determinism`) over
+  variables whose children happen to disjointly cover it, and a fitted circuit does not
+  retain, after fitting, which variables that held for. $L$ not being one of them can leave
+  `circuit.marginal(undetermined_latents)`'s root as a single, undifferentiated branch
+  (trivially "one region", not a genuine partition) or, in principle, with overlapping
+  branches -- either of which would violate the theorem's hypothesis while still
+  superficially looking like "a sum unit over $L$".
   `_undetermined_latents_partition_disjointly` checks pairwise disjointness on the
-  marginalized circuit directly, rather than assuming it from how the tree was fit. If the
+  marginalized circuit directly, rather than assuming it from how the circuit was fit. If the
   check fails, the precondition of {prf:ref}`thm-retained-latent-disjoint` does not hold, and
   `attach_exact_partition_mixture` raises `UndeterminedLatentsNotPartitionedError` rather than
   silently grounding every branch from the same representative point (which would discard
   $L$'s correlation with the rest of the circuit while still looking, structurally, like a
   valid disjoint partition). Grounding catches exactly this and falls back to `SAMPLED`,
-  logging a warning that the template needs refitting with $L$ as a feature for `EXACT` to
-  apply.
+  logging a warning that the template needs refitting so that it actually splits on $L$ for
+  `EXACT` to apply.
 
 The theorem only gives *structural* determinism (the property `verify_support_determinism`
 checks); it says nothing about whether the mixture weights $w_i$ are the right ones. Getting
@@ -238,19 +303,6 @@ tractability class (lifted over object symmetry, rather than exact per-query gro
 This package stays fully grounded per query rather than lifted: it answers exact causal
 queries at RSPN's existing per-query grounding granularity, not population-scale inference
 over many symmetric objects at once.
-
-## Open question: does the interventional distribution match reality?
-
-Everything above establishes that grounding-then-registering a relational cause is
-*structurally* sound -- it produces a valid, support-deterministic `CausalCircuit`, so
-`backdoor_adjustment` runs and returns something. It does not establish that the resulting
-interventional distribution is numerically close to the true causal effect in a physical
-system the model was fit on, nor how the two `GroundingMode`s compare in accuracy or latency
-at realistic leaf counts. That is an empirical question this chapter deliberately leaves
-open: the natural check is grounding on simulated data with a known ground truth (e.g. a
-box-stacking simulation where the true stack-success rate at each box count is directly
-measurable) and comparing it against `backdoor_adjustment`'s prediction, since only
-simulation offers that ground truth directly.
 
 ```{bibliography}
 ```

--- a/probabilistic_model/doc/causal_reasoning.md
+++ b/probabilistic_model/doc/causal_reasoning.md
@@ -1,0 +1,256 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.11.5
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+(chapter:causal-reasoning)=
+# Causal Reasoning
+
+This chapter summarizes the causal-inference literature this package builds on, and shows
+how `probabilistic_model.probabilistic_circuit.causal` and
+`probabilistic_model.probabilistic_circuit.relational` implement it. It assumes the
+probabilistic-circuit background from {ref}`chapter:queries` and the definitions in
+{cite}`choi2020probabilistic`.
+
+## Interventions and the backdoor-adjustment formula
+
+A causal query asks what happens to one variable when another is *forced* to a value,
+rather than merely *observed* to have it. Pearl's do-operator {cite}`pearl2009causality`
+writes this as $P(Y \mid do(X = x))$: the distribution of effect $Y$ once cause $X$ is set
+to $x$ by intervention, cutting $X$ off from whatever normally determines it. This differs
+from conditioning, $P(Y \mid X = x)$, whenever $X$ and $Y$ share a common cause: observing
+$X = x$ also tells you something about that common cause, which then leaks into what you
+infer about $Y$; intervening on $X$ does not.
+
+````{prf:definition} Backdoor Criterion
+:label: def-backdoor-criterion
+
+A set of variables $Z$ satisfies the backdoor criterion relative to an ordered pair
+$(X, Y)$ if:
+
+1. no node in $Z$ is a descendant of $X$, and
+2. $Z$ blocks every path between $X$ and $Y$ that contains an arrow into $X$.
+
+If $Z$ satisfies the backdoor criterion, the causal effect of $X$ on $Y$ is identifiable
+from observational data alone, and is given by
+
+$$P(Y \mid do(X = x)) = \sum_z P(Y \mid X = x, Z = z) \, P(Z = z).$$
+````
+
+With an empty adjustment set (no confounding to correct for -- the case for independently
+randomized training data), this collapses to $P(Y \mid do(X = x)) = P(Y \mid X = x)$: the
+interventional and observational distributions coincide.
+
+## Tractable causal inference on probabilistic circuits
+
+Evaluating the backdoor formula requires computing $P(Y \mid X = x, Z = z)$ for every value
+$z$ in the adjustment set's domain, and summing. On an arbitrary joint distribution this can
+be as expensive as the domain of $Z$ is large. {cite}`wang2023compositional` shows that on a
+*structured-decomposable* probabilistic circuit -- one where every product unit's children
+partition the scope along a shared, recursively fixed variable tree (a vtree) -- backdoor
+adjustment is tractable in the size of the circuit whenever the circuit satisfies one
+additional structural property for the relevant variables: **support determinism**.
+
+````{prf:definition} Support Determinism
+:label: def-support-determinism
+
+A sum unit is support-deterministic over a variable set $V$ if, for every pair of its
+children, the children's marginal supports on $V$ are disjoint: no assignment to $V$ has
+positive probability under more than one child.
+
+A circuit is support-deterministic over $V$ if every sum unit that splits on any variable
+in $V$ is support-deterministic over $V$.
+````
+
+Support determinism over the cause and adjustment variables means each sum unit's children
+already partition the world by the value those variables take -- so answering "what is
+$P(Y \mid X = x, Z = z)$ under this branch" never requires mixing across branches, and the
+backdoor sum becomes a single weighted pass over the circuit rather than one circuit
+evaluation per $(x, z)$ pair. {cite}`wang2023compositional` formalizes the circuit family
+that guarantees this (*md-vtrees*, a generalization of probabilistic sentential decision
+diagrams) and derives the first polytime algorithm for backdoor adjustment on such circuits.
+This package does not require an md-vtree-typed circuit outright; instead it *verifies* the
+support-determinism property directly on whatever structured-decomposable circuit it is
+given, which is the property the polytime algorithm actually depends on.
+
+### Implementation: `CausalCircuit`
+
+`probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit` wraps a
+fitted `ProbabilisticCircuit` together with:
+
+- `causal_variables` / `effect_variables` -- the registered $X$ and $Y$ of
+  {prf:ref}`def-backdoor-criterion`.
+- `marginal_determinism_tree`, a `MarginalDeterminismTreeNode` -- a binary tree over the
+  cause variables, built by `from_causal_graph` recursively bisecting the (priority-ordered)
+  cause list. Each node records the variables in its subtree and a `query_set` (by default
+  its own highest-priority variable); `all_query_sets()` flattens every node's `query_set`
+  in pre-order, and their union is exactly the set of cause variables that need to satisfy
+  {prf:ref}`def-support-determinism`. `find_node_for_variable` additionally lets
+  `diagnose_failure` walk the tree to recover the priority a variable was registered with.
+- `verify_support_determinism()`, which takes that union of query variables and checks
+  {prf:ref}`def-support-determinism` for each of them against every sum unit in the circuit,
+  raising `SupportDeterminismVerificationResult` with every violation found if any check
+  fails. This is a validity *check*, not a construction step: it does not repair a circuit
+  that fails it.
+- `backdoor_adjustment(cause_variable, effect_variable, adjustment_variables)`, which
+  implements the formula in {prf:ref}`def-backdoor-criterion` directly: with no adjustment
+  set it truncates the circuit to each cause region and reads off the effect marginal; with
+  one, it additionally weights each cause-region branch by $P(Z = z)$ and sums, using the
+  region structure `verify_support_determinism` already confirmed is disjoint.
+
+## Relational causal reasoning
+
+The circuits above assume a fixed variable set, decided once and for all when the circuit
+is fitted. That does not hold for a scene with an unknown number of objects: how many
+objects there are is itself a fact you might want to intervene on or condition on, but no
+single flat circuit has "object count" as one of its variables ahead of time -- the variable
+set depends on which scene is being described.
+
+`RelationalProbabilisticCircuit` ({cite}`nath2015rspn`, "Relational Sum-Product Networks",
+extended here onto circuits with the query system `probabilistic_model.probabilistic_circuit.relational`
+bridges into `krrood`) resolves this by *grounding*: given a query describing one concrete
+scene, it stamps out one instance of a fitted template circuit per object the query
+mentions, and combines the instances into a single circuit over that scene's actual
+variables. Where the query leaves some *aggregation statistic* undetermined -- e.g. it asks
+about "a room with some chairs" without saying how many -- grounding must decide how many
+child instances to stamp out and how to combine them, which requires resolving the
+statistic to a concrete value or distribution over values (the "undetermined latent") before
+grounding the exchangeable part.
+
+Prior to this package, that undetermined latent was resolved by marginalizing it out
+immediately: grounding blended over every possible object count and discarded the
+count itself, leaving no variable behind to register as a cause or an effect. That is fine
+for prediction (the blended answer is what you want, if you don't care why), but it removes
+exactly the variable a causal query about it would need. `GroundingMode` gives grounding two
+alternative representations that *retain* the latent as a variable of the grounded circuit
+instead:
+
+- `GroundingMode.SAMPLED`: draw `monte_carlo_sample_count` values of the latent from the
+  conditioned circuit, ground one child instance per distinct sampled value, and retain each
+  sampled value as an additional point-valued (Dirac) leaf mounted alongside its instance.
+- `GroundingMode.EXACT`: instead of sampling, enumerate the latent's own exact partition as
+  already fitted by the class circuit's `JointProbabilityTree` {cite}`nyga2023joint` -- the
+  branches of `circuit.marginal(undetermined_latents)`'s root sum unit -- and ground one
+  instance per branch, retaining that branch's own region rather than a single point.
+
+### Why retaining the latent this way preserves support determinism
+
+This is the structural argument `ExchangeablePartGrounder.attach_monte_carlo_mixture` and
+`attach_exact_partition_mixture` rely on, and the reason grounding can hand a causal circuit
+a retained latent without breaking {prf:ref}`def-support-determinism`:
+
+````{prf:theorem} Grounded latent retention is support-deterministic
+:label: thm-retained-latent-disjoint
+
+Let $L$ be an undetermined latent and $\{a_1, \dots, a_k\}$ a finite set of values (or
+regions) of $L$ such that the $a_i$ are pairwise disjoint as subsets of $L$'s domain. Let
+$C_1, \dots, C_k$ be circuits, each grounded by conditioning on a determined statistics and
+one $a_i$, and mounted so that $C_i$ additionally carries $L \in a_i$ as part of its scope
+(as a Dirac leaf at $a_i$, for a sampled point; as the branch region itself, for an exact
+partition branch). Then the sum unit $S = \sum_i w_i \cdot C_i$ is support-deterministic over
+$L$.
+````
+
+*Sketch.* Support determinism over $L$ requires every pair of $S$'s children to have
+disjoint marginal support on $L$. $C_i$'s marginal support on $L$ is exactly $a_i$ -- for the
+Dirac case because a point mass has no support outside its point, and for the exact-partition
+case because $a_i$ is one branch of `circuit.marginal(undetermined_latents)`'s root sum unit.
+Since the $a_i$ are pairwise disjoint by hypothesis, so are the $C_i$'s marginal supports on
+$L$. $\blacksquare$
+
+The hypothesis -- that the $a_i$ are actually pairwise disjoint -- is where the two modes
+differ, and it is not free for the exact-partition case:
+
+- **`SAMPLED`** deduplicates its Monte-Carlo draws before grounding
+  (`_sample_undetermined_latents`), so the $a_i$ are distinct points -- trivially pairwise
+  disjoint regardless of what the underlying distribution over $L$ looks like. This is why
+  `SAMPLED` always succeeds: disjointness of single points needs no assumption about the
+  fitted model.
+- **`EXACT`** instead needs the fitted `JointProbabilityTree` {cite}`nyga2023joint` to have
+  *actually split* on $L$: a JPT is only guaranteed deterministic
+  ({cite}`choi2020probabilistic`) over variables it chose to split on, and does not retain
+  which those were after fitting. $L$ being one of the tree's *targets* rather than a
+  *feature* it split on can leave `circuit.marginal(undetermined_latents)`'s root as a
+  single, undifferentiated branch (trivially "one region", not a genuine partition) or, in
+  principle, with overlapping branches -- either of which would violate the theorem's
+  hypothesis while still superficially looking like "a sum unit over $L$".
+  `_undetermined_latents_partition_disjointly` checks pairwise disjointness on the
+  marginalized circuit directly, rather than assuming it from how the tree was fit. If the
+  check fails, the precondition of {prf:ref}`thm-retained-latent-disjoint` does not hold, and
+  `attach_exact_partition_mixture` raises `UndeterminedLatentsNotPartitionedError` rather than
+  silently grounding every branch from the same representative point (which would discard
+  $L$'s correlation with the rest of the circuit while still looking, structurally, like a
+  valid disjoint partition). Grounding catches exactly this and falls back to `SAMPLED`,
+  logging a warning that the template needs refitting with $L$ as a feature for `EXACT` to
+  apply.
+
+The theorem only gives *structural* determinism (the property `verify_support_determinism`
+checks); it says nothing about whether the mixture weights $w_i$ are the right ones. Getting
+those right is a separate, per-mounting-node computation
+(`_node_local_latent_log_likelihoods` for `SAMPLED`, `_node_local_branch_log_probabilities`
+for `EXACT`): two product nodes that mount the same exchangeable relation can correlate $L$
+differently with the rest of the scene, so each node's weights over the same global set of
+branches are computed from that node's own local marginal, not shared globally.
+
+### `RelationalCausalCircuit`
+
+`probabilistic_model.probabilistic_circuit.relational.causal.RelationalCausalCircuit` is the
+factory that composes the two halves: `ground()` grounds a `RelationalProbabilisticCircuit`
+for a query under a chosen `GroundingMode`, then `from_grounded_circuit()` resolves the
+requested cause/effect/adjustment variables (by `Variable` or by a dotted access-path string,
+via `resolve_variable`), builds the `MarginalDeterminismTreeNode`, and returns a verified
+`CausalCircuit` -- the same object the flat, non-relational path produces, so
+`backdoor_adjustment` and `diagnose_failure` work identically regardless of whether the
+circuit came from a fixed template or was grounded per-query.
+
+Registering more than one relational adjustment variable at once is the one place this can
+get expensive: `CausalCircuit`'s adjustment-region extraction takes a Cartesian product
+across the adjustment variables' leaf regions, and a `GroundingMode.EXACT` variable's region
+count can grow with the training data (unlike `SAMPLED`, capped by
+`monte_carlo_sample_count`). `RelationalCausalCircuit.adjustment_region_count_warning_threshold`
+warns when that product is large, as a diagnostic against discovering the cost only at query
+time -- not a guarantee, since it is read off however the adjustment variables actually got
+grounded.
+
+## Literature position
+
+| Work | Relational | Causal | Substrate | Tractability mechanism |
+|---|---|---|---|---|
+| {cite}`nath2015rspn` (RSPN) | Yes | No | Sum-product network | Templated grounding |
+| {cite}`wang2023compositional` (md-vtrees) | No | Yes | Structured-decomposable circuit | Support determinism $\to$ polytime backdoor adjustment |
+| {cite}`luttermann2024lifted` (Lifted Causal Inference) | Yes | Yes | Parametric factor graphs | Domain-lifted: polynomial in domain size for a bounded-logvar fragment, non-grounding queries only |
+| This package | Yes | Yes | RSPN grounded onto a structured-decomposable circuit | Cause/effect registration: free (additive to circuit size). Adjustment registration: guarded against Cartesian-product blowup |
+
+No prior work was found combining md-vtree-style circuit causal inference with relational
+grounding directly; {cite}`luttermann2024lifted` is the closest bridge, but on a different
+substrate (parametric factor graphs, not circuits) with its own, differently scoped
+tractability class (lifted over object symmetry, rather than exact per-query grounding).
+This package stays fully grounded per query rather than lifted: it answers exact causal
+queries at RSPN's existing per-query grounding granularity, not population-scale inference
+over many symmetric objects at once.
+
+## Open question: does the interventional distribution match reality?
+
+Everything above establishes that grounding-then-registering a relational cause is
+*structurally* sound -- it produces a valid, support-deterministic `CausalCircuit`, so
+`backdoor_adjustment` runs and returns something. It does not establish that the resulting
+interventional distribution is numerically close to the true causal effect in a physical
+system the model was fit on, nor how the two `GroundingMode`s compare in accuracy or latency
+at realistic leaf counts. That is an empirical question this chapter deliberately leaves
+open: the natural check is grounding on simulated data with a known ground truth (e.g. a
+box-stacking simulation where the true stack-success rate at each box count is directly
+measurable) and comparing it against `backdoor_adjustment`'s prediction, since only
+simulation offers that ground truth directly.
+
+```{bibliography}
+```

--- a/probabilistic_model/doc/references.bib
+++ b/probabilistic_model/doc/references.bib
@@ -243,3 +243,13 @@ volume = {}
   year={2024},
   journal={arXiv preprint arXiv:2403.10184}
 }
+
+@mastersthesis{prueser2026knowledge,
+  author = {Pr{\"u}ser, David},
+  title = {Knowledge Representation and Reasoning under Uncertainty using Explicit Summaries about Entities and Relations},
+  school = {Universit{\"a}t Bremen, Faculty 03: Mathematics/Computer Science},
+  year = {2026},
+  month = aug,
+  note = {Supervisor: Tom Schierenbeck; First Examiner: Prof. Dr. h.c. Michael Beetz, PhD; Second Examiner: Prof. Dr. Nico Hochgeschwender},
+  type = {Master's Thesis}
+}

--- a/probabilistic_model/doc/references.bib
+++ b/probabilistic_model/doc/references.bib
@@ -228,6 +228,13 @@ volume = {}
   journal={arXiv preprint arXiv:2304.08278}
 }
 
+@inproceedings{kisa2014probabilistic,
+  title={Probabilistic Sentential Decision Diagrams},
+  author={Kisa, Doga and Van den Broeck, Guy and Choi, Arthur and Darwiche, Adnan},
+  booktitle={Fourteenth International Conference on the Principles of Knowledge Representation and Reasoning (KR)},
+  year={2014}
+}
+
 @inproceedings{luttermann2024lifted,
   title={Lifted Causal Inference in Relational Domains},
   author={Luttermann, Malte and Hartwig, Mattis and Braun, Tanya and M{\"o}ller, Ralf and Gehrke, Marcel},

--- a/probabilistic_model/doc/references.bib
+++ b/probabilistic_model/doc/references.bib
@@ -201,3 +201,38 @@ volume = {}
   journal={arXiv preprint arXiv:2302.07167},
   year={2023}
 }
+
+@book{pearl2009causality,
+  title={Causality: Models, Reasoning, and Inference},
+  author={Pearl, Judea},
+  edition={2nd},
+  publisher={Cambridge University Press},
+  year={2009}
+}
+
+@inproceedings{nath2015rspn,
+  title={Learning Relational Sum-Product Networks},
+  author={Nath, Aniruddh and Domingos, Pedro},
+  booktitle={Proceedings of the AAAI Conference on Artificial Intelligence},
+  volume={29},
+  year={2015}
+}
+
+@inproceedings{wang2023compositional,
+  title={Compositional Probabilistic and Causal Inference using Tractable Circuit Models},
+  author={Wang, Benjie and Kwiatkowska, Marta},
+  booktitle={Proceedings of the 26th International Conference on Artificial Intelligence and Statistics (AISTATS)},
+  series={Proceedings of Machine Learning Research},
+  volume={206},
+  year={2023},
+  journal={arXiv preprint arXiv:2304.08278}
+}
+
+@inproceedings{luttermann2024lifted,
+  title={Lifted Causal Inference in Relational Domains},
+  author={Luttermann, Malte and Hartwig, Mattis and Braun, Tanya and M{\"o}ller, Ralf and Gehrke, Marcel},
+  booktitle={Proceedings of the 3rd Conference on Causal Learning and Reasoning (CLeaR)},
+  pages={827--842},
+  year={2024},
+  journal={arXiv preprint arXiv:2403.10184}
+}

--- a/probabilistic_model/src/probabilistic_model/learning/jpt/variables.py
+++ b/probabilistic_model/src/probabilistic_model/learning/jpt/variables.py
@@ -4,7 +4,12 @@ import pandas as pd
 
 from krrood.utils import get_default_value
 from random_events.variable import Continuous, Integer, Symbolic, Variable
-from pandas.core.dtypes.common import is_integer_dtype, is_float_dtype, is_bool_dtype
+from pandas.core.dtypes.common import (
+    is_integer_dtype,
+    is_float_dtype,
+    is_bool_dtype,
+    is_string_dtype,
+)
 from random_events.set import Set
 from typing_extensions import List, Any
 
@@ -94,7 +99,7 @@ def infer_variables_from_dataframe(
         elif is_bool_dtype(datatype):
             variable_class = Symbolic
             domain = Set.from_iterable([True, False])
-        elif data[column].dtype == object:
+        elif data[column].dtype == object or is_string_dtype(datatype):
             unique_values = data[column].unique()
             variable_class = Symbolic
             domain = Set.from_iterable(unique_values)

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/causal/causal_circuit.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/causal/causal_circuit.py
@@ -293,8 +293,11 @@ class CausalCircuit:
     """
     A ProbabilisticCircuit extended with exact, tractable causal inference using the
     marginal determinism framework. The Marginal Determinism Variable Tree structure
-    encodes the causal graph and enables polytime backdoor adjustment for any valid
-    adjustment set Z.
+    groups the registered cause variables for the support-determinism check that enables
+    polytime backdoor adjustment for any valid adjustment set Z; it does not represent
+    the causal graph itself, which the caller supplies implicitly by registering
+    causal_variables, effect_variables, and an adjustment set known to satisfy the
+    backdoor criterion.
 
     Wraps a fitted ProbabilisticCircuit and adds:
       - backdoor_adjustment()        — P(effect | do(cause)) as a new circuit

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import logging
 import math
-from typing_extensions import TYPE_CHECKING, List, Optional, Union
+from dataclasses import dataclass
+from typing_extensions import TYPE_CHECKING, ClassVar, List, Optional, Union
 
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
@@ -35,166 +36,220 @@ from random_events.variable import Variable
 if TYPE_CHECKING:
     from krrood.entity_query_language.query.match import Match
 
-logger = logging.getLogger(__name__)
 
-DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD = 1000
-"""
-Default value of ``adjustment_region_count_warning_threshold``.
-
-See :func:`ground_relational_causal_circuit`.
-"""
-
-
-def resolve_variable(circuit: ProbabilisticCircuit, path: str) -> Variable:
+@dataclass
+class RelationalCausalCircuit:
     """
-    Resolve a dotted access-path suffix to the Variable it names in a grounded circuit.
+    Factory bridging ``RelationalProbabilisticCircuit`` grounding into ``CausalCircuit``
+    construction, mirroring how the rest of the ``relational`` package bridges
+    ``probabilistic_model`` and ``krrood``.
 
-    Accepts either a variable's full runtime name (e.g. ``"SceneRoom.objects[0].type"``)
-    or just enough of its trailing access path to be unambiguous (e.g.
-    ``"objects[0].type"``, or ``"chair_count()"`` for an aggregation latent), so callers
-    don't need to reconstruct the class-name prefixing convention grounding applies.
-
-    :param circuit: The grounded circuit to resolve the path against.
-    :param path: The variable's full name, or an unambiguous suffix of it.
-    :return: The matching Variable.
-    :raises VariableNotFoundError: If no variable's name matches.
-    :raises AmbiguousVariablePathError: If more than one variable's name matches.
+    Holds no state of its own; :meth:`ground` returns a plain ``CausalCircuit``.
     """
-    matches = [
-        variable
-        for variable in circuit.variables
-        if variable.name == path or variable.name.endswith(f".{path}")
-    ]
-    if len(matches) == 1:
-        return matches[0]
-    if not matches:
-        raise VariableNotFoundError(path, list(circuit.variables))
-    raise AmbiguousVariablePathError(path, matches)
 
-
-def _resolve_variables(
-    circuit: ProbabilisticCircuit, variables: List[Union[Variable, str]]
-) -> List[Variable]:
+    DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD: ClassVar[int] = 1000
     """
-    Resolve a mixed list of Variables and dotted access-path strings.
+    Default value of ``adjustment_region_count_warning_threshold``.
 
-    :param circuit: The grounded circuit to resolve any path strings against.
-    :param variables: Variables and/or dotted access-path strings.
-    :return: The resolved Variables, in input order.
+    See :meth:`ground`.
     """
-    return [
-        (
-            variable
-            if isinstance(variable, Variable)
-            else resolve_variable(circuit, variable)
-        )
-        for variable in variables
-    ]
 
-
-def ground_relational_causal_circuit(
-    relational_probabilistic_circuit: RelationalProbabilisticCircuit,
-    query: Match,
-    causal_variables: List[Union[Variable, str]],
-    effect_variables: List[Union[Variable, str]],
-    adjustment_variables: Optional[List[Union[Variable, str]]] = None,
-    grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED,
-    adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
-) -> CausalCircuit:
-    """
-    Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
-
-    :param relational_probabilistic_circuit: The fitted relational circuit to ground.
-    :param query: The grounding query.
-    :param causal_variables: Cause variables to register, as Variables or dotted
-        access-path strings resolved against the grounded circuit (see
-        :func:`resolve_variable`).
-    :param effect_variables: Effect variables to register, same format.
-    :param adjustment_variables: Backdoor-adjustment variables to register, same
-        format. Defaults to none.
-    :param grounding_mode: How to treat aggregation latents the query leaves
-        undetermined. Defaults to :attr:`GroundingMode.CAUSAL_SAMPLED`, which always
-        succeeds; :attr:`GroundingMode.CAUSAL_EXACT` gives reproducible,
-        domain-covering regions but may fall back internally if its precondition isn't
-        met. See :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
-    :param adjustment_region_count_warning_threshold: Under
-        :attr:`GroundingMode.CAUSAL_EXACT`, warn rather than silently proceed when the
-        Cartesian product of ``adjustment_variables``' leaf-region counts exceeds
-        this, since ``CausalCircuit.backdoor_adjustment``'s region-extraction cost
-        scales with it. See :func:`_warn_if_adjustment_regions_are_expensive` for a
-        caveat on what this warning does and does not detect.
-    :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
+    @staticmethod
+    def resolve_variable(circuit: ProbabilisticCircuit, path: str) -> Variable:
+        """
+        Resolve a dotted access-path suffix to the Variable it names in a grounded
         circuit.
-    :raises SupportDeterminismVerificationResult: If the grounded circuit is not
-        support-deterministic for ``causal_variables``.
-    """
-    adjustment_variables = adjustment_variables or []
-    grounded_circuit = relational_probabilistic_circuit.ground(query, grounding_mode)
 
-    causal_variables = _resolve_variables(grounded_circuit, causal_variables)
-    effect_variables = _resolve_variables(grounded_circuit, effect_variables)
-    adjustment_variables = _resolve_variables(grounded_circuit, adjustment_variables)
+        Accepts either a variable's full runtime name (e.g.
+        ``"SceneRoom.objects[0].type"``) or just enough of its trailing access path to
+        be unambiguous (e.g. ``"objects[0].type"``, or ``"chair_count()"`` for an
+        aggregation latent), so callers don't need to reconstruct the class-name
+        prefixing convention grounding applies.
 
-    _warn_if_adjustment_regions_are_expensive(
-        grounded_circuit,
-        adjustment_variables,
-        grounding_mode,
-        adjustment_region_count_warning_threshold,
-    )
+        :param circuit: The grounded circuit to resolve the path against.
+        :param path: The variable's full name, or an unambiguous suffix of it.
+        :return: The matching Variable.
+        :raises VariableNotFoundError: If no variable's name matches.
+        :raises AmbiguousVariablePathError: If more than one variable's name matches.
+        """
+        matches = [
+            variable
+            for variable in circuit.variables
+            if variable.name == path or variable.name.endswith(f".{path}")
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise VariableNotFoundError(path, list(circuit.variables))
+        raise AmbiguousVariablePathError(path, matches)
 
-    tree = MarginalDeterminismTreeNode.from_causal_graph(
-        causal_variables, effect_variables
-    )
-    causal_circuit = CausalCircuit.from_probabilistic_circuit(
-        grounded_circuit, tree, causal_variables, effect_variables
-    )
-    causal_circuit.verify_support_determinism()
-    return causal_circuit
+    @staticmethod
+    def _resolve_variables(
+        circuit: ProbabilisticCircuit, variables: List[Union[Variable, str]]
+    ) -> List[Variable]:
+        """
+        Resolve a mixed list of Variables and dotted access-path strings.
 
+        :param circuit: The grounded circuit to resolve any path strings against.
+        :param variables: Variables and/or dotted access-path strings.
+        :return: The resolved Variables, in input order.
+        """
+        return [
+            (
+                variable
+                if isinstance(variable, Variable)
+                else RelationalCausalCircuit.resolve_variable(circuit, variable)
+            )
+            for variable in variables
+        ]
 
-def _warn_if_adjustment_regions_are_expensive(
-    grounded_circuit: ProbabilisticCircuit,
-    adjustment_variables: List[Variable],
-    grounding_mode: GroundingMode,
-    threshold: int,
-) -> None:
-    """
-    Warn when registering ``adjustment_variables`` together would make
-    ``CausalCircuit.backdoor_adjustment``'s Cartesian product over their leaf regions
-    expensive, rather than waiting to discover this at query time.
+    @staticmethod
+    def ground(
+        relational_probabilistic_circuit: RelationalProbabilisticCircuit,
+        query: Match,
+        causal_variables: List[Union[Variable, str]],
+        effect_variables: List[Union[Variable, str]],
+        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
+        grounding_mode: GroundingMode = GroundingMode.SAMPLED,
+        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
+    ) -> CausalCircuit:
+        """
+        Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
 
-    Only relevant when the caller *requested* :attr:`GroundingMode.CAUSAL_EXACT`: that
-    mode grounds every value the model learned about, so a relational adjustment
-    variable's region count can grow with the training data, unlike
-    :attr:`GroundingMode.CAUSAL_SAMPLED`, whose region count is capped by
-    ``monte_carlo_sample_count``. This is a best-effort diagnostic based on the
-    requested mode, not a guarantee: individual exchangeable parts can still fall back
-    to ``CAUSAL_SAMPLED`` internally (logged separately) when their own partition isn't
-    disjoint, in which case this warning's premise may not hold for them.
+        Convenience wrapper combining ``RelationalProbabilisticCircuit.ground`` with
+        :meth:`from_grounded_circuit`; call them separately to build a ``CausalCircuit``
+        from a circuit that is already grounded.
 
-    :param grounded_circuit: The grounded circuit to extract leaf-region counts from.
-    :param adjustment_variables: The resolved adjustment variables.
-    :param grounding_mode: The grounding mode requested for ``grounded_circuit``.
-    :param threshold: Warn when the Cartesian product exceeds this.
-    """
-    if (
-        grounding_mode is not GroundingMode.CAUSAL_EXACT
-        or len(adjustment_variables) < 2
-    ):
-        return
-    region_counts = [
-        len(grounded_circuit.marginal([variable]).leaves)
-        for variable in adjustment_variables
-    ]
-    region_product = math.prod(region_counts)
-    if region_product > threshold:
-        logger.warning(
-            "Adjustment set [%s] has a Cartesian product of %d leaf regions (%s), "
-            "exceeding the configured threshold of %d; "
-            "CausalCircuit.backdoor_adjustment's region-extraction cost scales with "
-            "this.",
-            ", ".join(variable.name for variable in adjustment_variables),
-            region_product,
-            " x ".join(str(count) for count in region_counts),
-            threshold,
+        :param relational_probabilistic_circuit: The fitted relational circuit to
+            ground.
+        :param query: The grounding query.
+        :param causal_variables: Cause variables to register, as Variables or dotted
+            access-path strings resolved against the grounded circuit (see
+            :meth:`resolve_variable`).
+        :param effect_variables: Effect variables to register, same format.
+        :param adjustment_variables: Backdoor-adjustment variables to register, same
+            format. Defaults to none.
+        :param grounding_mode: How to represent aggregation latents the query leaves
+            undetermined. Defaults to :attr:`GroundingMode.SAMPLED`, which always
+            succeeds; :attr:`GroundingMode.EXACT` gives reproducible, domain-covering
+            regions but may fall back internally if its precondition isn't met. See
+            :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
+        :param adjustment_region_count_warning_threshold: See
+            :meth:`from_grounded_circuit`.
+        :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
+            circuit.
+        :raises SupportDeterminismVerificationResult: If the grounded circuit is not
+            support-deterministic for ``causal_variables``.
+        """
+        grounded_circuit = relational_probabilistic_circuit.ground(
+            query, grounding_mode
         )
+        return RelationalCausalCircuit.from_grounded_circuit(
+            grounded_circuit,
+            causal_variables,
+            effect_variables,
+            adjustment_variables,
+            adjustment_region_count_warning_threshold,
+        )
+
+    @staticmethod
+    def from_grounded_circuit(
+        grounded_circuit: ProbabilisticCircuit,
+        causal_variables: List[Union[Variable, str]],
+        effect_variables: List[Union[Variable, str]],
+        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
+        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
+    ) -> CausalCircuit:
+        """
+        Wrap an already-grounded circuit as a verified ``CausalCircuit``.
+
+        Registering causes and effects is a postprocessing step over grounding, not a
+        distinct way of grounding: any circuit whose undetermined aggregation latents
+        were retained (the only way ``RelationalProbabilisticCircuit.ground`` grounds)
+        can be wrapped this way, whether or not it was built with causal use in mind.
+
+        :param grounded_circuit: The grounded circuit to wrap.
+        :param causal_variables: Cause variables to register, as Variables or dotted
+            access-path strings resolved against ``grounded_circuit`` (see
+            :meth:`resolve_variable`).
+        :param effect_variables: Effect variables to register, same format.
+        :param adjustment_variables: Backdoor-adjustment variables to register, same
+            format. Defaults to none.
+        :param adjustment_region_count_warning_threshold: Warn rather than silently
+            proceed when the Cartesian product of ``adjustment_variables``' leaf-region
+            counts exceeds this, since ``CausalCircuit.backdoor_adjustment``'s
+            region-extraction cost scales with it. See
+            :meth:`_warn_if_adjustment_regions_are_expensive`.
+        :return: A verified, support-deterministic ``CausalCircuit`` over
+            ``grounded_circuit``.
+        :raises SupportDeterminismVerificationResult: If ``grounded_circuit`` is not
+            support-deterministic for ``causal_variables``.
+        """
+        adjustment_variables = adjustment_variables or []
+        causal_variables = RelationalCausalCircuit._resolve_variables(
+            grounded_circuit, causal_variables
+        )
+        effect_variables = RelationalCausalCircuit._resolve_variables(
+            grounded_circuit, effect_variables
+        )
+        adjustment_variables = RelationalCausalCircuit._resolve_variables(
+            grounded_circuit, adjustment_variables
+        )
+
+        RelationalCausalCircuit._warn_if_adjustment_regions_are_expensive(
+            grounded_circuit,
+            adjustment_variables,
+            adjustment_region_count_warning_threshold,
+        )
+
+        tree = MarginalDeterminismTreeNode.from_causal_graph(
+            causal_variables, effect_variables
+        )
+        causal_circuit = CausalCircuit.from_probabilistic_circuit(
+            grounded_circuit, tree, causal_variables, effect_variables
+        )
+        causal_circuit.verify_support_determinism()
+        return causal_circuit
+
+    @staticmethod
+    def _warn_if_adjustment_regions_are_expensive(
+        grounded_circuit: ProbabilisticCircuit,
+        adjustment_variables: List[Variable],
+        threshold: int,
+    ) -> None:
+        """
+        Warn when registering ``adjustment_variables`` together would make
+        ``CausalCircuit.backdoor_adjustment``'s Cartesian product over their leaf
+        regions expensive, rather than waiting to discover this at query time.
+
+        A relational adjustment variable's region count can grow with the training data
+        under :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.EXACT`,
+        unlike :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.SAMPLED`,
+        whose region count is capped by ``monte_carlo_sample_count``. This is a
+        best-effort diagnostic based on
+        ``grounded_circuit``'s actual leaf-region counts, not a guarantee: it flags
+        expensive adjustment sets regardless of how they were grounded.
+
+        :param grounded_circuit: The grounded circuit to extract leaf-region counts
+            from.
+        :param adjustment_variables: The resolved adjustment variables.
+        :param threshold: Warn when the Cartesian product exceeds this.
+        """
+        if len(adjustment_variables) < 2:
+            return
+        region_counts = [
+            len(grounded_circuit.marginal([variable]).leaves)
+            for variable in adjustment_variables
+        ]
+        region_product = math.prod(region_counts)
+        if region_product > threshold:
+            logging.getLogger(__name__).warning(
+                "Adjustment set [%s] has a Cartesian product of %d leaf regions (%s), "
+                "exceeding the configured threshold of %d; "
+                "CausalCircuit.backdoor_adjustment's region-extraction cost scales "
+                "with this.",
+                ", ".join(variable.name for variable in adjustment_variables),
+                region_product,
+                " x ".join(str(count) for count in region_counts),
+                threshold,
+            )

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass
 from typing_extensions import TYPE_CHECKING, List, Optional, Union
 
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
@@ -42,7 +41,7 @@ DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD = 1000
 """
 Default value of ``adjustment_region_count_warning_threshold``.
 
-See :meth:`RelationalCausalCircuit.from_relational_probabilistic_circuit`.
+See :func:`ground_relational_causal_circuit`.
 """
 
 
@@ -93,123 +92,109 @@ def _resolve_variables(
     ]
 
 
-@dataclass
-class RelationalCausalCircuit:
+def ground_relational_causal_circuit(
+    relational_probabilistic_circuit: RelationalProbabilisticCircuit,
+    query: Match,
+    causal_variables: List[Union[Variable, str]],
+    effect_variables: List[Union[Variable, str]],
+    adjustment_variables: Optional[List[Union[Variable, str]]] = None,
+    grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED,
+    adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
+) -> CausalCircuit:
     """
-    Factory bridging ``RelationalProbabilisticCircuit`` grounding into ``CausalCircuit``
-    construction, mirroring how the rest of the ``relational`` package bridges
-    ``probabilistic_model`` and ``krrood``.
+    Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
 
-    Holds no state of its own; :meth:`from_relational_probabilistic_circuit` returns a
-    plain ``CausalCircuit``.
+    :param relational_probabilistic_circuit: The fitted relational circuit to ground.
+    :param query: The grounding query.
+    :param causal_variables: Cause variables to register, as Variables or dotted
+        access-path strings resolved against the grounded circuit (see
+        :func:`resolve_variable`).
+    :param effect_variables: Effect variables to register, same format.
+    :param adjustment_variables: Backdoor-adjustment variables to register, same
+        format. Defaults to none.
+    :param grounding_mode: How to treat aggregation latents the query leaves
+        undetermined. Defaults to :attr:`GroundingMode.CAUSAL_SAMPLED`, which always
+        succeeds; :attr:`GroundingMode.CAUSAL_EXACT` gives reproducible,
+        domain-covering regions but may fall back internally if its precondition isn't
+        met. See :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
+    :param adjustment_region_count_warning_threshold: Under
+        :attr:`GroundingMode.CAUSAL_EXACT`, warn rather than silently proceed when the
+        Cartesian product of ``adjustment_variables``' leaf-region counts exceeds
+        this, since ``CausalCircuit.backdoor_adjustment``'s region-extraction cost
+        scales with it. See :func:`_warn_if_adjustment_regions_are_expensive` for a
+        caveat on what this warning does and does not detect.
+    :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
+        circuit.
+    :raises SupportDeterminismVerificationResult: If the grounded circuit is not
+        support-deterministic for ``causal_variables``.
     """
+    adjustment_variables = adjustment_variables or []
+    grounded_circuit = relational_probabilistic_circuit.ground(query, grounding_mode)
 
-    @staticmethod
-    def from_relational_probabilistic_circuit(
-        relational_probabilistic_circuit: RelationalProbabilisticCircuit,
-        query: Match,
-        causal_variables: List[Union[Variable, str]],
-        effect_variables: List[Union[Variable, str]],
-        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
-        grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED,
-        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
-    ) -> CausalCircuit:
-        """
-        Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
+    causal_variables = _resolve_variables(grounded_circuit, causal_variables)
+    effect_variables = _resolve_variables(grounded_circuit, effect_variables)
+    adjustment_variables = _resolve_variables(grounded_circuit, adjustment_variables)
 
-        :param relational_probabilistic_circuit: The fitted relational circuit to
-            ground.
-        :param query: The grounding query.
-        :param causal_variables: Cause variables to register, as Variables or dotted
-            access-path strings resolved against the grounded circuit (see
-            :func:`resolve_variable`).
-        :param effect_variables: Effect variables to register, same format.
-        :param adjustment_variables: Backdoor-adjustment variables to register, same
-            format. Defaults to none.
-        :param grounding_mode: How to treat aggregation latents the query leaves
-            undetermined. Defaults to :attr:`GroundingMode.CAUSAL_SAMPLED`, which
-            always succeeds; :attr:`GroundingMode.CAUSAL_EXACT` gives reproducible,
-            domain-covering regions but may fall back internally if its precondition
-            isn't met. See :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
-        :param adjustment_region_count_warning_threshold: Under
-            :attr:`GroundingMode.CAUSAL_EXACT`, warn rather than silently proceed when
-            the Cartesian product of ``adjustment_variables``' leaf-region counts
-            exceeds this, since ``CausalCircuit.backdoor_adjustment``'s
-            region-extraction cost scales with it.
-        :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
-            circuit.
-        :raises SupportDeterminismVerificationResult: If the grounded circuit is not
-            support-deterministic for ``causal_variables``.
-        """
-        adjustment_variables = adjustment_variables or []
-        grounded_circuit = relational_probabilistic_circuit.ground(
-            query, grounding_mode
+    _warn_if_adjustment_regions_are_expensive(
+        grounded_circuit,
+        adjustment_variables,
+        grounding_mode,
+        adjustment_region_count_warning_threshold,
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        causal_variables, effect_variables
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        grounded_circuit, tree, causal_variables, effect_variables
+    )
+    causal_circuit.verify_support_determinism()
+    return causal_circuit
+
+
+def _warn_if_adjustment_regions_are_expensive(
+    grounded_circuit: ProbabilisticCircuit,
+    adjustment_variables: List[Variable],
+    grounding_mode: GroundingMode,
+    threshold: int,
+) -> None:
+    """
+    Warn when registering ``adjustment_variables`` together would make
+    ``CausalCircuit.backdoor_adjustment``'s Cartesian product over their leaf regions
+    expensive, rather than waiting to discover this at query time.
+
+    Only relevant when the caller *requested* :attr:`GroundingMode.CAUSAL_EXACT`: that
+    mode grounds every value the model learned about, so a relational adjustment
+    variable's region count can grow with the training data, unlike
+    :attr:`GroundingMode.CAUSAL_SAMPLED`, whose region count is capped by
+    ``monte_carlo_sample_count``. This is a best-effort diagnostic based on the
+    requested mode, not a guarantee: individual exchangeable parts can still fall back
+    to ``CAUSAL_SAMPLED`` internally (logged separately) when their own partition isn't
+    disjoint, in which case this warning's premise may not hold for them.
+
+    :param grounded_circuit: The grounded circuit to extract leaf-region counts from.
+    :param adjustment_variables: The resolved adjustment variables.
+    :param grounding_mode: The grounding mode requested for ``grounded_circuit``.
+    :param threshold: Warn when the Cartesian product exceeds this.
+    """
+    if (
+        grounding_mode is not GroundingMode.CAUSAL_EXACT
+        or len(adjustment_variables) < 2
+    ):
+        return
+    region_counts = [
+        len(grounded_circuit.marginal([variable]).leaves)
+        for variable in adjustment_variables
+    ]
+    region_product = math.prod(region_counts)
+    if region_product > threshold:
+        logger.warning(
+            "Adjustment set [%s] has a Cartesian product of %d leaf regions (%s), "
+            "exceeding the configured threshold of %d; "
+            "CausalCircuit.backdoor_adjustment's region-extraction cost scales with "
+            "this.",
+            ", ".join(variable.name for variable in adjustment_variables),
+            region_product,
+            " x ".join(str(count) for count in region_counts),
+            threshold,
         )
-
-        causal_variables = _resolve_variables(grounded_circuit, causal_variables)
-        effect_variables = _resolve_variables(grounded_circuit, effect_variables)
-        adjustment_variables = _resolve_variables(
-            grounded_circuit, adjustment_variables
-        )
-
-        RelationalCausalCircuit._warn_if_adjustment_regions_are_expensive(
-            grounded_circuit,
-            adjustment_variables,
-            grounding_mode,
-            adjustment_region_count_warning_threshold,
-        )
-
-        tree = MarginalDeterminismTreeNode.from_causal_graph(
-            causal_variables, effect_variables
-        )
-        causal_circuit = CausalCircuit.from_probabilistic_circuit(
-            grounded_circuit, tree, causal_variables, effect_variables
-        )
-        causal_circuit.verify_support_determinism()
-        return causal_circuit
-
-    @staticmethod
-    def _warn_if_adjustment_regions_are_expensive(
-        grounded_circuit: ProbabilisticCircuit,
-        adjustment_variables: List[Variable],
-        grounding_mode: GroundingMode,
-        threshold: int,
-    ) -> None:
-        """
-        Warn when registering ``adjustment_variables`` together would make
-        ``CausalCircuit.backdoor_adjustment``'s Cartesian product over their leaf
-        regions expensive, rather than waiting to discover this at query time.
-
-        Only relevant under :attr:`GroundingMode.CAUSAL_EXACT`: that mode grounds every
-        value the model learned about, so a relational adjustment variable's region
-        count can grow with the training data, unlike
-        :attr:`GroundingMode.CAUSAL_SAMPLED`, whose region count is capped by
-        ``monte_carlo_sample_count``.
-
-        :param grounded_circuit: The grounded circuit to extract leaf-region counts
-            from.
-        :param adjustment_variables: The resolved adjustment variables.
-        :param grounding_mode: The grounding mode used to build ``grounded_circuit``.
-        :param threshold: Warn when the Cartesian product exceeds this.
-        """
-        if (
-            grounding_mode is not GroundingMode.CAUSAL_EXACT
-            or len(adjustment_variables) < 2
-        ):
-            return
-        region_counts = [
-            len(grounded_circuit.marginal([variable]).leaves)
-            for variable in adjustment_variables
-        ]
-        region_product = math.prod(region_counts)
-        if region_product > threshold:
-            logger.warning(
-                "Adjustment set [%s] has a Cartesian product of %d leaf regions "
-                "(%s), exceeding the configured threshold of %d; "
-                "CausalCircuit.backdoor_adjustment's region-extraction cost scales "
-                "with this.",
-                ", ".join(variable.name for variable in adjustment_variables),
-                region_product,
-                " x ".join(str(count) for count in region_counts),
-                threshold,
-            )

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
@@ -1,0 +1,215 @@
+"""
+Bridges ``RelationalProbabilisticCircuit`` grounding into ``CausalCircuit``
+construction.
+
+.. note::
+    This module mirrors how ``rspn.py`` deliberately bridges ``probabilistic_model``
+    and ``krrood``: it is the seam where relational grounding meets exact causal
+    inference, kept separate from both ``rspn.py`` and ``causal_circuit.py`` so
+    neither needs to depend on the other.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing_extensions import TYPE_CHECKING, List, Optional, Union
+
+from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
+    CausalCircuit,
+    MarginalDeterminismTreeNode,
+)
+from probabilistic_model.probabilistic_circuit.relational.exceptions import (
+    AmbiguousVariablePathError,
+    VariableNotFoundError,
+)
+from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    GroundingMode,
+    RelationalProbabilisticCircuit,
+)
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit,
+)
+from random_events.variable import Variable
+
+if TYPE_CHECKING:
+    from krrood.entity_query_language.query.match import Match
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD = 1000
+"""
+Default value of ``adjustment_region_count_warning_threshold``.
+
+See :meth:`RelationalCausalCircuit.from_relational_probabilistic_circuit`.
+"""
+
+
+def resolve_variable(circuit: ProbabilisticCircuit, path: str) -> Variable:
+    """
+    Resolve a dotted access-path suffix to the Variable it names in a grounded circuit.
+
+    Accepts either a variable's full runtime name (e.g. ``"SceneRoom.objects[0].type"``)
+    or just enough of its trailing access path to be unambiguous (e.g.
+    ``"objects[0].type"``, or ``"chair_count()"`` for an aggregation latent), so callers
+    don't need to reconstruct the class-name prefixing convention grounding applies.
+
+    :param circuit: The grounded circuit to resolve the path against.
+    :param path: The variable's full name, or an unambiguous suffix of it.
+    :return: The matching Variable.
+    :raises VariableNotFoundError: If no variable's name matches.
+    :raises AmbiguousVariablePathError: If more than one variable's name matches.
+    """
+    matches = [
+        variable
+        for variable in circuit.variables
+        if variable.name == path or variable.name.endswith(f".{path}")
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise VariableNotFoundError(path, list(circuit.variables))
+    raise AmbiguousVariablePathError(path, matches)
+
+
+def _resolve_variables(
+    circuit: ProbabilisticCircuit, variables: List[Union[Variable, str]]
+) -> List[Variable]:
+    """
+    Resolve a mixed list of Variables and dotted access-path strings.
+
+    :param circuit: The grounded circuit to resolve any path strings against.
+    :param variables: Variables and/or dotted access-path strings.
+    :return: The resolved Variables, in input order.
+    """
+    return [
+        (
+            variable
+            if isinstance(variable, Variable)
+            else resolve_variable(circuit, variable)
+        )
+        for variable in variables
+    ]
+
+
+@dataclass
+class RelationalCausalCircuit:
+    """
+    Factory bridging ``RelationalProbabilisticCircuit`` grounding into ``CausalCircuit``
+    construction, mirroring how the rest of the ``relational`` package bridges
+    ``probabilistic_model`` and ``krrood``.
+
+    Holds no state of its own; :meth:`from_relational_probabilistic_circuit` returns a
+    plain ``CausalCircuit``.
+    """
+
+    @staticmethod
+    def from_relational_probabilistic_circuit(
+        relational_probabilistic_circuit: RelationalProbabilisticCircuit,
+        query: Match,
+        causal_variables: List[Union[Variable, str]],
+        effect_variables: List[Union[Variable, str]],
+        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
+        grounding_mode: GroundingMode = GroundingMode.CAUSAL_SAMPLED,
+        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
+    ) -> CausalCircuit:
+        """
+        Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
+
+        :param relational_probabilistic_circuit: The fitted relational circuit to
+            ground.
+        :param query: The grounding query.
+        :param causal_variables: Cause variables to register, as Variables or dotted
+            access-path strings resolved against the grounded circuit (see
+            :func:`resolve_variable`).
+        :param effect_variables: Effect variables to register, same format.
+        :param adjustment_variables: Backdoor-adjustment variables to register, same
+            format. Defaults to none.
+        :param grounding_mode: How to treat aggregation latents the query leaves
+            undetermined. Defaults to :attr:`GroundingMode.CAUSAL_SAMPLED`, which
+            always succeeds; :attr:`GroundingMode.CAUSAL_EXACT` gives reproducible,
+            domain-covering regions but may fall back internally if its precondition
+            isn't met. See :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
+        :param adjustment_region_count_warning_threshold: Under
+            :attr:`GroundingMode.CAUSAL_EXACT`, warn rather than silently proceed when
+            the Cartesian product of ``adjustment_variables``' leaf-region counts
+            exceeds this, since ``CausalCircuit.backdoor_adjustment``'s
+            region-extraction cost scales with it.
+        :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
+            circuit.
+        :raises SupportDeterminismVerificationResult: If the grounded circuit is not
+            support-deterministic for ``causal_variables``.
+        """
+        adjustment_variables = adjustment_variables or []
+        grounded_circuit = relational_probabilistic_circuit.ground(
+            query, grounding_mode
+        )
+
+        causal_variables = _resolve_variables(grounded_circuit, causal_variables)
+        effect_variables = _resolve_variables(grounded_circuit, effect_variables)
+        adjustment_variables = _resolve_variables(
+            grounded_circuit, adjustment_variables
+        )
+
+        RelationalCausalCircuit._warn_if_adjustment_regions_are_expensive(
+            grounded_circuit,
+            adjustment_variables,
+            grounding_mode,
+            adjustment_region_count_warning_threshold,
+        )
+
+        tree = MarginalDeterminismTreeNode.from_causal_graph(
+            causal_variables, effect_variables
+        )
+        causal_circuit = CausalCircuit.from_probabilistic_circuit(
+            grounded_circuit, tree, causal_variables, effect_variables
+        )
+        causal_circuit.verify_support_determinism()
+        return causal_circuit
+
+    @staticmethod
+    def _warn_if_adjustment_regions_are_expensive(
+        grounded_circuit: ProbabilisticCircuit,
+        adjustment_variables: List[Variable],
+        grounding_mode: GroundingMode,
+        threshold: int,
+    ) -> None:
+        """
+        Warn when registering ``adjustment_variables`` together would make
+        ``CausalCircuit.backdoor_adjustment``'s Cartesian product over their leaf
+        regions expensive, rather than waiting to discover this at query time.
+
+        Only relevant under :attr:`GroundingMode.CAUSAL_EXACT`: that mode grounds every
+        value the model learned about, so a relational adjustment variable's region
+        count can grow with the training data, unlike
+        :attr:`GroundingMode.CAUSAL_SAMPLED`, whose region count is capped by
+        ``monte_carlo_sample_count``.
+
+        :param grounded_circuit: The grounded circuit to extract leaf-region counts
+            from.
+        :param adjustment_variables: The resolved adjustment variables.
+        :param grounding_mode: The grounding mode used to build ``grounded_circuit``.
+        :param threshold: Warn when the Cartesian product exceeds this.
+        """
+        if (
+            grounding_mode is not GroundingMode.CAUSAL_EXACT
+            or len(adjustment_variables) < 2
+        ):
+            return
+        region_counts = [
+            len(grounded_circuit.marginal([variable]).leaves)
+            for variable in adjustment_variables
+        ]
+        region_product = math.prod(region_counts)
+        if region_product > threshold:
+            logger.warning(
+                "Adjustment set [%s] has a Cartesian product of %d leaf regions "
+                "(%s), exceeding the configured threshold of %d; "
+                "CausalCircuit.backdoor_adjustment's region-extraction cost scales "
+                "with this.",
+                ", ".join(variable.name for variable in adjustment_variables),
+                region_product,
+                " x ".join(str(count) for count in region_counts),
+                threshold,
+            )

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/causal.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing_extensions import TYPE_CHECKING, ClassVar, List, Optional, Union
+from typing_extensions import TYPE_CHECKING, List, Optional, TypeAlias, Union
 
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
@@ -36,6 +36,15 @@ from random_events.variable import Variable
 if TYPE_CHECKING:
     from krrood.entity_query_language.query.match import Match
 
+logger = logging.getLogger(__name__)
+
+VariableReference: TypeAlias = Union[Variable, str]
+"""
+A cause, effect, or adjustment variable, given either as an already-resolved
+``Variable`` or as a dotted access-path string resolved against a grounded circuit via
+:meth:`RelationalCausalCircuit.resolve_variable`.
+"""
+
 
 @dataclass
 class RelationalCausalCircuit:
@@ -43,15 +52,12 @@ class RelationalCausalCircuit:
     Factory bridging ``RelationalProbabilisticCircuit`` grounding into ``CausalCircuit``
     construction, mirroring how the rest of the ``relational`` package bridges
     ``probabilistic_model`` and ``krrood``.
-
-    Holds no state of its own; :meth:`ground` returns a plain ``CausalCircuit``.
     """
 
-    DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD: ClassVar[int] = 1000
+    adjustment_region_count_warning_threshold: int = 1000
     """
-    Default value of ``adjustment_region_count_warning_threshold``.
-
-    See :meth:`ground`.
+    Warn rather than silently proceed when the Cartesian product of an adjustment
+    set's leaf-region counts exceeds this. See :meth:`from_grounded_circuit`.
     """
 
     @staticmethod
@@ -85,7 +91,7 @@ class RelationalCausalCircuit:
 
     @staticmethod
     def _resolve_variables(
-        circuit: ProbabilisticCircuit, variables: List[Union[Variable, str]]
+        circuit: ProbabilisticCircuit, variables: List[VariableReference]
     ) -> List[Variable]:
         """
         Resolve a mixed list of Variables and dotted access-path strings.
@@ -103,15 +109,14 @@ class RelationalCausalCircuit:
             for variable in variables
         ]
 
-    @staticmethod
     def ground(
+        self,
         relational_probabilistic_circuit: RelationalProbabilisticCircuit,
         query: Match,
-        causal_variables: List[Union[Variable, str]],
-        effect_variables: List[Union[Variable, str]],
-        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
+        causal_variables: List[VariableReference],
+        effect_variables: List[VariableReference],
+        adjustment_variables: Optional[List[VariableReference]] = None,
         grounding_mode: GroundingMode = GroundingMode.SAMPLED,
-        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
     ) -> CausalCircuit:
         """
         Ground a relational circuit for a query and wrap it as a ``CausalCircuit``.
@@ -134,8 +139,6 @@ class RelationalCausalCircuit:
             succeeds; :attr:`GroundingMode.EXACT` gives reproducible, domain-covering
             regions but may fall back internally if its precondition isn't met. See
             :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode`.
-        :param adjustment_region_count_warning_threshold: See
-            :meth:`from_grounded_circuit`.
         :return: A verified, support-deterministic ``CausalCircuit`` over the grounded
             circuit.
         :raises SupportDeterminismVerificationResult: If the grounded circuit is not
@@ -144,21 +147,16 @@ class RelationalCausalCircuit:
         grounded_circuit = relational_probabilistic_circuit.ground(
             query, grounding_mode
         )
-        return RelationalCausalCircuit.from_grounded_circuit(
-            grounded_circuit,
-            causal_variables,
-            effect_variables,
-            adjustment_variables,
-            adjustment_region_count_warning_threshold,
+        return self.from_grounded_circuit(
+            grounded_circuit, causal_variables, effect_variables, adjustment_variables
         )
 
-    @staticmethod
     def from_grounded_circuit(
+        self,
         grounded_circuit: ProbabilisticCircuit,
-        causal_variables: List[Union[Variable, str]],
-        effect_variables: List[Union[Variable, str]],
-        adjustment_variables: Optional[List[Union[Variable, str]]] = None,
-        adjustment_region_count_warning_threshold: int = DEFAULT_ADJUSTMENT_REGION_COUNT_WARNING_THRESHOLD,
+        causal_variables: List[VariableReference],
+        effect_variables: List[VariableReference],
+        adjustment_variables: Optional[List[VariableReference]] = None,
     ) -> CausalCircuit:
         """
         Wrap an already-grounded circuit as a verified ``CausalCircuit``.
@@ -175,31 +173,20 @@ class RelationalCausalCircuit:
         :param effect_variables: Effect variables to register, same format.
         :param adjustment_variables: Backdoor-adjustment variables to register, same
             format. Defaults to none.
-        :param adjustment_region_count_warning_threshold: Warn rather than silently
-            proceed when the Cartesian product of ``adjustment_variables``' leaf-region
-            counts exceeds this, since ``CausalCircuit.backdoor_adjustment``'s
-            region-extraction cost scales with it. See
-            :meth:`_warn_if_adjustment_regions_are_expensive`.
         :return: A verified, support-deterministic ``CausalCircuit`` over
             ``grounded_circuit``.
         :raises SupportDeterminismVerificationResult: If ``grounded_circuit`` is not
             support-deterministic for ``causal_variables``.
         """
         adjustment_variables = adjustment_variables or []
-        causal_variables = RelationalCausalCircuit._resolve_variables(
-            grounded_circuit, causal_variables
-        )
-        effect_variables = RelationalCausalCircuit._resolve_variables(
-            grounded_circuit, effect_variables
-        )
-        adjustment_variables = RelationalCausalCircuit._resolve_variables(
+        causal_variables = self._resolve_variables(grounded_circuit, causal_variables)
+        effect_variables = self._resolve_variables(grounded_circuit, effect_variables)
+        adjustment_variables = self._resolve_variables(
             grounded_circuit, adjustment_variables
         )
 
-        RelationalCausalCircuit._warn_if_adjustment_regions_are_expensive(
-            grounded_circuit,
-            adjustment_variables,
-            adjustment_region_count_warning_threshold,
+        self._warn_if_adjustment_regions_are_expensive(
+            grounded_circuit, adjustment_variables
         )
 
         tree = MarginalDeterminismTreeNode.from_causal_graph(
@@ -211,11 +198,10 @@ class RelationalCausalCircuit:
         causal_circuit.verify_support_determinism()
         return causal_circuit
 
-    @staticmethod
     def _warn_if_adjustment_regions_are_expensive(
+        self,
         grounded_circuit: ProbabilisticCircuit,
         adjustment_variables: List[Variable],
-        threshold: int,
     ) -> None:
         """
         Warn when registering ``adjustment_variables`` together would make
@@ -233,7 +219,6 @@ class RelationalCausalCircuit:
         :param grounded_circuit: The grounded circuit to extract leaf-region counts
             from.
         :param adjustment_variables: The resolved adjustment variables.
-        :param threshold: Warn when the Cartesian product exceeds this.
         """
         if len(adjustment_variables) < 2:
             return
@@ -242,8 +227,8 @@ class RelationalCausalCircuit:
             for variable in adjustment_variables
         ]
         region_product = math.prod(region_counts)
-        if region_product > threshold:
-            logging.getLogger(__name__).warning(
+        if region_product > self.adjustment_region_count_warning_threshold:
+            logger.warning(
                 "Adjustment set [%s] has a Cartesian product of %d leaf regions (%s), "
                 "exceeding the configured threshold of %d; "
                 "CausalCircuit.backdoor_adjustment's region-extraction cost scales "
@@ -251,5 +236,5 @@ class RelationalCausalCircuit:
                 ", ".join(variable.name for variable in adjustment_variables),
                 region_product,
                 " x ".join(str(count) for count in region_counts),
-                threshold,
+                self.adjustment_region_count_warning_threshold,
             )

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
@@ -109,3 +109,57 @@ class UndeterminedLatentsPartitionOverlapsError(DataclassException):
             "Refit the template so these latents are split on, or use "
             "GroundingMode.CAUSAL_SAMPLED instead."
         )
+
+
+@dataclass
+class VariableNotFoundError(DataclassException):
+    """
+    Raised when a dotted access path does not match any variable in a grounded circuit.
+    """
+
+    path: str
+    """
+    The access path that failed to resolve.
+    """
+
+    available_variables: List[Variable]
+    """
+    The variables the grounded circuit actually has, for diagnosis.
+    """
+
+    def error_message(self) -> str:
+        names = ", ".join(variable.name for variable in self.available_variables)
+        return (
+            f"No variable's name matches '{self.path}'. Available variables: [{names}]."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Check the access path against the grounded circuit's actual variable "
+            "names, e.g. 'objects[0].type' or 'chair_count()'."
+        )
+
+
+@dataclass
+class AmbiguousVariablePathError(DataclassException):
+    """
+    Raised when a dotted access path matches more than one variable in a grounded
+    circuit.
+    """
+
+    path: str
+    """
+    The access path that matched more than one variable.
+    """
+
+    matches: List[Variable]
+    """
+    The variables that matched.
+    """
+
+    def error_message(self) -> str:
+        names = ", ".join(variable.name for variable in self.matches)
+        return f"'{self.path}' matches more than one variable: [{names}]."
+
+    def suggest_correction(self) -> str:
+        return "Use a longer, more specific suffix of the variable's full name."

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
@@ -80,28 +80,32 @@ class UndeterminedLatentsNotModeledError(DataclassException):
 
 
 @dataclass
-class UndeterminedLatentsPartitionOverlapsError(DataclassException):
+class UndeterminedLatentsNotPartitionedError(DataclassException):
     """
-    Raised when the undetermined latents' exact partition -- their marginal support,
-    grouped by the fitted circuit's own mixture branches -- has overlapping branches.
+    Raised when the undetermined latents' marginal support -- grouped by the fitted
+    circuit's own mixture branches -- is not a genuine, pairwise-disjoint partition:
+    either the fitted circuit never actually split on these latents at all (a single,
+    undifferentiated branch), or the branches it did split into overlap.
 
-    Exact-partition grounding requires those branches to be mutually exclusive so the
-    resulting mixture stays support-deterministic. This is caught internally by
-    ``RelationalProbabilisticCircuit`` and triggers a fall back to
-    ``GroundingMode.CAUSAL_SAMPLED``; it is not expected to reach a caller of
-    ``ground``.
+    Exact-partition grounding requires at least two mutually exclusive branches so each
+    grounded exchangeable instance stays tied to the latent value its own branch
+    represents. This is caught internally by ``RelationalProbabilisticCircuit`` and
+    triggers a fall back to ``GroundingMode.CAUSAL_SAMPLED``; it is not expected to
+    reach a caller of ``ground``.
     """
 
     undetermined_latents: List[Variable]
     """
-    The undetermined latent variables whose exact partition overlaps.
+    The undetermined latent variables whose marginal support is not a genuine, disjoint
+    partition.
     """
 
     def error_message(self) -> str:
         names = ", ".join(latent.name for latent in self.undetermined_latents)
         return (
-            f"The exact partition of undetermined latents [{names}] has overlapping "
-            f"branches, so exact-partition grounding would not be support-deterministic."
+            f"The marginal support of undetermined latents [{names}] is not a "
+            f"genuine, pairwise-disjoint partition, so exact-partition grounding "
+            f"would not be support-deterministic."
         )
 
     def suggest_correction(self) -> str:

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
@@ -90,8 +90,8 @@ class UndeterminedLatentsNotPartitionedError(DataclassException):
     Exact-partition grounding requires at least two mutually exclusive branches so each
     grounded exchangeable instance stays tied to the latent value its own branch
     represents. This is caught internally by ``RelationalProbabilisticCircuit`` and
-    triggers a fall back to ``GroundingMode.CAUSAL_SAMPLED``; it is not expected to
-    reach a caller of ``ground``.
+    triggers a fall back to ``GroundingMode.SAMPLED``; it is not expected to reach a
+    caller of ``ground``.
     """
 
     undetermined_latents: List[Variable]
@@ -111,7 +111,7 @@ class UndeterminedLatentsNotPartitionedError(DataclassException):
     def suggest_correction(self) -> str:
         return (
             "Refit the template so these latents are split on, or use "
-            "GroundingMode.CAUSAL_SAMPLED instead."
+            "GroundingMode.SAMPLED instead."
         )
 
 

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
@@ -77,3 +77,35 @@ class UndeterminedLatentsNotModeledError(DataclassException):
             "Ensure the class circuit is fitted with these aggregation statistics "
             "as latent variables before grounding."
         )
+
+
+@dataclass
+class UndeterminedLatentsPartitionOverlapsError(DataclassException):
+    """
+    Raised when the undetermined latents' exact partition -- their marginal support,
+    grouped by the fitted circuit's own mixture branches -- has overlapping branches.
+
+    Exact-partition grounding requires those branches to be mutually exclusive so the
+    resulting mixture stays support-deterministic. This is caught internally by
+    ``RelationalProbabilisticCircuit`` and triggers a fall back to
+    ``GroundingMode.CAUSAL_SAMPLED``; it is not expected to reach a caller of
+    ``ground``.
+    """
+
+    undetermined_latents: List[Variable]
+    """
+    The undetermined latent variables whose exact partition overlaps.
+    """
+
+    def error_message(self) -> str:
+        names = ", ".join(latent.name for latent in self.undetermined_latents)
+        return (
+            f"The exact partition of undetermined latents [{names}] has overlapping "
+            f"branches, so exact-partition grounding would not be support-deterministic."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Refit the template so these latents are split on, or use "
+            "GroundingMode.CAUSAL_SAMPLED instead."
+        )

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/exceptions.py
@@ -32,6 +32,51 @@ class CircuitNotFittedError(DataclassException):
 
 
 @dataclass
+class ClassCircuitGroundingFailedError(DataclassException):
+    """
+    Raised when conditioning the class circuit on aggregation statistics leaves it with
+    no nodes at all.
+    """
+
+    class_: Type
+    """The domain class whose class circuit failed to ground."""
+
+    def error_message(self) -> str:
+        return (
+            f"Grounding the class circuit for {self.class_.__name__} produced an "
+            f"empty circuit."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Check that the conditioning aggregation statistics are consistent with "
+            "the fitted circuit's support."
+        )
+
+
+@dataclass
+class PartCircuitGroundingFailedError(DataclassException):
+    """
+    Raised when grounding one exchangeable part leaves its circuit with no nodes at all.
+    """
+
+    class_: Type
+    """The domain class of the exchangeable part that failed to ground."""
+
+    def error_message(self) -> str:
+        return (
+            f"Grounding the exchangeable part circuit for {self.class_.__name__} "
+            f"produced an empty circuit."
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Check that the conditioning aggregation statistics are consistent with "
+            "the fitted template's support."
+        )
+
+
+@dataclass
 class InvalidMonteCarloSampleCountError(DataclassException):
     """
     Raised when grounding must integrate out undetermined aggregation statistics but the

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import itertools
+import logging
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -39,6 +40,7 @@ from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     CircuitNotFittedError,
     InvalidMonteCarloSampleCountError,
     UndeterminedLatentsNotModeledError,
+    UndeterminedLatentsPartitionOverlapsError,
 )
 from probabilistic_model.probabilistic_circuit.relational.helper import (
     find_lowest_product_nodes_that_model_variables,
@@ -55,6 +57,8 @@ from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
 )
 from random_events.interval import Interval
 from random_events.variable import Variable
+
+logger = logging.getLogger(__name__)
 
 
 class GroundingMode(enum.Enum):
@@ -74,9 +78,20 @@ class GroundingMode(enum.Enum):
     CAUSAL_SAMPLED = enum.auto()
     """
     Retain each undetermined latent as a point-valued variable at its Monte-Carlo
-    sampled value instead of discarding it, so it can be registered as a cause or
-    effect in a :class:`CausalCircuit
+    sampled value instead of discarding it, so it can be registered as a cause or effect
+    in a :class:`CausalCircuit
     <probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit>`.
+    """
+
+    CAUSAL_EXACT = enum.auto()
+    """
+    Retain undetermined latents by enumerating the fitted circuit's own exact, disjoint
+    partition over them instead of sampling.
+
+    Reproducible across calls and covers the whole domain the model learned about,
+    unlike :attr:`CAUSAL_SAMPLED`. Falls back to :attr:`CAUSAL_SAMPLED`, with a logged
+    warning, when the fitted circuit's partition over the undetermined latents is not
+    itself disjoint.
     """
 
 
@@ -452,9 +467,11 @@ class RelationalProbabilisticCircuit:
         Ground one exchangeable part and attach it to the class circuit.
 
         Aggregation statistics determinable from the query condition the class circuit
-        directly. Monte-Carlo integrates out undetermined statistics: they are sampled
-        from the conditioned class circuit and each sampled value yields its own
-        exchangeable distribution instance.
+        directly. Undetermined statistics are integrated out: by Monte-Carlo sampling
+        (:attr:`GroundingMode.PREDICTIVE`, :attr:`GroundingMode.CAUSAL_SAMPLED`) or by
+        enumerating the fitted circuit's own exact partition over them
+        (:attr:`GroundingMode.CAUSAL_EXACT`, falling back to
+        :attr:`GroundingMode.CAUSAL_SAMPLED` if that partition is not disjoint).
 
         :param circuit: The current working copy of the class circuit.
         :param exchangeable_part_name: Field name of the exchangeable relation.
@@ -485,10 +502,7 @@ class RelationalProbabilisticCircuit:
         )
         query_parts = query.kwargs[exchangeable_part_name]
 
-        sampled_assignments = self._sample_undetermined_latents(
-            circuit, undetermined_latents
-        )
-        if not sampled_assignments:
+        if not undetermined_latents:
             self._attach_single_exchangeable_instance(
                 circuit,
                 product_nodes_to_extend,
@@ -498,6 +512,28 @@ class RelationalProbabilisticCircuit:
             )
             return circuit
 
+        if grounding_mode is GroundingMode.CAUSAL_EXACT:
+            try:
+                self._attach_exact_partition_mixture(
+                    circuit,
+                    product_nodes_to_extend,
+                    template,
+                    query_parts,
+                    determined_statistics,
+                    undetermined_latents,
+                )
+                return circuit
+            except UndeterminedLatentsPartitionOverlapsError:
+                logger.warning(
+                    "Exact-partition grounding for latents [%s] is not support-"
+                    "deterministic; falling back to GroundingMode.CAUSAL_SAMPLED.",
+                    ", ".join(variable.name for variable in undetermined_latents),
+                )
+                grounding_mode = GroundingMode.CAUSAL_SAMPLED
+
+        sampled_assignments = self._sample_undetermined_latents(
+            circuit, undetermined_latents
+        )
         self._attach_monte_carlo_mixture(
             circuit,
             product_nodes_to_extend,
@@ -734,6 +770,128 @@ class RelationalProbabilisticCircuit:
                 leaf(make_dirac(variable, assignment[variable]), circuit)
             )
         return wrapper
+
+    def _attach_exact_partition_mixture(
+        self,
+        circuit: ProbabilisticCircuit,
+        product_nodes_to_extend: list[ProductUnit],
+        template: ExchangeableDistributionTemplate,
+        query_parts: list,
+        determined_statistics: dict[Variable, Any],
+        undetermined_latents: SortedSet[Variable],
+    ) -> None:
+        """
+        Attach a mixture over the undetermined latents' own exact partition.
+
+        Unlike Monte-Carlo sampling, this enumerates ``circuit``'s already-fitted,
+        exact partition over ``undetermined_latents`` (the branches of
+        ``circuit.marginal(undetermined_latents)``'s root) instead of drawing samples
+        from it: reproducible across calls, and covers every value the model learned
+        about rather than only whichever points got sampled. One exchangeable instance
+        is grounded per branch and retains that branch's full region -- not narrowed to
+        a point -- by mounting the branch itself alongside the grounded instance.
+
+        :param circuit: The working class circuit.
+        :param product_nodes_to_extend: The mounting product nodes.
+        :param template: The fitted template for this relation.
+        :param query_parts: The query parts, one per child object.
+        :param determined_statistics: Statistics determinable from the query.
+        :param undetermined_latents: The latents to retain via exact partition.
+        :raises UndeterminedLatentsNotModeledError: If ``circuit`` does not model
+            ``undetermined_latents`` and thus has no partition over them.
+        :raises UndeterminedLatentsPartitionOverlapsError: If that partition's branches
+            are not pairwise disjoint, so exact-partition grounding would not be
+            support-deterministic.
+        """
+        proposal = circuit.marginal(undetermined_latents)
+        if proposal is None:
+            raise UndeterminedLatentsNotModeledError(list(undetermined_latents))
+        if not self._undetermined_latents_partition_disjointly(proposal):
+            raise UndeterminedLatentsPartitionOverlapsError(list(undetermined_latents))
+
+        retained_variables = SortedSet(circuit.variables) - undetermined_latents
+        circuit.marginal_in_place(retained_variables)
+
+        branches = (
+            proposal.root.log_weighted_subcircuits
+            if isinstance(proposal.root, SumUnit)
+            else [(0.0, proposal.root)]
+        )
+        mounted_roots = []
+        log_weights = []
+        for log_weight, latent_branch in branches:
+            representative_value = self._representative_value(
+                latent_branch, undetermined_latents
+            )
+            instance_root = self._mount_instance(
+                circuit,
+                template,
+                query_parts,
+                {**determined_statistics, **representative_value},
+            )
+            branch_root = ProductUnit(probabilistic_circuit=circuit)
+            branch_root.add_subcircuit(instance_root)
+            mounted_branch_nodes = circuit.mount(latent_branch)
+            branch_root.add_subcircuit(mounted_branch_nodes[latent_branch.index])
+            mounted_roots.append(branch_root)
+            log_weights.append(log_weight)
+
+        for product_node in product_nodes_to_extend:
+            self._attach_mixture_to_node(
+                circuit, product_node, mounted_roots, log_weights
+            )
+
+    @staticmethod
+    def _undetermined_latents_partition_disjointly(
+        proposal: ProbabilisticCircuit,
+    ) -> bool:
+        """
+        Check whether ``proposal``'s branches, if more than one, have disjoint support.
+
+        ``JointProbabilityTree`` does not retain which variables it actually split on
+        after fitting, so this checks the invariant exact-partition grounding actually
+        needs directly on the marginalized circuit, rather than trying to infer it from
+        fitting-time bookkeeping the tree does not expose: whether the branches of
+        ``proposal``'s own mixture over ``undetermined_latents`` overlap.
+
+        :param proposal: ``circuit`` marginalized down to exactly the undetermined
+            latents.
+        :return:``True`` if ``proposal``'s root is not a mixture (a single branch is
+            trivially disjoint), or if every pair of its branches has non-overlapping
+            support.
+        """
+        root = proposal.root
+        if not isinstance(root, SumUnit) or len(root.subcircuits) < 2:
+            return True
+        _ = proposal.support
+        branch_supports = [child.result_of_current_query for child in root.subcircuits]
+        return all(
+            left.intersection_with(right).is_empty()
+            for left, right in itertools.combinations(branch_supports, 2)
+        )
+
+    @staticmethod
+    def _representative_value(
+        latent_branch: Unit, undetermined_latents: SortedSet[Variable]
+    ) -> dict[Variable, Any]:
+        """
+        Extract one conditioning value per undetermined latent from a partition branch.
+
+        Uses each leaf's own mode. Any value within the branch's support would do for
+        grounding purposes here, since the branch's actual probability mass is retained
+        separately via :meth:`ProductUnit.attach_marginal_circuit`, not narrowed by this
+        choice -- a discrete leaf's mode is effectively a representative point, while a
+        continuous leaf's mode may itself be a sub-interval.
+
+        :param latent_branch: One branch of ``undetermined_latents``' exact partition.
+        :param undetermined_latents: The latent variables to extract a value for.
+        :return: One conditioning value per variable in ``undetermined_latents``.
+        """
+        return {
+            leaf_node.variable: leaf_node.distribution.univariate_log_mode()[0]
+            for leaf_node in latent_branch.leaves
+            if leaf_node.variable in undetermined_latents
+        }
 
     @staticmethod
     def _attach_mixture_to_node(

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -40,7 +40,7 @@ from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     CircuitNotFittedError,
     InvalidMonteCarloSampleCountError,
     UndeterminedLatentsNotModeledError,
-    UndeterminedLatentsPartitionOverlapsError,
+    UndeterminedLatentsNotPartitionedError,
 )
 from probabilistic_model.probabilistic_circuit.relational.helper import (
     find_lowest_product_nodes_that_model_variables,
@@ -523,7 +523,7 @@ class RelationalProbabilisticCircuit:
                     undetermined_latents,
                 )
                 return circuit
-            except UndeterminedLatentsPartitionOverlapsError:
+            except UndeterminedLatentsNotPartitionedError:
                 logger.warning(
                     "Exact-partition grounding for latents [%s] is not support-"
                     "deterministic; falling back to GroundingMode.CAUSAL_SAMPLED.",
@@ -799,7 +799,7 @@ class RelationalProbabilisticCircuit:
         :param undetermined_latents: The latents to retain via exact partition.
         :raises UndeterminedLatentsNotModeledError: If ``circuit`` does not model
             ``undetermined_latents`` and thus has no partition over them.
-        :raises UndeterminedLatentsPartitionOverlapsError: If that partition's branches
+        :raises UndeterminedLatentsNotPartitionedError: If that partition's branches
             are not pairwise disjoint, so exact-partition grounding would not be
             support-deterministic.
         """
@@ -807,19 +807,28 @@ class RelationalProbabilisticCircuit:
         if proposal is None:
             raise UndeterminedLatentsNotModeledError(list(undetermined_latents))
         if not self._undetermined_latents_partition_disjointly(proposal):
-            raise UndeterminedLatentsPartitionOverlapsError(list(undetermined_latents))
+            raise UndeterminedLatentsNotPartitionedError(list(undetermined_latents))
+
+        # the precondition just verified guarantees proposal.root is a SumUnit with at
+        # least two branches
+        branches = proposal.root.log_weighted_subcircuits
+        _ = proposal.support
+        branch_regions = [branch.result_of_current_query for _, branch in branches]
+
+        # each node's weights must be read off circuit before undetermined_latents are
+        # stripped from it below -- product_node stops modeling them afterward
+        log_weights_per_node = [
+            self._node_local_branch_log_probabilities(
+                product_node, undetermined_latents, branch_regions
+            )
+            for product_node in product_nodes_to_extend
+        ]
 
         retained_variables = SortedSet(circuit.variables) - undetermined_latents
         circuit.marginal_in_place(retained_variables)
 
-        branches = (
-            proposal.root.log_weighted_subcircuits
-            if isinstance(proposal.root, SumUnit)
-            else [(0.0, proposal.root)]
-        )
         mounted_roots = []
-        log_weights = []
-        for log_weight, latent_branch in branches:
+        for _, latent_branch in branches:
             representative_value = self._representative_value(
                 latent_branch, undetermined_latents
             )
@@ -834,35 +843,72 @@ class RelationalProbabilisticCircuit:
             mounted_branch_nodes = circuit.mount(latent_branch)
             branch_root.add_subcircuit(mounted_branch_nodes[latent_branch.index])
             mounted_roots.append(branch_root)
-            log_weights.append(log_weight)
 
-        for product_node in product_nodes_to_extend:
+        for product_node, log_weights in zip(
+            product_nodes_to_extend, log_weights_per_node
+        ):
             self._attach_mixture_to_node(
                 circuit, product_node, mounted_roots, log_weights
             )
+
+    @staticmethod
+    def _node_local_branch_log_probabilities(
+        product_node: ProductUnit,
+        undetermined_latents: SortedSet[Variable],
+        branch_regions: list,
+    ) -> list[float]:
+        """
+        Log-probability of each partition branch's region, local to a mounting product
+        node.
+
+        Different product nodes can correlate ``undetermined_latents`` with the
+        variables that distinguish them, so each node's weights over the same global
+        partition must be computed from its own local marginal, mirroring
+        :meth:`_node_local_latent_log_likelihoods`'s per-node handling for the Monte-
+        Carlo mixture.
+
+        :param product_node: The mounting product node.
+        :param undetermined_latents: The latent variables the partition covers.
+        :param branch_regions: Each partition branch's own support region, in the same
+            order as the branches being weighted.
+        :return: One log-probability per region, in input order.
+        """
+        subcircuit = ProbabilisticCircuit()
+        subcircuit.mount(product_node)
+        subcircuit.marginal_in_place(undetermined_latents)
+        with np.errstate(divide="ignore"):
+            return [
+                float(np.log(subcircuit.probability(region)))
+                for region in branch_regions
+            ]
 
     @staticmethod
     def _undetermined_latents_partition_disjointly(
         proposal: ProbabilisticCircuit,
     ) -> bool:
         """
-        Check whether ``proposal``'s branches, if more than one, have disjoint support.
+        Check whether ``proposal`` is a genuine, pairwise-disjoint partition over the
+        undetermined latents: a mixture of at least two branches, no two of which
+        overlap.
 
         ``JointProbabilityTree`` does not retain which variables it actually split on
         after fitting, so this checks the invariant exact-partition grounding actually
         needs directly on the marginalized circuit, rather than trying to infer it from
-        fitting-time bookkeeping the tree does not expose: whether the branches of
-        ``proposal``'s own mixture over ``undetermined_latents`` overlap.
+        fitting-time bookkeeping the tree does not expose. A single, undifferentiated
+        branch fails this precondition rather than trivially passing it: grounding
+        would still retain the latents as a real distribution, but every exchangeable
+        instance would be grounded from the same representative point regardless of
+        which latent value the region actually corresponds to, silently discarding any
+        correlation between the latents and the rest of the circuit.
 
         :param proposal: ``circuit`` marginalized down to exactly the undetermined
             latents.
-        :return:``True`` if ``proposal``'s root is not a mixture (a single branch is
-            trivially disjoint), or if every pair of its branches has non-overlapping
-            support.
+        :return:``True`` only if ``proposal``'s root is a mixture of at least two
+            branches, every pair of which has non-overlapping support.
         """
         root = proposal.root
         if not isinstance(root, SumUnit) or len(root.subcircuits) < 2:
-            return True
+            return False
         _ = proposal.support
         branch_supports = [child.result_of_current_query for child in root.subcircuits]
         return all(
@@ -875,23 +921,32 @@ class RelationalProbabilisticCircuit:
         latent_branch: Unit, undetermined_latents: SortedSet[Variable]
     ) -> dict[Variable, Any]:
         """
-        Extract one conditioning value per undetermined latent from a partition branch.
+        Extract one concrete point per undetermined latent from a partition branch.
 
-        Uses each leaf's own mode. Any value within the branch's support would do for
-        grounding purposes here, since the branch's actual probability mass is retained
-        separately via :meth:`ProductUnit.attach_marginal_circuit`, not narrowed by this
-        choice -- a discrete leaf's mode is effectively a representative point, while a
-        continuous leaf's mode may itself be a sub-interval.
+        Uses each leaf's own mode, collapsed to a single point of that mode region.
+        Any point within the branch's support would do for grounding purposes here,
+        since the branch's actual probability mass is retained separately by mounting
+        the branch itself, not narrowed by this choice. A single point is required
+        because conditioning a leaf's distribution on a whole region -- rather than one
+        point -- is not supported by :meth:`~probabilistic_model.distributions.distributions.ContinuousDistribution.log_conditional`,
+        which every leaf here resolves to (including :class:`IntegerDistribution`,
+        through its continuous base).
 
         :param latent_branch: One branch of ``undetermined_latents``' exact partition.
         :param undetermined_latents: The latent variables to extract a value for.
-        :return: One conditioning value per variable in ``undetermined_latents``.
+        :return: One conditioning point per variable in ``undetermined_latents``.
         """
-        return {
-            leaf_node.variable: leaf_node.distribution.univariate_log_mode()[0]
-            for leaf_node in latent_branch.leaves
-            if leaf_node.variable in undetermined_latents
-        }
+        values = {}
+        for leaf_node in latent_branch.leaves:
+            if leaf_node.variable not in undetermined_latents:
+                continue
+            mode, _ = leaf_node.distribution.univariate_log_mode()
+            values[leaf_node.variable] = (
+                mode.simple_sets[0].lower
+                if isinstance(mode, Interval)
+                else next(iter(mode))
+            )
+        return values
 
     @staticmethod
     def _attach_mixture_to_node(

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -63,35 +63,34 @@ logger = logging.getLogger(__name__)
 
 class GroundingMode(enum.Enum):
     """
-    Selects how ``RelationalProbabilisticCircuit.ground`` treats an exchangeable
+    Selects how ``RelationalProbabilisticCircuit.ground`` represents an exchangeable
     relation's aggregation latents that a query leaves undetermined.
+
+    Undetermined latents are always retained as variables of the grounded circuit --
+    never integrated out -- so any caller that only wants the query's own variables
+    marginalizes the ones it does not need afterward, as a postprocessing step, rather
+    than grounding deciding that for it. Registering a retained latent as a cause or
+    effect in a :class:`CausalCircuit
+    <probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit>` is
+    one such postprocessing step, not a distinct grounding behaviour.
     """
 
-    PREDICTIVE = enum.auto()
+    SAMPLED = enum.auto()
     """
-    Integrate undetermined latents out of the grounded circuit by Monte-Carlo mixture,
-    discarding them.
+    Retain each undetermined latent as a point-valued variable at its Monte-Carlo
+    sampled value.
 
     Default behaviour.
     """
 
-    CAUSAL_SAMPLED = enum.auto()
-    """
-    Retain each undetermined latent as a point-valued variable at its Monte-Carlo
-    sampled value instead of discarding it, so it can be registered as a cause or effect
-    in a :class:`CausalCircuit
-    <probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit>`.
-    """
-
-    CAUSAL_EXACT = enum.auto()
+    EXACT = enum.auto()
     """
     Retain undetermined latents by enumerating the fitted circuit's own exact, disjoint
     partition over them instead of sampling.
 
     Reproducible across calls and covers the whole domain the model learned about,
-    unlike :attr:`CAUSAL_SAMPLED`. Falls back to :attr:`CAUSAL_SAMPLED`, with a logged
-    warning, when the fitted circuit's partition over the undetermined latents is not
-    itself disjoint.
+    unlike :attr:`SAMPLED`. Falls back to :attr:`SAMPLED`, with a logged warning, when
+    the fitted circuit's partition over the undetermined latents is not itself disjoint.
     """
 
 
@@ -418,7 +417,7 @@ class RelationalProbabilisticCircuit:
     def ground(
         self,
         query: Match,
-        grounding_mode: GroundingMode = GroundingMode.PREDICTIVE,
+        grounding_mode: GroundingMode = GroundingMode.SAMPLED,
     ) -> ProbabilisticCircuit:
         """
         Ground the relational circuit for a specific query.
@@ -467,11 +466,11 @@ class RelationalProbabilisticCircuit:
         Ground one exchangeable part and attach it to the class circuit.
 
         Aggregation statistics determinable from the query condition the class circuit
-        directly. Undetermined statistics are integrated out: by Monte-Carlo sampling
-        (:attr:`GroundingMode.PREDICTIVE`, :attr:`GroundingMode.CAUSAL_SAMPLED`) or by
-        enumerating the fitted circuit's own exact partition over them
-        (:attr:`GroundingMode.CAUSAL_EXACT`, falling back to
-        :attr:`GroundingMode.CAUSAL_SAMPLED` if that partition is not disjoint).
+        directly. Undetermined statistics are retained as variables, represented either
+        by Monte-Carlo sampling (:attr:`GroundingMode.SAMPLED`) or by enumerating the
+        fitted circuit's own exact partition over them (:attr:`GroundingMode.EXACT`,
+        falling back to :attr:`GroundingMode.SAMPLED` if that partition is not
+        disjoint).
 
         :param circuit: The current working copy of the class circuit.
         :param exchangeable_part_name: Field name of the exchangeable relation.
@@ -512,7 +511,7 @@ class RelationalProbabilisticCircuit:
             )
             return circuit
 
-        if grounding_mode is GroundingMode.CAUSAL_EXACT:
+        if grounding_mode is GroundingMode.EXACT:
             try:
                 self._attach_exact_partition_mixture(
                     circuit,
@@ -526,10 +525,9 @@ class RelationalProbabilisticCircuit:
             except UndeterminedLatentsNotPartitionedError:
                 logger.warning(
                     "Exact-partition grounding for latents [%s] is not support-"
-                    "deterministic; falling back to GroundingMode.CAUSAL_SAMPLED.",
+                    "deterministic; falling back to GroundingMode.SAMPLED.",
                     ", ".join(variable.name for variable in undetermined_latents),
                 )
-                grounding_mode = GroundingMode.CAUSAL_SAMPLED
 
         sampled_assignments = self._sample_undetermined_latents(
             circuit, undetermined_latents
@@ -542,7 +540,6 @@ class RelationalProbabilisticCircuit:
             determined_statistics,
             undetermined_latents,
             sampled_assignments,
-            grounding_mode,
         )
         return circuit
 
@@ -671,29 +668,23 @@ class RelationalProbabilisticCircuit:
         determined_statistics: dict[Variable, Any],
         undetermined_latents: SortedSet[Variable],
         sampled_assignments: list[dict[Variable, Any]],
-        grounding_mode: GroundingMode,
     ) -> None:
         """
         Attach a Monte-Carlo mixture over undetermined aggregation statistics.
 
         For every sampled assignment one exchangeable instance is grounded on the
-        determined plus sampled statistics. The undetermined latents are then
-        marginalized out of the class circuit so their distribution is carried solely by
-        the mixture weights, which are the node-local likelihoods of the sampled values.
-        Each mounting product node receives its own normalized sum unit over the
-        instances. Under :attr:`GroundingMode.CAUSAL_SAMPLED`, each instance
-        additionally carries its sampled latent values back as point-valued variables
-        instead of leaving them discarded.
+        determined plus sampled statistics, and additionally carries its sampled latent
+        values back as point-valued variables instead of leaving them discarded. Each
+        mounting product node receives its own normalized sum unit over the instances,
+        weighted by the node-local likelihoods of the sampled values.
 
         :param circuit: The working class circuit.
         :param product_nodes_to_extend: The mounting product nodes.
         :param template: The fitted template for this relation.
         :param query_parts: The query parts, one per child object.
         :param determined_statistics: Statistics determinable from the query.
-        :param undetermined_latents: The latents integrated out by Monte-Carlo.
+        :param undetermined_latents: The latents represented by Monte-Carlo sampling.
         :param sampled_assignments: Distinct sampled values of the undetermined latents.
-        :param grounding_mode: How to treat ``undetermined_latents``. See
-            :class:`GroundingMode`.
         """
         log_weights_per_node = [
             self._node_local_latent_log_likelihoods(
@@ -703,28 +694,17 @@ class RelationalProbabilisticCircuit:
         ]
         retained_variables = SortedSet(circuit.variables) - undetermined_latents
         circuit.marginal_in_place(retained_variables)
-        if grounding_mode is GroundingMode.CAUSAL_SAMPLED:
-            mounted_roots = [
-                self._mount_instance_with_retained_latents(
-                    circuit,
-                    template,
-                    query_parts,
-                    determined_statistics,
-                    assignment,
-                    undetermined_latents,
-                )
-                for assignment in sampled_assignments
-            ]
-        else:
-            mounted_roots = [
-                self._mount_instance(
-                    circuit,
-                    template,
-                    query_parts,
-                    {**determined_statistics, **assignment},
-                )
-                for assignment in sampled_assignments
-            ]
+        mounted_roots = [
+            self._mount_instance_with_retained_latents(
+                circuit,
+                template,
+                query_parts,
+                determined_statistics,
+                assignment,
+                undetermined_latents,
+            )
+            for assignment in sampled_assignments
+        ]
         for product_node, log_weights in zip(
             product_nodes_to_extend, log_weights_per_node
         ):

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -11,6 +11,7 @@ Relational probabilistic circuits ("RSPNs").
 
 from __future__ import annotations
 
+import enum
 import itertools
 from dataclasses import dataclass, field
 
@@ -31,6 +32,7 @@ from krrood.parametrization.feature_extraction.feature_extractor import FeatureE
 
 if TYPE_CHECKING:
     from krrood.entity_query_language.query.match import Match
+from probabilistic_model.distributions.helper import make_dirac
 from probabilistic_model.learning.jpt.jpt import JointProbabilityTree
 from probabilistic_model.learning.jpt.variables import infer_variables_from_dataframe
 from probabilistic_model.probabilistic_circuit.relational.exceptions import (
@@ -49,9 +51,33 @@ from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
     ProductUnit,
     SumUnit,
     Unit,
+    leaf,
 )
 from random_events.interval import Interval
 from random_events.variable import Variable
+
+
+class GroundingMode(enum.Enum):
+    """
+    Selects how ``RelationalProbabilisticCircuit.ground`` treats an exchangeable
+    relation's aggregation latents that a query leaves undetermined.
+    """
+
+    PREDICTIVE = enum.auto()
+    """
+    Integrate undetermined latents out of the grounded circuit by Monte-Carlo mixture,
+    discarding them.
+
+    Default behaviour.
+    """
+
+    CAUSAL_SAMPLED = enum.auto()
+    """
+    Retain each undetermined latent as a point-valued variable at its Monte-Carlo
+    sampled value instead of discarding it, so it can be registered as a cause or
+    effect in a :class:`CausalCircuit
+    <probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit>`.
+    """
 
 
 def _is_concrete_statistic(variable: Variable, value: Any) -> bool:
@@ -374,7 +400,11 @@ class RelationalProbabilisticCircuit:
         )
         return circuit, product_nodes_to_extend
 
-    def ground(self, query: Match) -> ProbabilisticCircuit:
+    def ground(
+        self,
+        query: Match,
+        grounding_mode: GroundingMode = GroundingMode.PREDICTIVE,
+    ) -> ProbabilisticCircuit:
         """
         Ground the relational circuit for a specific query.
 
@@ -385,6 +415,8 @@ class RelationalProbabilisticCircuit:
         :param query: An underspecified, resolved query instance whose structure
             determines which parts are grounded and how many child objects each
             exchangeable relation contains.
+        :param grounding_mode: How to treat aggregation latents the query leaves
+            undetermined. See :class:`GroundingMode`.
         :return: A concrete ``ProbabilisticCircuit`` over all variables implied by the
             query.
         :raises CircuitNotFittedError: If ``ground`` is called before ``fit``.
@@ -398,7 +430,12 @@ class RelationalProbabilisticCircuit:
             template,
         ) in self.exchangeable_distribution_templates.items():
             circuit = self._ground_exchangeable_part(
-                circuit, exchangeable_part_name, template, query, instance
+                circuit,
+                exchangeable_part_name,
+                template,
+                query,
+                instance,
+                grounding_mode,
             )
         return circuit
 
@@ -409,6 +446,7 @@ class RelationalProbabilisticCircuit:
         template: ExchangeableDistributionTemplate,
         query: Match,
         instance: Any,
+        grounding_mode: GroundingMode,
     ) -> ProbabilisticCircuit:
         """
         Ground one exchangeable part and attach it to the class circuit.
@@ -423,6 +461,8 @@ class RelationalProbabilisticCircuit:
         :param template: The fitted template for this relation.
         :param query: The grounding query.
         :param instance: The concrete instance constructed from the query.
+        :param grounding_mode: How to treat aggregation latents the query leaves
+            undetermined. See :class:`GroundingMode`.
         :return: The class circuit extended with the grounded exchangeable part.
         """
         aggregation_statistics = compute_aggregation_statistics(
@@ -466,6 +506,7 @@ class RelationalProbabilisticCircuit:
             determined_statistics,
             undetermined_latents,
             sampled_assignments,
+            grounding_mode,
         )
         return circuit
 
@@ -594,6 +635,7 @@ class RelationalProbabilisticCircuit:
         determined_statistics: dict[Variable, Any],
         undetermined_latents: SortedSet[Variable],
         sampled_assignments: list[dict[Variable, Any]],
+        grounding_mode: GroundingMode,
     ) -> None:
         """
         Attach a Monte-Carlo mixture over undetermined aggregation statistics.
@@ -603,7 +645,9 @@ class RelationalProbabilisticCircuit:
         marginalized out of the class circuit so their distribution is carried solely by
         the mixture weights, which are the node-local likelihoods of the sampled values.
         Each mounting product node receives its own normalized sum unit over the
-        instances.
+        instances. Under :attr:`GroundingMode.CAUSAL_SAMPLED`, each instance
+        additionally carries its sampled latent values back as point-valued variables
+        instead of leaving them discarded.
 
         :param circuit: The working class circuit.
         :param product_nodes_to_extend: The mounting product nodes.
@@ -612,6 +656,8 @@ class RelationalProbabilisticCircuit:
         :param determined_statistics: Statistics determinable from the query.
         :param undetermined_latents: The latents integrated out by Monte-Carlo.
         :param sampled_assignments: Distinct sampled values of the undetermined latents.
+        :param grounding_mode: How to treat ``undetermined_latents``. See
+            :class:`GroundingMode`.
         """
         log_weights_per_node = [
             self._node_local_latent_log_likelihoods(
@@ -621,18 +667,73 @@ class RelationalProbabilisticCircuit:
         ]
         retained_variables = SortedSet(circuit.variables) - undetermined_latents
         circuit.marginal_in_place(retained_variables)
-        mounted_roots = [
-            self._mount_instance(
-                circuit, template, query_parts, {**determined_statistics, **assignment}
-            )
-            for assignment in sampled_assignments
-        ]
+        if grounding_mode is GroundingMode.CAUSAL_SAMPLED:
+            mounted_roots = [
+                self._mount_instance_with_retained_latents(
+                    circuit,
+                    template,
+                    query_parts,
+                    determined_statistics,
+                    assignment,
+                    undetermined_latents,
+                )
+                for assignment in sampled_assignments
+            ]
+        else:
+            mounted_roots = [
+                self._mount_instance(
+                    circuit,
+                    template,
+                    query_parts,
+                    {**determined_statistics, **assignment},
+                )
+                for assignment in sampled_assignments
+            ]
         for product_node, log_weights in zip(
             product_nodes_to_extend, log_weights_per_node
         ):
             self._attach_mixture_to_node(
                 circuit, product_node, mounted_roots, log_weights
             )
+
+    @staticmethod
+    def _mount_instance_with_retained_latents(
+        circuit: ProbabilisticCircuit,
+        template: ExchangeableDistributionTemplate,
+        query_parts: list,
+        determined_statistics: dict[Variable, Any],
+        assignment: dict[Variable, Any],
+        undetermined_latents: SortedSet[Variable],
+    ) -> Unit:
+        """
+        Ground one exchangeable instance and retain its sampled latents as variables.
+
+        Same grounding as :meth:`_mount_instance`, but each variable in
+        ``undetermined_latents`` is additionally mounted as a point-valued sibling leaf
+        at its sampled value, instead of leaving it to be marginalized away. Distinct
+        sampled values produce disjoint singleton supports by construction, so the
+        resulting mixture stays support-deterministic on the retained latents.
+
+        :param circuit: The working class circuit to mount into.
+        :param template: The fitted template for this relation.
+        :param query_parts: The query parts, one per child object.
+        :param determined_statistics: Statistics determinable from the query.
+        :param assignment: The sampled values of ``undetermined_latents`` for this
+            instance.
+        :param undetermined_latents: The latent variables to retain.
+        :return: The root of a product uniting the mounted instance with a point leaf
+            per retained latent, owned by ``circuit``.
+        """
+        instance_root = RelationalProbabilisticCircuit._mount_instance(
+            circuit, template, query_parts, {**determined_statistics, **assignment}
+        )
+        wrapper = ProductUnit(probabilistic_circuit=circuit)
+        wrapper.add_subcircuit(instance_root)
+        for variable in undetermined_latents:
+            wrapper.add_subcircuit(
+                leaf(make_dirac(variable, assignment[variable]), circuit)
+            )
+        return wrapper
 
     @staticmethod
     def _attach_mixture_to_node(

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -359,26 +359,20 @@ class RelationalProbabilisticCircuit:
         :param aggregation_statistics: Observed aggregation values to condition on.
         :param latent_variables: Variables that link the class circuit to the
             exchangeable distribution template.
-        :return: The conditioned circuit and the surviving product nodes that will be
-            extended with the grounded exchangeable distribution.
+        :return: The conditioned circuit and the product nodes that will be extended
+            with the grounded exchangeable distribution.
         """
-        product_nodes_to_extend = find_lowest_product_nodes_that_model_variables(
-            circuit, SortedSet(latent_variables)
-        )
         conditioning_result, _ = circuit.log_conditional_in_place(
             aggregation_statistics
         )
         if conditioning_result is None:
             circuit = self.class_probabilistic_circuit.__deepcopy__()
-            product_nodes_to_extend = find_lowest_product_nodes_that_model_variables(
-                circuit, SortedSet(latent_variables)
-            )
         if len(circuit.nodes()) == 0:
             raise ValueError("The grounding of the class failed.")
-        surviving_product_nodes = [
-            node for node in product_nodes_to_extend if node.index is not None
-        ]
-        return circuit, surviving_product_nodes
+        product_nodes_to_extend = find_lowest_product_nodes_that_model_variables(
+            circuit, SortedSet(latent_variables)
+        )
+        return circuit, product_nodes_to_extend
 
     def ground(self, query: Match) -> ProbabilisticCircuit:
         """

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -201,12 +201,12 @@ class ExchangeablePartGrounder:
     The class circuit's product nodes that mount the grounded instance(s).
     """
 
-    template: ExchangeableDistributionTemplate
+    template: RelationalDistributionTemplate
     """
-    The fitted template for this exchangeable relation.
+    The fitted template whose exchangeable relation is being grounded.
     """
 
-    query_parts: list
+    query_parts: list[Match]
     """
     The query parts, one per child object in the relation.
     """
@@ -295,6 +295,8 @@ class ExchangeablePartGrounder:
         # the precondition just verified guarantees proposal.root is a SumUnit with at
         # least two branches
         branches = proposal.root.log_weighted_subcircuits
+        # side-effecting traversal: populates result_of_current_query on every node,
+        # which branch_regions below reads off; the returned event itself is unused
         _ = proposal.support
         branch_regions = [branch.result_of_current_query for _, branch in branches]
 
@@ -469,15 +471,12 @@ class ExchangeablePartGrounder:
         undetermined latents: a mixture of at least two branches, no two of which
         overlap.
 
-        ``JointProbabilityTree`` does not retain which variables it actually split on
-        after fitting, so this checks the invariant exact-partition grounding actually
-        needs directly on the marginalized circuit, rather than trying to infer it from
-        fitting-time bookkeeping the tree does not expose. A single, undifferentiated
-        branch fails this precondition rather than trivially passing it: grounding
-        would still retain the latents as a real distribution, but every exchangeable
-        instance would be grounded from the same representative point regardless of
-        which latent value the region actually corresponds to, silently discarding any
-        correlation between the latents and the rest of the circuit.
+        A single, undifferentiated branch fails this precondition rather than
+        trivially passing it: grounding would still retain the latents as a real
+        distribution, but every exchangeable instance would be grounded from the same
+        representative point regardless of which latent value the region actually
+        corresponds to, silently discarding any correlation between the latents and
+        the rest of the circuit.
 
         :param proposal: ``circuit`` marginalized down to exactly the undetermined
             latents.

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -38,7 +38,9 @@ from probabilistic_model.learning.jpt.jpt import JointProbabilityTree
 from probabilistic_model.learning.jpt.variables import infer_variables_from_dataframe
 from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     CircuitNotFittedError,
+    ClassCircuitGroundingFailedError,
     InvalidMonteCarloSampleCountError,
+    PartCircuitGroundingFailedError,
     UndeterminedLatentsNotModeledError,
     UndeterminedLatentsNotPartitionedError,
 )
@@ -61,7 +63,7 @@ from random_events.variable import Variable
 logger = logging.getLogger(__name__)
 
 
-class GroundingMode(enum.Enum):
+class GroundingMode(enum.IntEnum):
     """
     Selects how ``RelationalProbabilisticCircuit.ground`` represents an exchangeable
     relation's aggregation latents that a query leaves undetermined.
@@ -69,10 +71,7 @@ class GroundingMode(enum.Enum):
     Undetermined latents are always retained as variables of the grounded circuit --
     never integrated out -- so any caller that only wants the query's own variables
     marginalizes the ones it does not need afterward, as a postprocessing step, rather
-    than grounding deciding that for it. Registering a retained latent as a cause or
-    effect in a :class:`CausalCircuit
-    <probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit>` is
-    one such postprocessing step, not a distinct grounding behaviour.
+    than grounding deciding that for it.
     """
 
     SAMPLED = enum.auto()
@@ -156,7 +155,7 @@ class ExchangeableDistributionTemplate(RelationalDistributionTemplate):
         prefix = self._prefix_for_part(part, index)
         part_circuit.rename_variables_with_prefix(prefix, self.latent_variables)
         if len(part_circuit.nodes()) == 0:
-            raise ValueError("The grounding of the part failed.")
+            raise PartCircuitGroundingFailedError(self.template_distribution.class_)
         return part_circuit
 
     def ground(
@@ -178,6 +177,384 @@ class ExchangeableDistributionTemplate(RelationalDistributionTemplate):
             )
             root.add_subcircuit(self._mount_part(result, part_circuit))
         return result
+
+
+@dataclass
+class ExchangeablePartGrounder:
+    """
+    Grounds one exchangeable part into the mounting product nodes of a class circuit.
+
+    Bundles the circuit, template, and query context one exchangeable part's grounding
+    needs, so the different ways of representing undetermined aggregation latents
+    (:attr:`GroundingMode.SAMPLED`, :attr:`GroundingMode.EXACT`) read and mutate that
+    context through fields instead of threading the same handful of arguments through a
+    chain of static methods.
+    """
+
+    circuit: ProbabilisticCircuit
+    """
+    The working class circuit being extended.
+    """
+
+    product_nodes_to_extend: list[ProductUnit]
+    """
+    The class circuit's product nodes that mount the grounded instance(s).
+    """
+
+    template: ExchangeableDistributionTemplate
+    """
+    The fitted template for this exchangeable relation.
+    """
+
+    query_parts: list
+    """
+    The query parts, one per child object in the relation.
+    """
+
+    determined_statistics: dict[Variable, Any]
+    """
+    Aggregation statistics determinable from the query.
+    """
+
+    undetermined_latents: SortedSet[Variable] = field(default_factory=SortedSet)
+    """
+    Latent variables the query leaves undetermined.
+    """
+
+    monte_carlo_sample_count: int = 10
+    """
+    Number of Monte-Carlo samples drawn to integrate out ``undetermined_latents``.
+    """
+
+    def attach_single_instance(self) -> None:
+        """
+        Attach one grounded exchangeable instance to every mounting product node.
+
+        The instance is mounted once and shared as a child of every node.
+        """
+        instance_root = self._mount_instance(self.determined_statistics)
+        for product_node in self.product_nodes_to_extend:
+            product_node.add_subcircuit(instance_root)
+
+    def attach_monte_carlo_mixture(self) -> None:
+        """
+        Attach a Monte-Carlo mixture over undetermined aggregation statistics.
+
+        For every sampled assignment one exchangeable instance is grounded on the
+        determined plus sampled statistics, and additionally carries its sampled latent
+        values back as point-valued variables instead of leaving them discarded. Each
+        mounting product node receives its own normalized sum unit over the instances,
+        weighted by the node-local likelihoods of the sampled values.
+        """
+        sampled_assignments = self._sample_undetermined_latents()
+        log_weights_per_node = [
+            self._node_local_latent_log_likelihoods(
+                product_node, self.undetermined_latents, sampled_assignments
+            )
+            for product_node in self.product_nodes_to_extend
+        ]
+        retained_variables = (
+            SortedSet(self.circuit.variables) - self.undetermined_latents
+        )
+        self.circuit.marginal_in_place(retained_variables)
+        mounted_roots = [
+            self._mount_instance_with_retained_latents(assignment)
+            for assignment in sampled_assignments
+        ]
+        for product_node, log_weights in zip(
+            self.product_nodes_to_extend, log_weights_per_node
+        ):
+            self._attach_mixture_to_node(product_node, mounted_roots, log_weights)
+
+    def attach_exact_partition_mixture(self) -> None:
+        """
+        Attach a mixture over the undetermined latents' own exact partition.
+
+        Unlike Monte-Carlo sampling, this enumerates ``circuit``'s already-fitted,
+        exact partition over ``undetermined_latents`` (the branches of
+        ``circuit.marginal(undetermined_latents)``'s root) instead of drawing samples
+        from it: reproducible across calls, and covers every value the model learned
+        about rather than only whichever points got sampled. One exchangeable instance
+        is grounded per branch and retains that branch's full region -- not narrowed to
+        a point -- by mounting the branch itself alongside the grounded instance.
+
+        :raises UndeterminedLatentsNotModeledError: If ``circuit`` does not model
+            ``undetermined_latents`` and thus has no partition over them.
+        :raises UndeterminedLatentsNotPartitionedError: If that partition's branches
+            are not pairwise disjoint, so exact-partition grounding would not be
+            support-deterministic.
+        """
+        proposal = self.circuit.marginal(self.undetermined_latents)
+        if proposal is None:
+            raise UndeterminedLatentsNotModeledError(list(self.undetermined_latents))
+        if not self._undetermined_latents_partition_disjointly(proposal):
+            raise UndeterminedLatentsNotPartitionedError(
+                list(self.undetermined_latents)
+            )
+
+        # the precondition just verified guarantees proposal.root is a SumUnit with at
+        # least two branches
+        branches = proposal.root.log_weighted_subcircuits
+        _ = proposal.support
+        branch_regions = [branch.result_of_current_query for _, branch in branches]
+
+        # each node's weights must be read off circuit before undetermined_latents are
+        # stripped from it below -- product_node stops modeling them afterward
+        log_weights_per_node = [
+            self._node_local_branch_log_probabilities(
+                product_node, self.undetermined_latents, branch_regions
+            )
+            for product_node in self.product_nodes_to_extend
+        ]
+
+        retained_variables = (
+            SortedSet(self.circuit.variables) - self.undetermined_latents
+        )
+        self.circuit.marginal_in_place(retained_variables)
+
+        mounted_roots = []
+        for _, latent_branch in branches:
+            representative_value = self._representative_value(
+                latent_branch, self.undetermined_latents
+            )
+            instance_root = self._mount_instance(
+                {**self.determined_statistics, **representative_value}
+            )
+            branch_root = ProductUnit(probabilistic_circuit=self.circuit)
+            branch_root.add_subcircuit(instance_root)
+            mounted_branch_nodes = self.circuit.mount(latent_branch)
+            branch_root.add_subcircuit(mounted_branch_nodes[latent_branch.index])
+            mounted_roots.append(branch_root)
+
+        for product_node, log_weights in zip(
+            self.product_nodes_to_extend, log_weights_per_node
+        ):
+            self._attach_mixture_to_node(product_node, mounted_roots, log_weights)
+
+    def _mount_instance(self, aggregation_statistics: dict[Variable, Any]) -> Unit:
+        """
+        Ground one exchangeable instance and mount it into the class circuit.
+
+        :param aggregation_statistics: Statistics to condition the instance on.
+        :return: The root of the mounted instance, owned by ``circuit``.
+        """
+        grounded = self.template.ground(self.query_parts, aggregation_statistics)
+        node_index_map = self.circuit.mount(grounded.root)
+        return node_index_map[grounded.root.index]
+
+    def _mount_instance_with_retained_latents(
+        self, assignment: dict[Variable, Any]
+    ) -> Unit:
+        """
+        Ground one exchangeable instance and retain its sampled latents as variables.
+
+        Same grounding as :meth:`_mount_instance`, but each variable in
+        ``undetermined_latents`` is additionally mounted as a point-valued sibling leaf
+        at its sampled value, instead of leaving it to be marginalized away. Distinct
+        sampled values produce disjoint singleton supports by construction, so the
+        resulting mixture stays support-deterministic on the retained latents.
+
+        :param assignment: The sampled values of ``undetermined_latents`` for this
+            instance.
+        :return: The root of a product uniting the mounted instance with a point leaf
+            per retained latent, owned by ``circuit``.
+        """
+        instance_root = self._mount_instance(
+            {**self.determined_statistics, **assignment}
+        )
+        wrapper = ProductUnit(probabilistic_circuit=self.circuit)
+        wrapper.add_subcircuit(instance_root)
+        for variable in self.undetermined_latents:
+            wrapper.add_subcircuit(
+                leaf(make_dirac(variable, assignment[variable]), self.circuit)
+            )
+        return wrapper
+
+    def _sample_undetermined_latents(self) -> list[dict[Variable, Any]]:
+        """
+        Draw the distinct values of the undetermined latents to integrate over.
+
+        Samples ``monte_carlo_sample_count`` joint assignments of the undetermined
+        latents from the conditioned class circuit and deduplicates them, so that each
+        distinct value is grounded only once.
+
+        :return: One value assignment per distinct sampled point.
+        :raises InvalidMonteCarloSampleCountError: If the sample count is not positive.
+        :raises UndeterminedLatentsNotModeledError: If the conditioned class circuit
+            does not model the undetermined latents and thus cannot be sampled from.
+        """
+        if self.monte_carlo_sample_count < 1:
+            raise InvalidMonteCarloSampleCountError(self.monte_carlo_sample_count)
+        proposal = self.circuit.marginal(self.undetermined_latents)
+        if proposal is None:
+            raise UndeterminedLatentsNotModeledError(list(self.undetermined_latents))
+        samples = proposal.sample(self.monte_carlo_sample_count)
+        index_of_variable = proposal.variable_to_index_map
+        unique_rows = {tuple(row) for row in samples.tolist()}
+        return [
+            {
+                variable: row[index_of_variable[variable]]
+                for variable in self.undetermined_latents
+            }
+            for row in (np.array(unique_row) for unique_row in unique_rows)
+        ]
+
+    @staticmethod
+    def _node_local_latent_log_likelihoods(
+        product_node: ProductUnit,
+        undetermined_latents: SortedSet[Variable],
+        latent_assignments: list[dict[Variable, Any]],
+    ) -> list[float]:
+        """
+        Log-likelihoods of latent assignments local to a mounting product node.
+
+        Marginalizes the subcircuit rooted at ``product_node`` to the undetermined
+        latents once, then evaluates every assignment in a single batched pass.
+
+        :param product_node: The mounting product node.
+        :param undetermined_latents: The latent variables sampled by Monte-Carlo.
+        :param latent_assignments: The sampled assignments of those latents.
+        :return: One log-likelihood per assignment, in input order.
+        """
+        subcircuit = ProbabilisticCircuit()
+        subcircuit.mount(product_node)
+        subcircuit.marginal_in_place(undetermined_latents)
+        index_of_variable = subcircuit.variable_to_index_map
+        events = np.full((len(latent_assignments), len(index_of_variable)), np.nan)
+        for row, assignment in enumerate(latent_assignments):
+            for variable, value in assignment.items():
+                events[row, index_of_variable[variable]] = value
+        return [
+            float(log_likelihood)
+            for log_likelihood in subcircuit.log_likelihood(events)
+        ]
+
+    @staticmethod
+    def _node_local_branch_log_probabilities(
+        product_node: ProductUnit,
+        undetermined_latents: SortedSet[Variable],
+        branch_regions: list,
+    ) -> list[float]:
+        """
+        Log-probability of each partition branch's region, local to a mounting product
+        node.
+
+        Different product nodes can correlate ``undetermined_latents`` with the
+        variables that distinguish them, so each node's weights over the same global
+        partition must be computed from its own local marginal, mirroring
+        :meth:`_node_local_latent_log_likelihoods`'s per-node handling for the Monte-
+        Carlo mixture.
+
+        :param product_node: The mounting product node.
+        :param undetermined_latents: The latent variables the partition covers.
+        :param branch_regions: Each partition branch's own support region, in the same
+            order as the branches being weighted.
+        :return: One log-probability per region, in input order.
+        """
+        subcircuit = ProbabilisticCircuit()
+        subcircuit.mount(product_node)
+        subcircuit.marginal_in_place(undetermined_latents)
+        with np.errstate(divide="ignore"):
+            return [
+                float(np.log(subcircuit.probability(region)))
+                for region in branch_regions
+            ]
+
+    @staticmethod
+    def _undetermined_latents_partition_disjointly(
+        proposal: ProbabilisticCircuit,
+    ) -> bool:
+        """
+        Check whether ``proposal`` is a genuine, pairwise-disjoint partition over the
+        undetermined latents: a mixture of at least two branches, no two of which
+        overlap.
+
+        ``JointProbabilityTree`` does not retain which variables it actually split on
+        after fitting, so this checks the invariant exact-partition grounding actually
+        needs directly on the marginalized circuit, rather than trying to infer it from
+        fitting-time bookkeeping the tree does not expose. A single, undifferentiated
+        branch fails this precondition rather than trivially passing it: grounding
+        would still retain the latents as a real distribution, but every exchangeable
+        instance would be grounded from the same representative point regardless of
+        which latent value the region actually corresponds to, silently discarding any
+        correlation between the latents and the rest of the circuit.
+
+        :param proposal: ``circuit`` marginalized down to exactly the undetermined
+            latents.
+        :return:``True`` only if ``proposal``'s root is a mixture of at least two
+            branches, every pair of which has non-overlapping support.
+        """
+        root = proposal.root
+        if not isinstance(root, SumUnit) or len(root.subcircuits) < 2:
+            return False
+        _ = proposal.support
+        branch_supports = [child.result_of_current_query for child in root.subcircuits]
+        return all(
+            left.intersection_with(right).is_empty()
+            for left, right in itertools.combinations(branch_supports, 2)
+        )
+
+    @staticmethod
+    def _representative_value(
+        latent_branch: Unit, undetermined_latents: SortedSet[Variable]
+    ) -> dict[Variable, Any]:
+        """
+        Extract one concrete point per undetermined latent from a partition branch.
+
+        Uses each leaf's own mode, collapsed to a single point of that mode region.
+        Any point within the branch's support would do for grounding purposes here,
+        since the branch's actual probability mass is retained separately by mounting
+        the branch itself, not narrowed by this choice. A single point is required
+        because conditioning a leaf's distribution on a whole region -- rather than one
+        point -- is not supported by :meth:`~probabilistic_model.distributions.distributions.ContinuousDistribution.log_conditional`,
+        which every leaf here resolves to (including :class:`IntegerDistribution`,
+        through its continuous base).
+
+        :param latent_branch: One branch of ``undetermined_latents``' exact partition.
+        :param undetermined_latents: The latent variables to extract a value for.
+        :return: One conditioning point per variable in ``undetermined_latents``.
+        """
+        values = {}
+        for leaf_node in latent_branch.leaves:
+            if leaf_node.variable not in undetermined_latents:
+                continue
+            mode, _ = leaf_node.distribution.univariate_log_mode()
+            values[leaf_node.variable] = (
+                mode.simple_sets[0].lower
+                if isinstance(mode, Interval)
+                else next(iter(mode))
+            )
+        return values
+
+    def _attach_mixture_to_node(
+        self,
+        product_node: ProductUnit,
+        instance_roots: list[Unit],
+        log_weights: list[float],
+    ) -> None:
+        """
+        Attach a normalized sum unit over exchangeable instances to one node.
+
+        Instances whose node-local likelihood is zero are skipped. The instances are
+        already mounted in ``circuit`` and shared across all mounting nodes; only the
+        weighted sum-unit edges differ per node.
+
+        :param product_node: The mounting product node to extend.
+        :param instance_roots: The roots of the mounted exchangeable instances.
+        :param log_weights: The node-local log-likelihood weight of each instance.
+        """
+        weighted_instances = [
+            (instance_root, log_weight)
+            for instance_root, log_weight in zip(instance_roots, log_weights)
+            if log_weight > -np.inf
+        ]
+        if not weighted_instances:
+            weighted_instances = [(instance_roots[0], 0.0)]
+        sum_unit = SumUnit(probabilistic_circuit=self.circuit)
+        product_node.add_subcircuit(sum_unit)
+        for instance_root, log_weight in weighted_instances:
+            sum_unit.add_subcircuit(instance_root, log_weight)
+        sum_unit.normalize()
 
 
 @dataclass
@@ -408,7 +785,7 @@ class RelationalProbabilisticCircuit:
         if conditioning_result is None:
             circuit = self.class_probabilistic_circuit.__deepcopy__()
         if len(circuit.nodes()) == 0:
-            raise ValueError("The grounding of the class failed.")
+            raise ClassCircuitGroundingFailedError(self.class_)
         product_nodes_to_extend = find_lowest_product_nodes_that_model_variables(
             circuit, SortedSet(latent_variables)
         )
@@ -501,461 +878,60 @@ class RelationalProbabilisticCircuit:
         )
         query_parts = query.kwargs[exchangeable_part_name]
 
+        grounder = ExchangeablePartGrounder(
+            circuit=circuit,
+            product_nodes_to_extend=product_nodes_to_extend,
+            template=template,
+            query_parts=query_parts,
+            determined_statistics=determined_statistics,
+            undetermined_latents=undetermined_latents,
+            monte_carlo_sample_count=self.monte_carlo_sample_count,
+        )
+
         if not undetermined_latents:
-            self._attach_single_exchangeable_instance(
-                circuit,
-                product_nodes_to_extend,
-                template,
-                query_parts,
-                determined_statistics,
-            )
+            grounder.attach_single_instance()
             return circuit
 
         if grounding_mode is GroundingMode.EXACT:
-            try:
-                self._attach_exact_partition_mixture(
-                    circuit,
-                    product_nodes_to_extend,
-                    template,
-                    query_parts,
-                    determined_statistics,
-                    undetermined_latents,
-                )
-                return circuit
-            except UndeterminedLatentsNotPartitionedError:
-                logger.warning(
-                    "Exact-partition grounding for latents [%s] is not support-"
-                    "deterministic; falling back to GroundingMode.SAMPLED.",
-                    ", ".join(variable.name for variable in undetermined_latents),
-                )
+            return self._ground_exact(grounder, circuit)
+        return self._ground_monte_carlo(grounder, circuit)
 
-        sampled_assignments = self._sample_undetermined_latents(
-            circuit, undetermined_latents
-        )
-        self._attach_monte_carlo_mixture(
-            circuit,
-            product_nodes_to_extend,
-            template,
-            query_parts,
-            determined_statistics,
-            undetermined_latents,
-            sampled_assignments,
-        )
+    def _ground_exact(
+        self, grounder: ExchangeablePartGrounder, circuit: ProbabilisticCircuit
+    ) -> ProbabilisticCircuit:
+        """
+        Ground via :attr:`GroundingMode.EXACT`, falling back to Monte-Carlo sampling if
+        the undetermined latents' fitted partition is not support-deterministic.
+
+        :param grounder: The grounder holding this exchangeable part's grounding
+            context.
+        :param circuit: The class circuit being extended; ``grounder`` mutates it in
+            place, so it is returned unchanged once grounding succeeds.
+        :return: The class circuit extended with the grounded exchangeable part.
+        """
+        try:
+            grounder.attach_exact_partition_mixture()
+            return circuit
+        except UndeterminedLatentsNotPartitionedError:
+            logger.warning(
+                "Exact-partition grounding for latents [%s] is not support-"
+                "deterministic; falling back to GroundingMode.SAMPLED.",
+                ", ".join(variable.name for variable in grounder.undetermined_latents),
+            )
+            return self._ground_monte_carlo(grounder, circuit)
+
+    def _ground_monte_carlo(
+        self, grounder: ExchangeablePartGrounder, circuit: ProbabilisticCircuit
+    ) -> ProbabilisticCircuit:
+        """
+        Ground via :attr:`GroundingMode.SAMPLED`, attaching a Monte-Carlo mixture over
+        the undetermined latents.
+
+        :param grounder: The grounder holding this exchangeable part's grounding
+            context.
+        :param circuit: The class circuit being extended; ``grounder`` mutates it in
+            place, so it is returned unchanged.
+        :return: The class circuit extended with the grounded exchangeable part.
+        """
+        grounder.attach_monte_carlo_mixture()
         return circuit
-
-    def _sample_undetermined_latents(
-        self,
-        conditioned_circuit: ProbabilisticCircuit,
-        undetermined_latents: SortedSet[Variable],
-    ) -> list[dict[Variable, Any]]:
-        """
-        Draw the distinct values of the undetermined latents to integrate over.
-
-        Samples ``monte_carlo_sample_count`` joint assignments of the undetermined
-        latents from the conditioned class circuit and deduplicates them, so that each
-        distinct value is grounded only once.
-
-        :param conditioned_circuit: The class circuit conditioned on the determined
-            statistics.
-        :param undetermined_latents: The latent variables that could not be determined
-            from the query.
-        :return: One value assignment per distinct sampled point, empty when there are
-            no undetermined latents to integrate out.
-        :raises InvalidMonteCarloSampleCountError: If there are undetermined latents but
-            the sample count is not positive.
-        :raises UndeterminedLatentsNotModeledError: If the conditioned class circuit
-            does not model the undetermined latents and thus cannot be sampled from.
-        """
-        if not undetermined_latents:
-            return []
-        if self.monte_carlo_sample_count < 1:
-            raise InvalidMonteCarloSampleCountError(self.monte_carlo_sample_count)
-        proposal = conditioned_circuit.marginal(undetermined_latents)
-        if proposal is None:
-            raise UndeterminedLatentsNotModeledError(list(undetermined_latents))
-        samples = proposal.sample(self.monte_carlo_sample_count)
-        index_of_variable = proposal.variable_to_index_map
-        unique_rows = {tuple(row) for row in samples.tolist()}
-        return [
-            {
-                variable: row[index_of_variable[variable]]
-                for variable in undetermined_latents
-            }
-            for row in (np.array(unique_row) for unique_row in unique_rows)
-        ]
-
-    @staticmethod
-    def _node_local_latent_log_likelihoods(
-        product_node: ProductUnit,
-        undetermined_latents: SortedSet[Variable],
-        latent_assignments: list[dict[Variable, Any]],
-    ) -> list[float]:
-        """
-        Log-likelihoods of latent assignments local to a mounting product node.
-
-        Marginalizes the subcircuit rooted at ``product_node`` to the undetermined
-        latents once, then evaluates every assignment in a single batched pass.
-
-        :param product_node: The mounting product node.
-        :param undetermined_latents: The latent variables sampled by Monte-Carlo.
-        :param latent_assignments: The sampled assignments of those latents.
-        :return: One log-likelihood per assignment, in input order.
-        """
-        subcircuit = ProbabilisticCircuit()
-        subcircuit.mount(product_node)
-        subcircuit.marginal_in_place(undetermined_latents)
-        index_of_variable = subcircuit.variable_to_index_map
-        events = np.full((len(latent_assignments), len(index_of_variable)), np.nan)
-        for row, assignment in enumerate(latent_assignments):
-            for variable, value in assignment.items():
-                events[row, index_of_variable[variable]] = value
-        return [
-            float(log_likelihood)
-            for log_likelihood in subcircuit.log_likelihood(events)
-        ]
-
-    @staticmethod
-    def _mount_instance(
-        circuit: ProbabilisticCircuit,
-        template: ExchangeableDistributionTemplate,
-        query_parts: list,
-        aggregation_statistics: dict[Variable, Any],
-    ) -> Unit:
-        """
-        Ground one exchangeable instance and mount it into the class circuit.
-
-        :param circuit: The working class circuit to mount into.
-        :param template: The fitted template for this relation.
-        :param query_parts: The query parts, one per child object.
-        :param aggregation_statistics: Statistics to condition the instance on.
-        :return: The root of the mounted instance, owned by ``circuit``.
-        """
-        grounded = template.ground(query_parts, aggregation_statistics)
-        node_index_map = circuit.mount(grounded.root)
-        return node_index_map[grounded.root.index]
-
-    @staticmethod
-    def _attach_single_exchangeable_instance(
-        circuit: ProbabilisticCircuit,
-        product_nodes_to_extend: list[ProductUnit],
-        template: ExchangeableDistributionTemplate,
-        query_parts: list,
-        aggregation_statistics: dict[Variable, Any],
-    ) -> None:
-        """
-        Attach one grounded exchangeable instance to every mounting product node.
-
-        The instance is mounted once and shared as a child of every node.
-
-        :param circuit: The working class circuit.
-        :param product_nodes_to_extend: The mounting product nodes.
-        :param template: The fitted template for this relation.
-        :param query_parts: The query parts, one per child object.
-        :param aggregation_statistics: Statistics to condition the instance on.
-        """
-        instance_root = RelationalProbabilisticCircuit._mount_instance(
-            circuit, template, query_parts, aggregation_statistics
-        )
-        for product_node in product_nodes_to_extend:
-            product_node.add_subcircuit(instance_root)
-
-    def _attach_monte_carlo_mixture(
-        self,
-        circuit: ProbabilisticCircuit,
-        product_nodes_to_extend: list[ProductUnit],
-        template: ExchangeableDistributionTemplate,
-        query_parts: list,
-        determined_statistics: dict[Variable, Any],
-        undetermined_latents: SortedSet[Variable],
-        sampled_assignments: list[dict[Variable, Any]],
-    ) -> None:
-        """
-        Attach a Monte-Carlo mixture over undetermined aggregation statistics.
-
-        For every sampled assignment one exchangeable instance is grounded on the
-        determined plus sampled statistics, and additionally carries its sampled latent
-        values back as point-valued variables instead of leaving them discarded. Each
-        mounting product node receives its own normalized sum unit over the instances,
-        weighted by the node-local likelihoods of the sampled values.
-
-        :param circuit: The working class circuit.
-        :param product_nodes_to_extend: The mounting product nodes.
-        :param template: The fitted template for this relation.
-        :param query_parts: The query parts, one per child object.
-        :param determined_statistics: Statistics determinable from the query.
-        :param undetermined_latents: The latents represented by Monte-Carlo sampling.
-        :param sampled_assignments: Distinct sampled values of the undetermined latents.
-        """
-        log_weights_per_node = [
-            self._node_local_latent_log_likelihoods(
-                product_node, undetermined_latents, sampled_assignments
-            )
-            for product_node in product_nodes_to_extend
-        ]
-        retained_variables = SortedSet(circuit.variables) - undetermined_latents
-        circuit.marginal_in_place(retained_variables)
-        mounted_roots = [
-            self._mount_instance_with_retained_latents(
-                circuit,
-                template,
-                query_parts,
-                determined_statistics,
-                assignment,
-                undetermined_latents,
-            )
-            for assignment in sampled_assignments
-        ]
-        for product_node, log_weights in zip(
-            product_nodes_to_extend, log_weights_per_node
-        ):
-            self._attach_mixture_to_node(
-                circuit, product_node, mounted_roots, log_weights
-            )
-
-    @staticmethod
-    def _mount_instance_with_retained_latents(
-        circuit: ProbabilisticCircuit,
-        template: ExchangeableDistributionTemplate,
-        query_parts: list,
-        determined_statistics: dict[Variable, Any],
-        assignment: dict[Variable, Any],
-        undetermined_latents: SortedSet[Variable],
-    ) -> Unit:
-        """
-        Ground one exchangeable instance and retain its sampled latents as variables.
-
-        Same grounding as :meth:`_mount_instance`, but each variable in
-        ``undetermined_latents`` is additionally mounted as a point-valued sibling leaf
-        at its sampled value, instead of leaving it to be marginalized away. Distinct
-        sampled values produce disjoint singleton supports by construction, so the
-        resulting mixture stays support-deterministic on the retained latents.
-
-        :param circuit: The working class circuit to mount into.
-        :param template: The fitted template for this relation.
-        :param query_parts: The query parts, one per child object.
-        :param determined_statistics: Statistics determinable from the query.
-        :param assignment: The sampled values of ``undetermined_latents`` for this
-            instance.
-        :param undetermined_latents: The latent variables to retain.
-        :return: The root of a product uniting the mounted instance with a point leaf
-            per retained latent, owned by ``circuit``.
-        """
-        instance_root = RelationalProbabilisticCircuit._mount_instance(
-            circuit, template, query_parts, {**determined_statistics, **assignment}
-        )
-        wrapper = ProductUnit(probabilistic_circuit=circuit)
-        wrapper.add_subcircuit(instance_root)
-        for variable in undetermined_latents:
-            wrapper.add_subcircuit(
-                leaf(make_dirac(variable, assignment[variable]), circuit)
-            )
-        return wrapper
-
-    def _attach_exact_partition_mixture(
-        self,
-        circuit: ProbabilisticCircuit,
-        product_nodes_to_extend: list[ProductUnit],
-        template: ExchangeableDistributionTemplate,
-        query_parts: list,
-        determined_statistics: dict[Variable, Any],
-        undetermined_latents: SortedSet[Variable],
-    ) -> None:
-        """
-        Attach a mixture over the undetermined latents' own exact partition.
-
-        Unlike Monte-Carlo sampling, this enumerates ``circuit``'s already-fitted,
-        exact partition over ``undetermined_latents`` (the branches of
-        ``circuit.marginal(undetermined_latents)``'s root) instead of drawing samples
-        from it: reproducible across calls, and covers every value the model learned
-        about rather than only whichever points got sampled. One exchangeable instance
-        is grounded per branch and retains that branch's full region -- not narrowed to
-        a point -- by mounting the branch itself alongside the grounded instance.
-
-        :param circuit: The working class circuit.
-        :param product_nodes_to_extend: The mounting product nodes.
-        :param template: The fitted template for this relation.
-        :param query_parts: The query parts, one per child object.
-        :param determined_statistics: Statistics determinable from the query.
-        :param undetermined_latents: The latents to retain via exact partition.
-        :raises UndeterminedLatentsNotModeledError: If ``circuit`` does not model
-            ``undetermined_latents`` and thus has no partition over them.
-        :raises UndeterminedLatentsNotPartitionedError: If that partition's branches
-            are not pairwise disjoint, so exact-partition grounding would not be
-            support-deterministic.
-        """
-        proposal = circuit.marginal(undetermined_latents)
-        if proposal is None:
-            raise UndeterminedLatentsNotModeledError(list(undetermined_latents))
-        if not self._undetermined_latents_partition_disjointly(proposal):
-            raise UndeterminedLatentsNotPartitionedError(list(undetermined_latents))
-
-        # the precondition just verified guarantees proposal.root is a SumUnit with at
-        # least two branches
-        branches = proposal.root.log_weighted_subcircuits
-        _ = proposal.support
-        branch_regions = [branch.result_of_current_query for _, branch in branches]
-
-        # each node's weights must be read off circuit before undetermined_latents are
-        # stripped from it below -- product_node stops modeling them afterward
-        log_weights_per_node = [
-            self._node_local_branch_log_probabilities(
-                product_node, undetermined_latents, branch_regions
-            )
-            for product_node in product_nodes_to_extend
-        ]
-
-        retained_variables = SortedSet(circuit.variables) - undetermined_latents
-        circuit.marginal_in_place(retained_variables)
-
-        mounted_roots = []
-        for _, latent_branch in branches:
-            representative_value = self._representative_value(
-                latent_branch, undetermined_latents
-            )
-            instance_root = self._mount_instance(
-                circuit,
-                template,
-                query_parts,
-                {**determined_statistics, **representative_value},
-            )
-            branch_root = ProductUnit(probabilistic_circuit=circuit)
-            branch_root.add_subcircuit(instance_root)
-            mounted_branch_nodes = circuit.mount(latent_branch)
-            branch_root.add_subcircuit(mounted_branch_nodes[latent_branch.index])
-            mounted_roots.append(branch_root)
-
-        for product_node, log_weights in zip(
-            product_nodes_to_extend, log_weights_per_node
-        ):
-            self._attach_mixture_to_node(
-                circuit, product_node, mounted_roots, log_weights
-            )
-
-    @staticmethod
-    def _node_local_branch_log_probabilities(
-        product_node: ProductUnit,
-        undetermined_latents: SortedSet[Variable],
-        branch_regions: list,
-    ) -> list[float]:
-        """
-        Log-probability of each partition branch's region, local to a mounting product
-        node.
-
-        Different product nodes can correlate ``undetermined_latents`` with the
-        variables that distinguish them, so each node's weights over the same global
-        partition must be computed from its own local marginal, mirroring
-        :meth:`_node_local_latent_log_likelihoods`'s per-node handling for the Monte-
-        Carlo mixture.
-
-        :param product_node: The mounting product node.
-        :param undetermined_latents: The latent variables the partition covers.
-        :param branch_regions: Each partition branch's own support region, in the same
-            order as the branches being weighted.
-        :return: One log-probability per region, in input order.
-        """
-        subcircuit = ProbabilisticCircuit()
-        subcircuit.mount(product_node)
-        subcircuit.marginal_in_place(undetermined_latents)
-        with np.errstate(divide="ignore"):
-            return [
-                float(np.log(subcircuit.probability(region)))
-                for region in branch_regions
-            ]
-
-    @staticmethod
-    def _undetermined_latents_partition_disjointly(
-        proposal: ProbabilisticCircuit,
-    ) -> bool:
-        """
-        Check whether ``proposal`` is a genuine, pairwise-disjoint partition over the
-        undetermined latents: a mixture of at least two branches, no two of which
-        overlap.
-
-        ``JointProbabilityTree`` does not retain which variables it actually split on
-        after fitting, so this checks the invariant exact-partition grounding actually
-        needs directly on the marginalized circuit, rather than trying to infer it from
-        fitting-time bookkeeping the tree does not expose. A single, undifferentiated
-        branch fails this precondition rather than trivially passing it: grounding
-        would still retain the latents as a real distribution, but every exchangeable
-        instance would be grounded from the same representative point regardless of
-        which latent value the region actually corresponds to, silently discarding any
-        correlation between the latents and the rest of the circuit.
-
-        :param proposal: ``circuit`` marginalized down to exactly the undetermined
-            latents.
-        :return:``True`` only if ``proposal``'s root is a mixture of at least two
-            branches, every pair of which has non-overlapping support.
-        """
-        root = proposal.root
-        if not isinstance(root, SumUnit) or len(root.subcircuits) < 2:
-            return False
-        _ = proposal.support
-        branch_supports = [child.result_of_current_query for child in root.subcircuits]
-        return all(
-            left.intersection_with(right).is_empty()
-            for left, right in itertools.combinations(branch_supports, 2)
-        )
-
-    @staticmethod
-    def _representative_value(
-        latent_branch: Unit, undetermined_latents: SortedSet[Variable]
-    ) -> dict[Variable, Any]:
-        """
-        Extract one concrete point per undetermined latent from a partition branch.
-
-        Uses each leaf's own mode, collapsed to a single point of that mode region.
-        Any point within the branch's support would do for grounding purposes here,
-        since the branch's actual probability mass is retained separately by mounting
-        the branch itself, not narrowed by this choice. A single point is required
-        because conditioning a leaf's distribution on a whole region -- rather than one
-        point -- is not supported by :meth:`~probabilistic_model.distributions.distributions.ContinuousDistribution.log_conditional`,
-        which every leaf here resolves to (including :class:`IntegerDistribution`,
-        through its continuous base).
-
-        :param latent_branch: One branch of ``undetermined_latents``' exact partition.
-        :param undetermined_latents: The latent variables to extract a value for.
-        :return: One conditioning point per variable in ``undetermined_latents``.
-        """
-        values = {}
-        for leaf_node in latent_branch.leaves:
-            if leaf_node.variable not in undetermined_latents:
-                continue
-            mode, _ = leaf_node.distribution.univariate_log_mode()
-            values[leaf_node.variable] = (
-                mode.simple_sets[0].lower
-                if isinstance(mode, Interval)
-                else next(iter(mode))
-            )
-        return values
-
-    @staticmethod
-    def _attach_mixture_to_node(
-        circuit: ProbabilisticCircuit,
-        product_node: ProductUnit,
-        instance_roots: list[Unit],
-        log_weights: list[float],
-    ) -> None:
-        """
-        Attach a normalized sum unit over exchangeable instances to one node.
-
-        Instances whose node-local likelihood is zero are skipped. The instances are
-        already mounted in ``circuit`` and shared across all mounting nodes; only the
-        weighted sum-unit edges differ per node.
-
-        :param circuit: The working class circuit.
-        :param product_node: The mounting product node to extend.
-        :param instance_roots: The roots of the mounted exchangeable instances.
-        :param log_weights: The node-local log-likelihood weight of each instance.
-        """
-        weighted_instances = [
-            (instance_root, log_weight)
-            for instance_root, log_weight in zip(instance_roots, log_weights)
-            if log_weight > -np.inf
-        ]
-        if not weighted_instances:
-            weighted_instances = [(instance_roots[0], 0.0)]
-        sum_unit = SumUnit(probabilistic_circuit=circuit)
-        product_node.add_subcircuit(sum_unit)
-        for instance_root, log_weight in weighted_instances:
-            sum_unit.add_subcircuit(instance_root, log_weight)
-        sum_unit.normalize()

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/relational/rspn.py
@@ -295,9 +295,8 @@ class ExchangeablePartGrounder:
         # the precondition just verified guarantees proposal.root is a SumUnit with at
         # least two branches
         branches = proposal.root.log_weighted_subcircuits
-        # side-effecting traversal: populates result_of_current_query on every node,
-        # which branch_regions below reads off; the returned event itself is unused
-        _ = proposal.support
+        # _undetermined_latents_partition_disjointly already called proposal.support
+        # above, caching each branch's region on it as result_of_current_query
         branch_regions = [branch.result_of_current_query for _, branch in branches]
 
         # each node's weights must be read off circuit before undetermined_latents are

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
@@ -857,9 +857,12 @@ class ProductUnit(InnerUnit):
                 # type hinting
                 subcircuit: Self
 
-                # mount the children of that circuit directly
+                # mount the children of that circuit directly onto this one
                 for sub_subcircuit in subcircuit.subcircuits:
-                    subcircuit.add_subcircuit(sub_subcircuit)
+                    self.add_subcircuit(sub_subcircuit)
+
+                # remove the now-redundant nested product unit
+                self.probabilistic_circuit.remove_node(subcircuit)
 
     def sample(self, *args, **kwargs):
         """

--- a/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
+++ b/probabilistic_model/src/probabilistic_model/probabilistic_circuit/rx/probabilistic_circuit.py
@@ -286,7 +286,7 @@ class LeafUnit(Unit):
 
     @property
     def leaves(self) -> List[LeafUnit]:
-        return []
+        return [self]
 
     def log_likelihood(self, events: npt.NDArray):
         self.result_of_current_query = self.distribution.log_likelihood(events)
@@ -560,7 +560,7 @@ class SumUnit(InnerUnit):
     def mount_with_interaction_terms(
         self, other: Self, interaction_model: ProbabilisticModel
     ):
-        """
+        r"""
         Create a distribution that factorizes as follows:
 
         .. math::

--- a/test/krrood_test/dataset/example_classes.py
+++ b/test/krrood_test/dataset/example_classes.py
@@ -896,6 +896,69 @@ class TestExPartsAggregations(SceneObjectAggregationBase[TestExParts]):
         return cou
 
 
+# %% Relational causal experiment (skill-confounded grasp attempts)
+
+
+@dataclass
+class GraspAttempt:
+    """
+    A single grasp attempt, whose arm position and outcome may be confounded by
+    the robot's shared skill level.
+    """
+
+    arm: float
+    """
+    The arm's position at the time of this attempt.
+    """
+
+    grasped: bool
+    """
+    Whether this attempt succeeded.
+    """
+
+
+@dataclass
+class PickingRobot:
+    """
+    A robot performing a series of grasp attempts, with a skill level shared
+    across every attempt it makes.
+    """
+
+    skill: float
+    """
+    The robot's skill level, generated independently of any single attempt.
+    """
+
+    attempts: List[GraspAttempt]
+    """
+    The robot's grasp attempts.
+    """
+
+
+@dataclass
+class PickingRobotAggregations(AggregationStatistic[PickingRobot]):
+    """
+    Aggregation statistics for :class:`PickingRobot` over its ``attempts`` field.
+    """
+
+    @aggregation_statistic("attempts")
+    def success_count(self) -> int:
+        """
+        Count of successful grasp attempts.
+        """
+        grasped_var = variable(GraspAttempt, self.instance.attempts).grasped
+        [cou] = entity(count_range(grasped_var)).where(grasped_var == True).tolist()
+        return cou
+
+    @aggregation_statistic("attempts")
+    def total_count(self) -> int:
+        """
+        Total number of grasp attempts.
+        """
+        [cou] = count(variable(GraspAttempt, self.instance.attempts)).tolist()
+        return cou
+
+
 @dataclass
 class ExampleInt:
     attribute: int

--- a/test/krrood_test/dataset/example_classes.py
+++ b/test/krrood_test/dataset/example_classes.py
@@ -27,6 +27,7 @@ from krrood.ormatic.data_access_objects.alternative_mappings import (
 )
 from krrood.symbol_graph.symbol_graph import Symbol
 from krrood import logger
+
 try:
     from random_events.interval import Bound, SimpleInterval
     from krrood.parametrization.feature_extraction.aggregations import (
@@ -36,8 +37,9 @@ try:
 except ImportError as e:
     # Was added to allow this to work on Windows which random_events does not support.
     logger.debug(f"Could not import random_events: {e}")
-    class AggregationStatistic(MockedClass, Generic[T]):
-        ...
+
+    class AggregationStatistic(MockedClass, Generic[T]): ...
+
     aggregation_statistic = lambda *args: lambda *args2: args2
     Bound = NoneType
     SimpleInterval = NoneType
@@ -947,16 +949,16 @@ class PickingRobotAggregations(AggregationStatistic[PickingRobot]):
         Count of successful grasp attempts.
         """
         grasped_var = variable(GraspAttempt, self.instance.attempts).grasped
-        [cou] = entity(count_range(grasped_var)).where(grasped_var == True).tolist()
-        return cou
+        [result] = entity(count_range(grasped_var)).where(grasped_var == True).tolist()
+        return result
 
     @aggregation_statistic("attempts")
     def total_count(self) -> int:
         """
         Total number of grasp attempts.
         """
-        [cou] = count(variable(GraspAttempt, self.instance.attempts)).tolist()
-        return cou
+        [result] = count(variable(GraspAttempt, self.instance.attempts)).tolist()
+        return result
 
 
 @dataclass

--- a/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
+++ b/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
@@ -1,7 +1,7 @@
 """
 Tests for ``RelationalCircuitRegistry``'s causal query support: registering relational
-grounded variables (retained via ``GroundingMode.CAUSAL_SAMPLED``/``CAUSAL_EXACT``) as
-causes or effects through the same ``cause``/``causes_effect`` EQL machinery
+grounded variables (retained via ``GroundingMode.SAMPLED``/``EXACT``) as causes or
+effects through the same ``cause``/``causes_effect`` EQL machinery
 ``CausalCircuitRegistry`` already supports for static, non-relational circuits.
 """
 
@@ -94,20 +94,20 @@ def test_non_causal_query_is_unaffected(rpc):
     assert not isinstance(result, CausalCircuit)
 
 
-def test_causal_grounding_mode_field_is_actually_used(rpc):
+def test_grounding_mode_field_is_actually_used(rpc):
     """
-    Regression test for the ``causal_grounding_mode`` field: overriding it to
-    ``GroundingMode.CAUSAL_EXACT`` must actually change grounding behaviour, not be
-    silently ignored in favour of a hardcoded ``CAUSAL_SAMPLED``.
+    Regression test for the ``grounding_mode`` field: overriding it to
+    ``GroundingMode.EXACT`` must actually change grounding behaviour, not be silently
+    ignored in favour of a hardcoded ``SAMPLED``.
 
     Both modes retain the latent as a variable and ground a valid circuit, but only
     exact-partition grounding (or its fallback, which still retains the latent) is
-    reproducible across calls under different random state -- exactly what
-    ``CAUSAL_SAMPLED`` alone is not guaranteed to be.
+    reproducible across calls under different random state -- exactly what ``SAMPLED``
+    alone is not guaranteed to be.
     """
     registry = RelationalCircuitRegistry(
         relational_probabilistic_circuit=rpc,
-        causal_grounding_mode=GroundingMode.CAUSAL_EXACT,
+        grounding_mode=GroundingMode.EXACT,
     )
 
     np.random.seed(0)

--- a/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
+++ b/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
@@ -10,16 +10,12 @@ from __future__ import annotations
 import numpy as np
 
 from krrood.entity_query_language.factories import a, cause
-from krrood.ormatic.data_access_objects.helper import to_dao
 from krrood.parametrization.model_registries import RelationalCircuitRegistry
 from krrood.parametrization.parameterizer import UnderspecifiedParameters
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
 )
-from probabilistic_model.probabilistic_circuit.relational.rspn import (
-    RelationalProbabilisticCircuit,
-)
-from ...dataset import ormatic_interface  # type: ignore
+from probabilistic_model.probabilistic_circuit.relational.rspn import GroundingMode
 from ...dataset.example_classes import (
     KRROODOrientation,
     KRROODPosition,
@@ -27,28 +23,7 @@ from ...dataset.example_classes import (
     SceneObjectType,
     SceneRoom,
 )
-
-
-def _fitted_scene_room_model() -> RelationalProbabilisticCircuit:
-    objects = [
-        SceneObject(type=SceneObjectType.TABLE),
-        SceneObject(type=SceneObjectType.CHAIR),
-        SceneObject(type=SceneObjectType.CHAIR),
-        SceneObject(type=SceneObjectType.CHAIR),
-    ]
-    room = SceneRoom(
-        position=KRROODPosition(x=2.0, y=1.0, z=0.0),
-        orientation=KRROODOrientation(x=0.0, y=0.0, z=0.0, w=1.0),
-        objects=objects[:3],
-    )
-    room2 = SceneRoom(
-        position=KRROODPosition(x=4.0, y=3.0, z=0.0),
-        orientation=KRROODOrientation(x=0.0, y=0.0, z=0.0, w=1.0),
-        objects=objects,
-    )
-    model = RelationalProbabilisticCircuit(SceneRoom)
-    model.fit([to_dao(room), to_dao(room2)])
-    return model
+from ...test_feature_extraction.test_rspns import rpc, scenario  # noqa: F401
 
 
 def _cause_and_effect_query():
@@ -61,14 +36,13 @@ def _cause_and_effect_query():
     return query
 
 
-def test_registry_returns_a_causal_circuit_for_a_cause_query():
+def test_registry_returns_a_causal_circuit_for_a_cause_query(rpc):
     """
     A relational Match query with cause/causes_effect markers must resolve to a
     CausalCircuit, not the plain grounded circuit DoRequiresCausalCircuitModel would
     otherwise reject.
     """
-    model = _fitted_scene_room_model()
-    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=rpc)
     parameters = UnderspecifiedParameters(_cause_and_effect_query())
 
     np.random.seed(0)
@@ -77,9 +51,8 @@ def test_registry_returns_a_causal_circuit_for_a_cause_query():
     assert isinstance(result, CausalCircuit)
 
 
-def test_registered_causal_circuit_has_the_queried_cause_and_effect_variables():
-    model = _fitted_scene_room_model()
-    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+def test_registered_causal_circuit_has_the_queried_cause_and_effect_variables(rpc):
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=rpc)
     parameters = UnderspecifiedParameters(_cause_and_effect_query())
 
     np.random.seed(0)
@@ -89,9 +62,8 @@ def test_registered_causal_circuit_has_the_queried_cause_and_effect_variables():
     assert [v.name for v in result.effect_variables] == ["SceneRoom.objects[0].type"]
 
 
-def test_registered_causal_circuit_supports_backdoor_adjustment():
-    model = _fitted_scene_room_model()
-    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+def test_registered_causal_circuit_supports_backdoor_adjustment(rpc):
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=rpc)
     parameters = UnderspecifiedParameters(_cause_and_effect_query())
 
     np.random.seed(0)
@@ -104,13 +76,12 @@ def test_registered_causal_circuit_supports_backdoor_adjustment():
     assert interventional_circuit.is_valid()
 
 
-def test_non_causal_query_is_unaffected():
+def test_non_causal_query_is_unaffected(rpc):
     """
     A plain (non-cause) relational query must still return the grounded circuit
     directly, exactly as before this registry gained causal support.
     """
-    model = _fitted_scene_room_model()
-    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=rpc)
     query = a(SceneRoom)(
         position=a(KRROODPosition)(x=..., y=..., z=...),
         orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
@@ -121,3 +92,30 @@ def test_non_causal_query_is_unaffected():
     result = registry.get_model(parameters)
 
     assert not isinstance(result, CausalCircuit)
+
+
+def test_causal_grounding_mode_field_is_actually_used(rpc):
+    """
+    Regression test for the ``causal_grounding_mode`` field: overriding it to
+    ``GroundingMode.CAUSAL_EXACT`` must actually change grounding behaviour, not be
+    silently ignored in favour of a hardcoded ``CAUSAL_SAMPLED``.
+
+    Both modes retain the latent as a variable and ground a valid circuit, but only
+    exact-partition grounding (or its fallback, which still retains the latent) is
+    reproducible across calls under different random state -- exactly what
+    ``CAUSAL_SAMPLED`` alone is not guaranteed to be.
+    """
+    registry = RelationalCircuitRegistry(
+        relational_probabilistic_circuit=rpc,
+        causal_grounding_mode=GroundingMode.CAUSAL_EXACT,
+    )
+
+    np.random.seed(0)
+    first = registry.get_model(UnderspecifiedParameters(_cause_and_effect_query()))
+    np.random.seed(123)
+    second = registry.get_model(UnderspecifiedParameters(_cause_and_effect_query()))
+
+    assert isinstance(first, CausalCircuit)
+    assert {v.name for v in first.probabilistic_circuit.variables} == {
+        v.name for v in second.probabilistic_circuit.variables
+    }

--- a/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
+++ b/test/krrood_test/test_eql/test_causal/test_relational_circuit_registry_causal.py
@@ -1,0 +1,123 @@
+"""
+Tests for ``RelationalCircuitRegistry``'s causal query support: registering relational
+grounded variables (retained via ``GroundingMode.CAUSAL_SAMPLED``/``CAUSAL_EXACT``) as
+causes or effects through the same ``cause``/``causes_effect`` EQL machinery
+``CausalCircuitRegistry`` already supports for static, non-relational circuits.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from krrood.entity_query_language.factories import a, cause
+from krrood.ormatic.data_access_objects.helper import to_dao
+from krrood.parametrization.model_registries import RelationalCircuitRegistry
+from krrood.parametrization.parameterizer import UnderspecifiedParameters
+from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
+    CausalCircuit,
+)
+from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    RelationalProbabilisticCircuit,
+)
+from ...dataset import ormatic_interface  # type: ignore
+from ...dataset.example_classes import (
+    KRROODOrientation,
+    KRROODPosition,
+    SceneObject,
+    SceneObjectType,
+    SceneRoom,
+)
+
+
+def _fitted_scene_room_model() -> RelationalProbabilisticCircuit:
+    objects = [
+        SceneObject(type=SceneObjectType.TABLE),
+        SceneObject(type=SceneObjectType.CHAIR),
+        SceneObject(type=SceneObjectType.CHAIR),
+        SceneObject(type=SceneObjectType.CHAIR),
+    ]
+    room = SceneRoom(
+        position=KRROODPosition(x=2.0, y=1.0, z=0.0),
+        orientation=KRROODOrientation(x=0.0, y=0.0, z=0.0, w=1.0),
+        objects=objects[:3],
+    )
+    room2 = SceneRoom(
+        position=KRROODPosition(x=4.0, y=3.0, z=0.0),
+        orientation=KRROODOrientation(x=0.0, y=0.0, z=0.0, w=1.0),
+        objects=objects,
+    )
+    model = RelationalProbabilisticCircuit(SceneRoom)
+    model.fit([to_dao(room), to_dao(room2)])
+    return model
+
+
+def _cause_and_effect_query():
+    query = a(SceneRoom)(
+        position=a(KRROODPosition)(x=cause, y=..., z=...),
+        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
+        objects=[a(SceneObject)(type=...) for _ in range(4)],
+    )
+    query.causes_effect(query.variable.objects[0].type == SceneObjectType.CHAIR)
+    return query
+
+
+def test_registry_returns_a_causal_circuit_for_a_cause_query():
+    """
+    A relational Match query with cause/causes_effect markers must resolve to a
+    CausalCircuit, not the plain grounded circuit DoRequiresCausalCircuitModel would
+    otherwise reject.
+    """
+    model = _fitted_scene_room_model()
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    parameters = UnderspecifiedParameters(_cause_and_effect_query())
+
+    np.random.seed(0)
+    result = registry.get_model(parameters)
+
+    assert isinstance(result, CausalCircuit)
+
+
+def test_registered_causal_circuit_has_the_queried_cause_and_effect_variables():
+    model = _fitted_scene_room_model()
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    parameters = UnderspecifiedParameters(_cause_and_effect_query())
+
+    np.random.seed(0)
+    result = registry.get_model(parameters)
+
+    assert [v.name for v in result.causal_variables] == ["SceneRoom.position.x"]
+    assert [v.name for v in result.effect_variables] == ["SceneRoom.objects[0].type"]
+
+
+def test_registered_causal_circuit_supports_backdoor_adjustment():
+    model = _fitted_scene_room_model()
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    parameters = UnderspecifiedParameters(_cause_and_effect_query())
+
+    np.random.seed(0)
+    result = registry.get_model(parameters)
+
+    interventional_circuit = result.backdoor_adjustment(
+        cause_variable=result.causal_variables[0],
+        effect_variable=result.effect_variables[0],
+    )
+    assert interventional_circuit.is_valid()
+
+
+def test_non_causal_query_is_unaffected():
+    """
+    A plain (non-cause) relational query must still return the grounded circuit
+    directly, exactly as before this registry gained causal support.
+    """
+    model = _fitted_scene_room_model()
+    registry = RelationalCircuitRegistry(relational_probabilistic_circuit=model)
+    query = a(SceneRoom)(
+        position=a(KRROODPosition)(x=..., y=..., z=...),
+        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
+        objects=[a(SceneObject)(type=...) for _ in range(4)],
+    )
+    parameters = UnderspecifiedParameters(query)
+
+    result = registry.get_model(parameters)
+
+    assert not isinstance(result, CausalCircuit)

--- a/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
@@ -1,23 +1,18 @@
 """
-Experiment: can :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.RelationalProbabilisticCircuit`
-ground a query whose backdoor-adjustment set is a confounder shared across an
-exchangeable relation, so that the result could be wrapped in
-:class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
-for relational ``do()`` reasoning?
+Grounding a scalar confounder alongside an exchangeable relation.
 
 The scenario: a :class:`~test.krrood_test.dataset.example_classes.PickingRobot` has a
 ``skill`` level that confounds its :class:`~test.krrood_test.dataset.example_classes.GraspAttempt`
 attempts — skill affects both the arm position chosen (the cause) and the grasp
 outcome (the effect) directly, so the naive (non-adjusted) correlation between arm and
-outcome is biased and only backdoor-adjusting for skill recovers the true causal effect.
+outcome is biased and only backdoor-adjusting for skill recovers the true causal
+effect. This is the shape any relational causal query needs before a
+:class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
+could be built on top of it: a class-level scalar alongside an exchangeable relation
+whose own aggregation statistics may or may not be determined by the query.
 
-Grounding this relation — the step every relational causal query would need before a
-:class:`CausalCircuit` could even be built — never reaches the causal machinery at all:
-the resulting circuit is either structurally disconnected or the grounding call itself
-raises, in both cases from ``RelationalProbabilisticCircuit.ground()``'s own
-node-mounting logic. A relational ``do()`` query is therefore not currently possible
-through this API, independently of any further question about backdoor-criterion
-validity.
+These tests exercise ``RelationalProbabilisticCircuit.ground()`` for that shape,
+independently of any further question about backdoor-criterion validity.
 """
 
 from __future__ import annotations
@@ -56,7 +51,9 @@ def _sample_confounded_robot(rng: np.random.Generator) -> PickingRobot:
     for _ in range(ATTEMPTS_PER_ROBOT):
         arm = 1.0 if rng.random() < arm_probability else 0.0
         grasp_probability = 0.2 + 0.5 * arm + 0.3 * skill
-        attempts.append(GraspAttempt(arm=arm, grasped=bool(rng.random() < grasp_probability)))
+        attempts.append(
+            GraspAttempt(arm=arm, grasped=bool(rng.random() < grasp_probability))
+        )
     return PickingRobot(skill=skill, attempts=attempts)
 
 
@@ -67,6 +64,14 @@ def confounded_model() -> RelationalProbabilisticCircuit:
     model = RelationalProbabilisticCircuit(PickingRobot)
     model.fit([to_dao(robot) for robot in robots])
     return model
+
+
+def _attempt_variable_names(count: int) -> set[str]:
+    names = set()
+    for index in range(count):
+        names.add(f"PickingRobot.attempts[{index}].arm")
+        names.add(f"PickingRobot.attempts[{index}].grasped")
+    return names
 
 
 # %% the class-level circuit does capture the confound (sanity check on the fit itself)
@@ -80,17 +85,16 @@ def test_class_circuit_models_both_skill_and_the_aggregate_it_confounds(
     assert "PickingRobotAggregations.success_count()" in names
 
 
-# %% grounding breaks before a CausalCircuit could ever be built
+# %% grounding a scalar confounder alongside a fully determined exchangeable relation
 
 
-def test_grounding_a_fully_observed_query_yields_a_disconnected_circuit(
+def test_grounding_a_fully_observed_query_yields_one_connected_circuit(
     confounded_model,
 ):
     """
     A backdoor-adjustment query needs the adjustment set concrete, so every attempt is
-    given a concrete arm/grasped value here (making ``success_count`` fully
-    determined, avoiding the Monte-Carlo integration path). ``ground()`` does not
-    raise, but the circuit it returns has two disconnected roots instead of one.
+    given a concrete arm/grasped value here (making ``success_count`` fully determined,
+    avoiding the Monte-Carlo integration path).
     """
     query = a(PickingRobot)(
         skill=...,
@@ -105,23 +109,41 @@ def test_grounding_a_fully_observed_query_yields_a_disconnected_circuit(
 
     grounded = confounded_model.ground(query)
 
-    with pytest.raises(ValueError, match="More than one root"):
-        grounded.variables
+    assert grounded.is_valid()
+    names = {v.name for v in grounded.variables}
+    assert names == _attempt_variable_names(ATTEMPTS_PER_ROBOT) | {
+        "PickingRobot.skill",
+        "PickingRobotAggregations.success_count()",
+        "PickingRobotAggregations.total_count()",
+    }
 
 
-def test_grounding_an_underspecified_query_raises_immediately(confounded_model):
+# %% grounding a scalar confounder alongside an underspecified exchangeable relation
+
+
+def test_grounding_an_underspecified_query_yields_one_connected_circuit(
+    confounded_model,
+):
     """
-    The Monte-Carlo path (every attempt field left underspecified) is the pattern the
-    RSPN test suite already exercises successfully for a richer class circuit
-    (``SceneRoom``). For this relation, mounting a sampled exchangeable instance onto
-    the conditioned class circuit fails outright.
+    Every attempt field is left underspecified, so ``success_count`` cannot be
+    determined from the query and must be integrated out via the Monte-Carlo path, while
+    ``total_count`` is determined directly from the query's attempt count.
     """
     query = a(PickingRobot)(
         skill=...,
-        attempts=[a(GraspAttempt)(arm=..., grasped=...) for _ in range(ATTEMPTS_PER_ROBOT)],
+        attempts=[
+            a(GraspAttempt)(arm=..., grasped=...) for _ in range(ATTEMPTS_PER_ROBOT)
+        ],
     )
     query.resolve()
 
     np.random.seed(0)
-    with pytest.raises(AttributeError, match="add_edge"):
-        confounded_model.ground(query)
+    grounded = confounded_model.ground(query)
+
+    assert grounded.is_valid()
+    names = {v.name for v in grounded.variables}
+    assert names == _attempt_variable_names(ATTEMPTS_PER_ROBOT) | {
+        "PickingRobot.skill",
+        "PickingRobotAggregations.total_count()",
+    }
+    assert "PickingRobotAggregations.success_count()" not in names

--- a/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
@@ -1,0 +1,127 @@
+"""
+Experiment: can :class:`~probabilistic_model.probabilistic_circuit.relational.rspn.RelationalProbabilisticCircuit`
+ground a query whose backdoor-adjustment set is a confounder shared across an
+exchangeable relation, so that the result could be wrapped in
+:class:`~probabilistic_model.probabilistic_circuit.causal.causal_circuit.CausalCircuit`
+for relational ``do()`` reasoning?
+
+The scenario: a :class:`~test.krrood_test.dataset.example_classes.PickingRobot` has a
+``skill`` level that confounds its :class:`~test.krrood_test.dataset.example_classes.GraspAttempt`
+attempts — skill affects both the arm position chosen (the cause) and the grasp
+outcome (the effect) directly, so the naive (non-adjusted) correlation between arm and
+outcome is biased and only backdoor-adjusting for skill recovers the true causal effect.
+
+Grounding this relation — the step every relational causal query would need before a
+:class:`CausalCircuit` could even be built — never reaches the causal machinery at all:
+the resulting circuit is either structurally disconnected or the grounding call itself
+raises, in both cases from ``RelationalProbabilisticCircuit.ground()``'s own
+node-mounting logic. A relational ``do()`` query is therefore not currently possible
+through this API, independently of any further question about backdoor-criterion
+validity.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from krrood.entity_query_language.factories import a
+from krrood.ormatic.data_access_objects.helper import to_dao
+from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    RelationalProbabilisticCircuit,
+)
+from ..dataset import ormatic_interface  # type: ignore
+from ..dataset.example_classes import GraspAttempt, PickingRobot
+
+ATTEMPTS_PER_ROBOT = 4
+TRAINING_ROBOT_COUNT = 400
+
+
+# %% confounded synthetic population
+#
+# skill in {0.0, 1.0}, P(skill=1) = 0.5
+# arm in {0.0, 1.0}: P(arm=1|skill=1)=0.9, P(arm=1|skill=0)=0.1   -- skill confounds arm
+# grasped ~ Bernoulli(0.2 + 0.5*arm + 0.3*skill)                  -- arm causes grasped,
+#                                                                     skill also affects
+#                                                                     it directly
+#
+# True P(grasped=True | do(arm=1)) = 0.5*0.7 + 0.5*1.0 = 0.85
+# Naive P(grasped=True | arm=1), uncorrected for skill, is biased toward ~0.97.
+
+
+def _sample_confounded_robot(rng: np.random.Generator) -> PickingRobot:
+    skill = 1.0 if rng.random() < 0.5 else 0.0
+    arm_probability = 0.9 if skill == 1.0 else 0.1
+    attempts = []
+    for _ in range(ATTEMPTS_PER_ROBOT):
+        arm = 1.0 if rng.random() < arm_probability else 0.0
+        grasp_probability = 0.2 + 0.5 * arm + 0.3 * skill
+        attempts.append(GraspAttempt(arm=arm, grasped=bool(rng.random() < grasp_probability)))
+    return PickingRobot(skill=skill, attempts=attempts)
+
+
+@pytest.fixture
+def confounded_model() -> RelationalProbabilisticCircuit:
+    rng = np.random.default_rng(0)
+    robots = [_sample_confounded_robot(rng) for _ in range(TRAINING_ROBOT_COUNT)]
+    model = RelationalProbabilisticCircuit(PickingRobot)
+    model.fit([to_dao(robot) for robot in robots])
+    return model
+
+
+# %% the class-level circuit does capture the confound (sanity check on the fit itself)
+
+
+def test_class_circuit_models_both_skill_and_the_aggregate_it_confounds(
+    confounded_model,
+):
+    names = {v.name for v in confounded_model.class_probabilistic_circuit.variables}
+    assert "PickingRobot.skill" in names
+    assert "PickingRobotAggregations.success_count()" in names
+
+
+# %% grounding breaks before a CausalCircuit could ever be built
+
+
+def test_grounding_a_fully_observed_query_yields_a_disconnected_circuit(
+    confounded_model,
+):
+    """
+    A backdoor-adjustment query needs the adjustment set concrete, so every attempt is
+    given a concrete arm/grasped value here (making ``success_count`` fully
+    determined, avoiding the Monte-Carlo integration path). ``ground()`` does not
+    raise, but the circuit it returns has two disconnected roots instead of one.
+    """
+    query = a(PickingRobot)(
+        skill=...,
+        attempts=[
+            a(GraspAttempt)(arm=1.0, grasped=True),
+            a(GraspAttempt)(arm=1.0, grasped=True),
+            a(GraspAttempt)(arm=1.0, grasped=False),
+            a(GraspAttempt)(arm=0.0, grasped=True),
+        ],
+    )
+    query.resolve()
+
+    grounded = confounded_model.ground(query)
+
+    with pytest.raises(ValueError, match="More than one root"):
+        grounded.variables
+
+
+def test_grounding_an_underspecified_query_raises_immediately(confounded_model):
+    """
+    The Monte-Carlo path (every attempt field left underspecified) is the pattern the
+    RSPN test suite already exercises successfully for a richer class circuit
+    (``SceneRoom``). For this relation, mounting a sampled exchangeable instance onto
+    the conditioned class circuit fails outright.
+    """
+    query = a(PickingRobot)(
+        skill=...,
+        attempts=[a(GraspAttempt)(arm=..., grasped=...) for _ in range(ATTEMPTS_PER_ROBOT)],
+    )
+    query.resolve()
+
+    np.random.seed(0)
+    with pytest.raises(AttributeError, match="add_edge"):
+        confounded_model.ground(query)

--- a/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_backdoor_experiment.py
@@ -126,8 +126,10 @@ def test_grounding_an_underspecified_query_yields_one_connected_circuit(
 ):
     """
     Every attempt field is left underspecified, so ``success_count`` cannot be
-    determined from the query and must be integrated out via the Monte-Carlo path, while
-    ``total_count`` is determined directly from the query's attempt count.
+    determined from the query and is retained via the default
+    :attr:`~probabilistic_model.probabilistic_circuit.relational.rspn.GroundingMode.SAMPLED`
+    Monte-Carlo path rather than integrated out, while ``total_count`` is determined
+    directly from the query's attempt count.
     """
     query = a(PickingRobot)(
         skill=...,
@@ -145,5 +147,5 @@ def test_grounding_an_underspecified_query_yields_one_connected_circuit(
     assert names == _attempt_variable_names(ATTEMPTS_PER_ROBOT) | {
         "PickingRobot.skill",
         "PickingRobotAggregations.total_count()",
+        "PickingRobotAggregations.success_count()",
     }
-    assert "PickingRobotAggregations.success_count()" not in names

--- a/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
@@ -12,7 +12,7 @@ from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
 )
 from probabilistic_model.probabilistic_circuit.relational.causal import (
-    RelationalCausalCircuit,
+    ground_relational_causal_circuit,
     resolve_variable,
 )
 from probabilistic_model.probabilistic_circuit.relational.exceptions import (
@@ -64,14 +64,12 @@ def test_resolve_variable_raises_for_ambiguous_suffix(rpc, room_query_4):
         resolve_variable(grounded, "type")
 
 
-# %% RelationalCausalCircuit.from_relational_probabilistic_circuit
+# %% ground_relational_causal_circuit
 
 
-def test_from_relational_probabilistic_circuit_returns_a_causal_circuit(
-    rpc, room_query_4
-):
+def test_ground_relational_causal_circuit_returns_a_causal_circuit(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+    causal_circuit = ground_relational_causal_circuit(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -80,9 +78,7 @@ def test_from_relational_probabilistic_circuit_returns_a_causal_circuit(
     assert isinstance(causal_circuit, CausalCircuit)
 
 
-def test_from_relational_probabilistic_circuit_accepts_resolved_variables(
-    rpc, room_query_4
-):
+def test_ground_relational_causal_circuit_accepts_resolved_variables(rpc, room_query_4):
     """
     Callers may pass already-resolved Variable objects instead of path strings.
     """
@@ -92,7 +88,7 @@ def test_from_relational_probabilistic_circuit_accepts_resolved_variables(
     object_type_variable = resolve_variable(grounded, "objects[0].type")
 
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+    causal_circuit = ground_relational_causal_circuit(
         rpc,
         room_query_4,
         causal_variables=[chair_count_variable],
@@ -101,16 +97,14 @@ def test_from_relational_probabilistic_circuit_accepts_resolved_variables(
     assert isinstance(causal_circuit, CausalCircuit)
 
 
-def test_from_relational_probabilistic_circuit_defaults_to_causal_sampled(
-    rpc, room_query_4
-):
+def test_ground_relational_causal_circuit_defaults_to_causal_sampled(rpc, room_query_4):
     """
     The default grounding mode must retain undetermined latents (unlike
-    GroundingMode.PREDICTIVE), since that is the entire point of building a
-    RelationalCausalCircuit around one.
+    GroundingMode.PREDICTIVE), since that is the entire point of grounding a
+    CausalCircuit this way.
     """
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+    causal_circuit = ground_relational_causal_circuit(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -120,11 +114,9 @@ def test_from_relational_probabilistic_circuit_defaults_to_causal_sampled(
     assert "SceneRoomAggregations.chair_count()" in names
 
 
-def test_from_relational_probabilistic_circuit_backdoor_adjustment_runs(
-    rpc, room_query_4
-):
+def test_ground_relational_causal_circuit_backdoor_adjustment_runs(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+    causal_circuit = ground_relational_causal_circuit(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -142,7 +134,7 @@ def test_from_relational_probabilistic_circuit_backdoor_adjustment_runs(
     assert interventional_circuit.is_valid()
 
 
-def test_from_relational_probabilistic_circuit_warns_on_expensive_adjustment_set(
+def test_ground_relational_causal_circuit_warns_on_expensive_adjustment_set(
     rpc, room_query_4, caplog
 ):
     """
@@ -151,7 +143,7 @@ def test_from_relational_probabilistic_circuit_warns_on_expensive_adjustment_set
     threshold, rather than waiting to discover the cost at query time.
     """
     with caplog.at_level("WARNING"):
-        RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        ground_relational_causal_circuit(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],
@@ -163,11 +155,11 @@ def test_from_relational_probabilistic_circuit_warns_on_expensive_adjustment_set
     assert any("leaf regions" in message for message in caplog.messages)
 
 
-def test_from_relational_probabilistic_circuit_does_not_warn_below_threshold(
+def test_ground_relational_causal_circuit_does_not_warn_below_threshold(
     rpc, room_query_4, caplog
 ):
     with caplog.at_level("WARNING"):
-        RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        ground_relational_causal_circuit(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],

--- a/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
@@ -1,0 +1,179 @@
+"""
+Tests for :mod:`probabilistic_model.probabilistic_circuit.relational.causal`: the bridge
+from ``RelationalProbabilisticCircuit`` grounding to ``CausalCircuit`` construction.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
+    CausalCircuit,
+)
+from probabilistic_model.probabilistic_circuit.relational.causal import (
+    RelationalCausalCircuit,
+    resolve_variable,
+)
+from probabilistic_model.probabilistic_circuit.relational.exceptions import (
+    AmbiguousVariablePathError,
+    VariableNotFoundError,
+)
+from probabilistic_model.probabilistic_circuit.relational.rspn import GroundingMode
+from .test_rspns import rpc, room_query_4, scenario  # noqa: F401
+
+# %% resolve_variable
+
+
+def test_resolve_variable_matches_the_full_name(rpc, room_query_4):
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    variable = resolve_variable(grounded, "SceneRoomAggregations.chair_count()")
+    assert variable.name == "SceneRoomAggregations.chair_count()"
+
+
+def test_resolve_variable_matches_an_unambiguous_suffix(rpc, room_query_4):
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    variable = resolve_variable(grounded, "chair_count()")
+    assert variable.name == "SceneRoomAggregations.chair_count()"
+
+
+def test_resolve_variable_matches_a_relational_index_suffix(rpc, room_query_4):
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    variable = resolve_variable(grounded, "objects[2].type")
+    assert variable.name == "SceneRoom.objects[2].type"
+
+
+def test_resolve_variable_raises_for_no_match(rpc, room_query_4):
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    with pytest.raises(VariableNotFoundError):
+        resolve_variable(grounded, "not_a_real_variable")
+
+
+def test_resolve_variable_raises_for_ambiguous_suffix(rpc, room_query_4):
+    """
+    ``type`` alone matches every ``objects[i].type``, so it must be rejected rather than
+    silently picking one.
+    """
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    with pytest.raises(AmbiguousVariablePathError):
+        resolve_variable(grounded, "type")
+
+
+# %% RelationalCausalCircuit.from_relational_probabilistic_circuit
+
+
+def test_from_relational_probabilistic_circuit_returns_a_causal_circuit(
+    rpc, room_query_4
+):
+    np.random.seed(0)
+    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        rpc,
+        room_query_4,
+        causal_variables=["chair_count()"],
+        effect_variables=["objects[0].type"],
+    )
+    assert isinstance(causal_circuit, CausalCircuit)
+
+
+def test_from_relational_probabilistic_circuit_accepts_resolved_variables(
+    rpc, room_query_4
+):
+    """
+    Callers may pass already-resolved Variable objects instead of path strings.
+    """
+    np.random.seed(0)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    chair_count_variable = resolve_variable(grounded, "chair_count()")
+    object_type_variable = resolve_variable(grounded, "objects[0].type")
+
+    np.random.seed(0)
+    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        rpc,
+        room_query_4,
+        causal_variables=[chair_count_variable],
+        effect_variables=[object_type_variable],
+    )
+    assert isinstance(causal_circuit, CausalCircuit)
+
+
+def test_from_relational_probabilistic_circuit_defaults_to_causal_sampled(
+    rpc, room_query_4
+):
+    """
+    The default grounding mode must retain undetermined latents (unlike
+    GroundingMode.PREDICTIVE), since that is the entire point of building a
+    RelationalCausalCircuit around one.
+    """
+    np.random.seed(0)
+    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        rpc,
+        room_query_4,
+        causal_variables=["chair_count()"],
+        effect_variables=["objects[0].type"],
+    )
+    names = {v.name for v in causal_circuit.probabilistic_circuit.variables}
+    assert "SceneRoomAggregations.chair_count()" in names
+
+
+def test_from_relational_probabilistic_circuit_backdoor_adjustment_runs(
+    rpc, room_query_4
+):
+    np.random.seed(0)
+    causal_circuit = RelationalCausalCircuit.from_relational_probabilistic_circuit(
+        rpc,
+        room_query_4,
+        causal_variables=["chair_count()"],
+        effect_variables=["objects[0].type"],
+    )
+    chair_count_variable = resolve_variable(
+        causal_circuit.probabilistic_circuit, "chair_count()"
+    )
+    object_type_variable = resolve_variable(
+        causal_circuit.probabilistic_circuit, "objects[0].type"
+    )
+    interventional_circuit = causal_circuit.backdoor_adjustment(
+        cause_variable=chair_count_variable, effect_variable=object_type_variable
+    )
+    assert interventional_circuit.is_valid()
+
+
+def test_from_relational_probabilistic_circuit_warns_on_expensive_adjustment_set(
+    rpc, room_query_4, caplog
+):
+    """
+    Under GroundingMode.CAUSAL_EXACT, registering more than one relational adjustment
+    variable together must warn once their leaf-region product exceeds the configured
+    threshold, rather than waiting to discover the cost at query time.
+    """
+    with caplog.at_level("WARNING"):
+        RelationalCausalCircuit.from_relational_probabilistic_circuit(
+            rpc,
+            room_query_4,
+            causal_variables=["objects[0].type"],
+            effect_variables=["objects[1].type"],
+            adjustment_variables=["chair_count()", "table_count()"],
+            grounding_mode=GroundingMode.CAUSAL_EXACT,
+            adjustment_region_count_warning_threshold=0,
+        )
+    assert any("leaf regions" in message for message in caplog.messages)
+
+
+def test_from_relational_probabilistic_circuit_does_not_warn_below_threshold(
+    rpc, room_query_4, caplog
+):
+    with caplog.at_level("WARNING"):
+        RelationalCausalCircuit.from_relational_probabilistic_circuit(
+            rpc,
+            room_query_4,
+            causal_variables=["objects[0].type"],
+            effect_variables=["objects[1].type"],
+            adjustment_variables=["chair_count()", "table_count()"],
+            grounding_mode=GroundingMode.CAUSAL_EXACT,
+            adjustment_region_count_warning_threshold=10_000,
+        )
+    assert not any("leaf regions" in message for message in caplog.messages)

--- a/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
@@ -12,8 +12,7 @@ from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
 )
 from probabilistic_model.probabilistic_circuit.relational.causal import (
-    ground_relational_causal_circuit,
-    resolve_variable,
+    RelationalCausalCircuit,
 )
 from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     AmbiguousVariablePathError,
@@ -27,30 +26,32 @@ from .test_rspns import rpc, room_query_4, scenario  # noqa: F401
 
 def test_resolve_variable_matches_the_full_name(rpc, room_query_4):
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    variable = resolve_variable(grounded, "SceneRoomAggregations.chair_count()")
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
+    variable = RelationalCausalCircuit.resolve_variable(
+        grounded, "SceneRoomAggregations.chair_count()"
+    )
     assert variable.name == "SceneRoomAggregations.chair_count()"
 
 
 def test_resolve_variable_matches_an_unambiguous_suffix(rpc, room_query_4):
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    variable = resolve_variable(grounded, "chair_count()")
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
+    variable = RelationalCausalCircuit.resolve_variable(grounded, "chair_count()")
     assert variable.name == "SceneRoomAggregations.chair_count()"
 
 
 def test_resolve_variable_matches_a_relational_index_suffix(rpc, room_query_4):
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    variable = resolve_variable(grounded, "objects[2].type")
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
+    variable = RelationalCausalCircuit.resolve_variable(grounded, "objects[2].type")
     assert variable.name == "SceneRoom.objects[2].type"
 
 
 def test_resolve_variable_raises_for_no_match(rpc, room_query_4):
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     with pytest.raises(VariableNotFoundError):
-        resolve_variable(grounded, "not_a_real_variable")
+        RelationalCausalCircuit.resolve_variable(grounded, "not_a_real_variable")
 
 
 def test_resolve_variable_raises_for_ambiguous_suffix(rpc, room_query_4):
@@ -59,17 +60,17 @@ def test_resolve_variable_raises_for_ambiguous_suffix(rpc, room_query_4):
     silently picking one.
     """
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     with pytest.raises(AmbiguousVariablePathError):
-        resolve_variable(grounded, "type")
+        RelationalCausalCircuit.resolve_variable(grounded, "type")
 
 
-# %% ground_relational_causal_circuit
+# %% RelationalCausalCircuit.ground
 
 
-def test_ground_relational_causal_circuit_returns_a_causal_circuit(rpc, room_query_4):
+def test_relational_causal_circuit_ground_returns_a_causal_circuit(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = ground_relational_causal_circuit(
+    causal_circuit = RelationalCausalCircuit.ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -78,17 +79,21 @@ def test_ground_relational_causal_circuit_returns_a_causal_circuit(rpc, room_que
     assert isinstance(causal_circuit, CausalCircuit)
 
 
-def test_ground_relational_causal_circuit_accepts_resolved_variables(rpc, room_query_4):
+def test_relational_causal_circuit_ground_accepts_resolved_variables(rpc, room_query_4):
     """
     Callers may pass already-resolved Variable objects instead of path strings.
     """
     np.random.seed(0)
-    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    chair_count_variable = resolve_variable(grounded, "chair_count()")
-    object_type_variable = resolve_variable(grounded, "objects[0].type")
+    grounded = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
+    chair_count_variable = RelationalCausalCircuit.resolve_variable(
+        grounded, "chair_count()"
+    )
+    object_type_variable = RelationalCausalCircuit.resolve_variable(
+        grounded, "objects[0].type"
+    )
 
     np.random.seed(0)
-    causal_circuit = ground_relational_causal_circuit(
+    causal_circuit = RelationalCausalCircuit.ground(
         rpc,
         room_query_4,
         causal_variables=[chair_count_variable],
@@ -97,14 +102,13 @@ def test_ground_relational_causal_circuit_accepts_resolved_variables(rpc, room_q
     assert isinstance(causal_circuit, CausalCircuit)
 
 
-def test_ground_relational_causal_circuit_defaults_to_causal_sampled(rpc, room_query_4):
+def test_relational_causal_circuit_ground_defaults_to_causal_sampled(rpc, room_query_4):
     """
-    The default grounding mode must retain undetermined latents (unlike
-    GroundingMode.PREDICTIVE), since that is the entire point of grounding a
-    CausalCircuit this way.
+    The default grounding mode must retain undetermined latents, since that is the
+    entire point of grounding a CausalCircuit this way.
     """
     np.random.seed(0)
-    causal_circuit = ground_relational_causal_circuit(
+    causal_circuit = RelationalCausalCircuit.ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -114,18 +118,18 @@ def test_ground_relational_causal_circuit_defaults_to_causal_sampled(rpc, room_q
     assert "SceneRoomAggregations.chair_count()" in names
 
 
-def test_ground_relational_causal_circuit_backdoor_adjustment_runs(rpc, room_query_4):
+def test_relational_causal_circuit_ground_backdoor_adjustment_runs(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = ground_relational_causal_circuit(
+    causal_circuit = RelationalCausalCircuit.ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
         effect_variables=["objects[0].type"],
     )
-    chair_count_variable = resolve_variable(
+    chair_count_variable = RelationalCausalCircuit.resolve_variable(
         causal_circuit.probabilistic_circuit, "chair_count()"
     )
-    object_type_variable = resolve_variable(
+    object_type_variable = RelationalCausalCircuit.resolve_variable(
         causal_circuit.probabilistic_circuit, "objects[0].type"
     )
     interventional_circuit = causal_circuit.backdoor_adjustment(
@@ -134,38 +138,38 @@ def test_ground_relational_causal_circuit_backdoor_adjustment_runs(rpc, room_que
     assert interventional_circuit.is_valid()
 
 
-def test_ground_relational_causal_circuit_warns_on_expensive_adjustment_set(
+def test_relational_causal_circuit_ground_warns_on_expensive_adjustment_set(
     rpc, room_query_4, caplog
 ):
     """
-    Under GroundingMode.CAUSAL_EXACT, registering more than one relational adjustment
-    variable together must warn once their leaf-region product exceeds the configured
-    threshold, rather than waiting to discover the cost at query time.
+    Under GroundingMode.EXACT, registering more than one relational adjustment variable
+    together must warn once their leaf-region product exceeds the configured threshold,
+    rather than waiting to discover the cost at query time.
     """
     with caplog.at_level("WARNING"):
-        ground_relational_causal_circuit(
+        RelationalCausalCircuit.ground(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],
             effect_variables=["objects[1].type"],
             adjustment_variables=["chair_count()", "table_count()"],
-            grounding_mode=GroundingMode.CAUSAL_EXACT,
+            grounding_mode=GroundingMode.EXACT,
             adjustment_region_count_warning_threshold=0,
         )
     assert any("leaf regions" in message for message in caplog.messages)
 
 
-def test_ground_relational_causal_circuit_does_not_warn_below_threshold(
+def test_relational_causal_circuit_ground_does_not_warn_below_threshold(
     rpc, room_query_4, caplog
 ):
     with caplog.at_level("WARNING"):
-        ground_relational_causal_circuit(
+        RelationalCausalCircuit.ground(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],
             effect_variables=["objects[1].type"],
             adjustment_variables=["chair_count()", "table_count()"],
-            grounding_mode=GroundingMode.CAUSAL_EXACT,
+            grounding_mode=GroundingMode.EXACT,
             adjustment_region_count_warning_threshold=10_000,
         )
     assert not any("leaf regions" in message for message in caplog.messages)

--- a/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
+++ b/test/krrood_test/test_feature_extraction/test_relational_causal_circuit.py
@@ -70,7 +70,7 @@ def test_resolve_variable_raises_for_ambiguous_suffix(rpc, room_query_4):
 
 def test_relational_causal_circuit_ground_returns_a_causal_circuit(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.ground(
+    causal_circuit = RelationalCausalCircuit().ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -93,7 +93,7 @@ def test_relational_causal_circuit_ground_accepts_resolved_variables(rpc, room_q
     )
 
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.ground(
+    causal_circuit = RelationalCausalCircuit().ground(
         rpc,
         room_query_4,
         causal_variables=[chair_count_variable],
@@ -108,7 +108,7 @@ def test_relational_causal_circuit_ground_defaults_to_causal_sampled(rpc, room_q
     entire point of grounding a CausalCircuit this way.
     """
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.ground(
+    causal_circuit = RelationalCausalCircuit().ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -120,7 +120,7 @@ def test_relational_causal_circuit_ground_defaults_to_causal_sampled(rpc, room_q
 
 def test_relational_causal_circuit_ground_backdoor_adjustment_runs(rpc, room_query_4):
     np.random.seed(0)
-    causal_circuit = RelationalCausalCircuit.ground(
+    causal_circuit = RelationalCausalCircuit().ground(
         rpc,
         room_query_4,
         causal_variables=["chair_count()"],
@@ -147,14 +147,13 @@ def test_relational_causal_circuit_ground_warns_on_expensive_adjustment_set(
     rather than waiting to discover the cost at query time.
     """
     with caplog.at_level("WARNING"):
-        RelationalCausalCircuit.ground(
+        RelationalCausalCircuit(adjustment_region_count_warning_threshold=0).ground(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],
             effect_variables=["objects[1].type"],
             adjustment_variables=["chair_count()", "table_count()"],
             grounding_mode=GroundingMode.EXACT,
-            adjustment_region_count_warning_threshold=0,
         )
     assert any("leaf regions" in message for message in caplog.messages)
 
@@ -163,13 +162,14 @@ def test_relational_causal_circuit_ground_does_not_warn_below_threshold(
     rpc, room_query_4, caplog
 ):
     with caplog.at_level("WARNING"):
-        RelationalCausalCircuit.ground(
+        RelationalCausalCircuit(
+            adjustment_region_count_warning_threshold=10_000
+        ).ground(
             rpc,
             room_query_4,
             causal_variables=["objects[0].type"],
             effect_variables=["objects[1].type"],
             adjustment_variables=["chair_count()", "table_count()"],
             grounding_mode=GroundingMode.EXACT,
-            adjustment_region_count_warning_threshold=10_000,
         )
     assert not any("leaf regions" in message for message in caplog.messages)

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -145,16 +145,17 @@ def test_ground_preserves_room_scalar_variables(rpc, room_query_4):
     assert "SceneRoom.orientation.w" in names
 
 
-def test_ground_integrates_out_unavailable_aggregates(rpc, room_query_4):
+def test_ground_retains_unavailable_aggregates_by_default(rpc, room_query_4):
     """
     ``chair_count`` and ``table_count`` cannot be determined from the underspecified
-    query, so the Monte-Carlo path must integrate them out: they must not survive as
-    variables, while the object-type variables remain.
+    query, so the Monte-Carlo path must retain them as variables (grounding never
+    integrates undetermined latents out), alongside the object-type variables.
     """
+    np.random.seed(0)
     model = rpc.ground(room_query_4)
     names = {v.name for v in model.variables}
-    assert "SceneRoomAggregations.chair_count()" not in names
-    assert "SceneRoomAggregations.table_count()" not in names
+    assert "SceneRoomAggregations.chair_count()" in names
+    assert "SceneRoomAggregations.table_count()" in names
     for i in range(4):
         assert f"SceneRoom.objects[{i}].type" in names
 
@@ -204,43 +205,28 @@ def test_ground_variable_count_scales_with_query_size(rpc):
     assert len(rpc.ground(query_4).variables) > len(rpc.ground(query_2).variables)
 
 
-# %% GroundingMode.CAUSAL_SAMPLED retains undetermined latents instead of discarding them
+# %% GroundingMode.SAMPLED retains undetermined latents instead of discarding them
 
 
-def test_predictive_grounding_is_unaffected_by_the_explicit_default(rpc, room_query_4):
+def test_sampled_grounding_retains_undetermined_latents_as_variables(rpc, room_query_4):
     np.random.seed(0)
-    implicit_default = {v.name for v in rpc.ground(room_query_4).variables}
-    np.random.seed(0)
-    explicit_predictive = {
-        v.name
-        for v in rpc.ground(
-            room_query_4, grounding_mode=GroundingMode.PREDICTIVE
-        ).variables
-    }
-    assert implicit_default == explicit_predictive
-
-
-def test_causal_sampled_grounding_retains_undetermined_latents_as_variables(
-    rpc, room_query_4
-):
-    np.random.seed(0)
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     names = {v.name for v in model.variables}
     assert "SceneRoomAggregations.chair_count()" in names
     assert "SceneRoomAggregations.table_count()" in names
 
 
-def test_causal_sampled_grounding_preserves_object_type_variables(rpc, room_query_4):
+def test_sampled_grounding_preserves_object_type_variables(rpc, room_query_4):
     np.random.seed(0)
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     names = {v.name for v in model.variables}
     for i in range(4):
         assert f"SceneRoom.objects[{i}].type" in names
 
 
-def test_causal_sampled_grounding_is_valid(rpc, room_query_4):
+def test_sampled_grounding_is_valid(rpc, room_query_4):
     np.random.seed(0)
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     assert model.is_valid()
 
 
@@ -248,7 +234,7 @@ def _causal_circuit_for(model):
     """
     Build a CausalCircuit registering ``chair_count()`` as the cause and
     ``objects[0].type`` as the effect over a grounded circuit, the pair every
-    GroundingMode.CAUSAL_SAMPLED/CAUSAL_EXACT causal-registration test below exercises.
+    GroundingMode.SAMPLED/EXACT causal-registration test below exercises.
     """
     chair_count_variable = next(
         v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
@@ -264,33 +250,31 @@ def _causal_circuit_for(model):
     )
 
 
-def test_causal_sampled_grounding_supports_causal_circuit_registration(
-    rpc, room_query_4
-):
+def test_sampled_grounding_supports_causal_circuit_registration(rpc, room_query_4):
     """
-    The whole point of ``GroundingMode.CAUSAL_SAMPLED``: a latent that predictive
+    The whole point of ``GroundingMode.SAMPLED``: a latent that predictive
     grounding would have discarded must be usable as a registered cause in a
     ``CausalCircuit`` -- i.e. verified support-deterministic against it, the structural
     precondition ``backdoor_adjustment`` relies on.
     """
     np.random.seed(0)
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     causal_circuit = _causal_circuit_for(model)
 
     result = causal_circuit.verify_support_determinism()
     assert result.passed
 
 
-def test_causal_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
+def test_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
     """
     End-to-end regression test: computing ``P(effect | do(cause))`` on a
-    ``CAUSAL_SAMPLED``-grounded circuit must not raise.
+    ``SAMPLED``-grounded circuit must not raise.
 
     This exercises every renamed exchangeable-instance leaf, including any query part
     whose grounded circuit happens to collapse to a single leaf as its own root.
     """
     np.random.seed(0)
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.SAMPLED)
     causal_circuit = _causal_circuit_for(model)
 
     interventional_circuit = causal_circuit.backdoor_adjustment(
@@ -300,56 +284,50 @@ def test_causal_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
     assert interventional_circuit.is_valid()
 
 
-# %% GroundingMode.CAUSAL_EXACT retains undetermined latents via exact partition
+# %% GroundingMode.EXACT retains undetermined latents via exact partition
 
 
-def test_causal_exact_grounding_retains_undetermined_latents_as_variables(
-    rpc, room_query_4
-):
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+def test_exact_grounding_retains_undetermined_latents_as_variables(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT)
     names = {v.name for v in model.variables}
     assert "SceneRoomAggregations.chair_count()" in names
     assert "SceneRoomAggregations.table_count()" in names
 
 
-def test_causal_exact_grounding_is_valid(rpc, room_query_4):
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+def test_exact_grounding_is_valid(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT)
     assert model.is_valid()
 
 
-def test_causal_exact_grounding_is_reproducible_across_calls(rpc, room_query_4):
+def test_exact_grounding_is_reproducible_across_calls(rpc, room_query_4):
     """
-    ``CAUSAL_EXACT`` grounding -- whether it takes its own exact-partition path or falls
-    back to ``CAUSAL_SAMPLED`` -- must ground the identical set of variables across
-    calls, even under different random state.
+    ``EXACT`` grounding -- whether it takes its own exact-partition path or falls back
+    to ``SAMPLED`` -- must ground the identical set of variables across calls, even
+    under different random state.
     """
     np.random.seed(0)
     first = {
         v.name
-        for v in rpc.ground(
-            room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT
-        ).variables
+        for v in rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT).variables
     }
     np.random.seed(123)
     second = {
         v.name
-        for v in rpc.ground(
-            room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT
-        ).variables
+        for v in rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT).variables
     }
     assert first == second
 
 
-def test_causal_exact_grounding_supports_causal_circuit_registration(rpc, room_query_4):
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+def test_exact_grounding_supports_causal_circuit_registration(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT)
     causal_circuit = _causal_circuit_for(model)
 
     result = causal_circuit.verify_support_determinism()
     assert result.passed
 
 
-def test_causal_exact_grounding_backdoor_adjustment_runs(rpc, room_query_4):
-    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+def test_exact_grounding_backdoor_adjustment_runs(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT)
     causal_circuit = _causal_circuit_for(model)
 
     interventional_circuit = causal_circuit.backdoor_adjustment(
@@ -359,13 +337,13 @@ def test_causal_exact_grounding_backdoor_adjustment_runs(rpc, room_query_4):
     assert interventional_circuit.is_valid()
 
 
-def test_causal_exact_grounding_falls_back_to_causal_sampled_when_partition_overlaps(
+def test_exact_grounding_falls_back_to_sampled_when_partition_overlaps(
     rpc, room_query_4, caplog
 ):
     """
     When the fitted circuit's partition over the undetermined latents is not disjoint,
-    ``CAUSAL_EXACT`` must fall back to ``CAUSAL_SAMPLED`` rather than raise or produce
-    an unsound circuit.
+    ``EXACT`` must fall back to ``SAMPLED`` rather than raise or produce an unsound
+    circuit.
     """
     np.random.seed(0)
     with patch.object(
@@ -374,7 +352,7 @@ def test_causal_exact_grounding_falls_back_to_causal_sampled_when_partition_over
         return_value=False,
     ):
         with caplog.at_level("WARNING"):
-            model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+            model = rpc.ground(room_query_4, grounding_mode=GroundingMode.EXACT)
 
     assert model.is_valid()
     names = {v.name for v in model.variables}
@@ -382,7 +360,7 @@ def test_causal_exact_grounding_falls_back_to_causal_sampled_when_partition_over
     assert any("falling back" in message.lower() for message in caplog.messages)
 
 
-# %% GroundingMode.CAUSAL_EXACT preserves the actual correlation between the retained
+# %% GroundingMode.EXACT preserves the actual correlation between the retained
 # latent and the exchangeable relation's own attributes, not just its variable set
 
 
@@ -433,7 +411,7 @@ def correlated_room_query():
     return query
 
 
-def test_causal_exact_grounding_preserves_correlation_with_the_retained_latent(
+def test_exact_grounding_preserves_correlation_with_the_retained_latent(
     correlated_rpc, correlated_room_query
 ):
     """
@@ -452,7 +430,7 @@ def test_causal_exact_grounding_preserves_correlation_with_the_retained_latent(
     """
     np.random.seed(0)
     grounded = correlated_rpc.ground(
-        correlated_room_query, grounding_mode=GroundingMode.CAUSAL_EXACT
+        correlated_room_query, grounding_mode=GroundingMode.EXACT
     )
     chair_count_variable = next(
         v for v in grounded.variables if v.name == "SceneRoomAggregations.chair_count()"
@@ -500,7 +478,7 @@ def test_representative_value_returns_a_point_not_a_region():
     point.
 
     Passing the mode region itself into conditioning always fails silently (see
-    test_causal_exact_grounding_preserves_correlation_with_the_retained_latent).
+    test_exact_grounding_preserves_correlation_with_the_retained_latent).
     """
     variable = Integer("value")
     circuit = ProbabilisticCircuit()

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
 from krrood.entity_query_language.factories import a, an
 from krrood.ormatic.data_access_objects.helper import to_dao
+from probabilistic_model.distributions.distributions import IntegerDistribution
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
     MarginalDeterminismTreeNode,
@@ -15,7 +18,13 @@ from probabilistic_model.probabilistic_circuit.relational.rspn import (
     GroundingMode,
     RelationalProbabilisticCircuit,
 )
-from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import SumUnit
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
+    ProbabilisticCircuit,
+    SumUnit,
+    leaf,
+)
+from probabilistic_model.utils import MissingDict
+from random_events.variable import Integer
 from ..dataset import ormatic_interface  # type: ignore
 from ..dataset.example_classes import (
     KRROODOrientation,
@@ -287,3 +296,155 @@ def test_causal_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
         cause_variable=chair_count_variable, effect_variable=object_type_variable
     )
     assert interventional_circuit.is_valid()
+
+
+# %% GroundingMode.CAUSAL_EXACT retains undetermined latents via exact partition
+
+
+def test_causal_exact_grounding_retains_undetermined_latents_as_variables(
+    rpc, room_query_4
+):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+    names = {v.name for v in model.variables}
+    assert "SceneRoomAggregations.chair_count()" in names
+    assert "SceneRoomAggregations.table_count()" in names
+
+
+def test_causal_exact_grounding_is_valid(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+    assert model.is_valid()
+
+
+def test_causal_exact_grounding_is_reproducible_across_calls(rpc, room_query_4):
+    """
+    Unlike ``CAUSAL_SAMPLED``, exact-partition grounding enumerates the model's own
+    partition rather than sampling from it, so repeated calls -- even under different
+    random state -- must ground the identical set of variables.
+    """
+    np.random.seed(0)
+    first = {
+        v.name
+        for v in rpc.ground(
+            room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT
+        ).variables
+    }
+    np.random.seed(123)
+    second = {
+        v.name
+        for v in rpc.ground(
+            room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT
+        ).variables
+    }
+    assert first == second
+
+
+def test_causal_exact_grounding_supports_causal_circuit_registration(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+    chair_count_variable = next(
+        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        model, tree, [chair_count_variable], [object_type_variable]
+    )
+
+    result = causal_circuit.verify_support_determinism()
+    assert result.passed
+
+
+def test_causal_exact_grounding_backdoor_adjustment_runs(rpc, room_query_4):
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+    chair_count_variable = next(
+        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        model, tree, [chair_count_variable], [object_type_variable]
+    )
+
+    interventional_circuit = causal_circuit.backdoor_adjustment(
+        cause_variable=chair_count_variable, effect_variable=object_type_variable
+    )
+    assert interventional_circuit.is_valid()
+
+
+def test_causal_exact_grounding_falls_back_to_causal_sampled_when_partition_overlaps(
+    rpc, room_query_4, caplog
+):
+    """
+    When the fitted circuit's partition over the undetermined latents is not disjoint,
+    ``CAUSAL_EXACT`` must fall back to ``CAUSAL_SAMPLED`` rather than raise or produce
+    an unsound circuit.
+    """
+    np.random.seed(0)
+    with patch.object(
+        RelationalProbabilisticCircuit,
+        "_undetermined_latents_partition_disjointly",
+        return_value=False,
+    ):
+        with caplog.at_level("WARNING"):
+            model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
+
+    assert model.is_valid()
+    names = {v.name for v in model.variables}
+    assert "SceneRoomAggregations.chair_count()" in names
+    assert any("falling back" in message.lower() for message in caplog.messages)
+
+
+# %% RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly
+
+
+def _integer_leaf(variable, probabilities, circuit):
+    return leaf(
+        IntegerDistribution(
+            variable=variable, probabilities=MissingDict(float, probabilities)
+        ),
+        circuit,
+    )
+
+
+def test_partition_disjointly_true_for_a_single_branch():
+    variable = Integer("value")
+    circuit = ProbabilisticCircuit()
+    _integer_leaf(variable, {1: 1.0}, circuit)
+    assert RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+        circuit
+    )
+
+
+def test_partition_disjointly_true_for_disjoint_branches():
+    variable = Integer("value")
+    circuit = ProbabilisticCircuit()
+    root = SumUnit(probabilistic_circuit=circuit)
+    root.add_subcircuit(_integer_leaf(variable, {1: 1.0}, circuit), 0.0)
+    root.add_subcircuit(_integer_leaf(variable, {2: 1.0}, circuit), 0.0)
+    root.normalize()
+    assert RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+        circuit
+    )
+
+
+def test_partition_disjointly_false_for_overlapping_branches():
+    variable = Integer("value")
+    circuit = ProbabilisticCircuit()
+    root = SumUnit(probabilistic_circuit=circuit)
+    root.add_subcircuit(_integer_leaf(variable, {1: 0.5, 2: 0.5}, circuit), 0.0)
+    root.add_subcircuit(_integer_leaf(variable, {2: 0.5, 3: 0.5}, circuit), 0.0)
+    root.normalize()
+    assert (
+        not RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+            circuit
+        )
+    )

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -257,3 +257,33 @@ def test_causal_sampled_grounding_supports_causal_circuit_registration(
 
     result = causal_circuit.verify_support_determinism()
     assert result.passed
+
+
+def test_causal_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
+    """
+    End-to-end regression test: computing ``P(effect | do(cause))`` on a
+    ``CAUSAL_SAMPLED``-grounded circuit must not raise.
+
+    This exercises every renamed exchangeable-instance leaf, including any query part
+    whose grounded circuit happens to collapse to a single leaf as its own root.
+    """
+    np.random.seed(0)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    chair_count_variable = next(
+        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        model, tree, [chair_count_variable], [object_type_variable]
+    )
+
+    interventional_circuit = causal_circuit.backdoor_adjustment(
+        cause_variable=chair_count_variable, effect_variable=object_type_variable
+    )
+    assert interventional_circuit.is_valid()

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -2,10 +2,12 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from sortedcontainers import SortedSet
 
 from krrood.entity_query_language.factories import a, an
 from krrood.ormatic.data_access_objects.helper import to_dao
 from probabilistic_model.distributions.distributions import IntegerDistribution
+from probabilistic_model.distributions.uniform import UniformDistribution
 from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
     CausalCircuit,
     MarginalDeterminismTreeNode,
@@ -20,11 +22,14 @@ from probabilistic_model.probabilistic_circuit.relational.rspn import (
 )
 from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import (
     ProbabilisticCircuit,
+    ProductUnit,
     SumUnit,
     leaf,
 )
 from probabilistic_model.utils import MissingDict
-from random_events.variable import Integer
+from random_events.interval import closed
+from random_events.product_algebra import SimpleEvent
+from random_events.variable import Continuous, Integer
 from ..dataset import ormatic_interface  # type: ignore
 from ..dataset.example_classes import (
     KRROODOrientation,
@@ -317,9 +322,9 @@ def test_causal_exact_grounding_is_valid(rpc, room_query_4):
 
 def test_causal_exact_grounding_is_reproducible_across_calls(rpc, room_query_4):
     """
-    Unlike ``CAUSAL_SAMPLED``, exact-partition grounding enumerates the model's own
-    partition rather than sampling from it, so repeated calls -- even under different
-    random state -- must ground the identical set of variables.
+    ``CAUSAL_EXACT`` grounding -- whether it takes its own exact-partition path or falls
+    back to ``CAUSAL_SAMPLED`` -- must ground the identical set of variables across
+    calls, even under different random state.
     """
     np.random.seed(0)
     first = {
@@ -403,6 +408,197 @@ def test_causal_exact_grounding_falls_back_to_causal_sampled_when_partition_over
     assert any("falling back" in message.lower() for message in caplog.messages)
 
 
+# %% GroundingMode.CAUSAL_EXACT preserves the actual correlation between the retained
+# latent and the exchangeable relation's own attributes, not just its variable set
+
+
+def _room_with_chair_count(rng: np.random.Generator, chair_count: int) -> SceneRoom:
+    """
+    A three-object room whose first object's type is CHAIR whenever chair_count is at
+    least 2, TABLE otherwise, and whose remaining objects are padded to match
+    chair_count exactly.
+    """
+    first_type = SceneObjectType.CHAIR if chair_count >= 2 else SceneObjectType.TABLE
+    remaining_chairs = max(
+        chair_count - (1 if first_type == SceneObjectType.CHAIR else 0), 0
+    )
+    remaining_types = [SceneObjectType.CHAIR] * remaining_chairs
+    while len(remaining_types) < 2:
+        remaining_types.append(SceneObjectType.TABLE)
+    objects = [SceneObject(type=first_type)] + [
+        SceneObject(type=object_type) for object_type in remaining_types[:2]
+    ]
+    return SceneRoom(
+        position=KRROODPosition(
+            x=float(rng.uniform(0, 5)), y=float(rng.uniform(0, 5)), z=0.0
+        ),
+        orientation=KRROODOrientation(x=0.0, y=0.0, z=0.0, w=1.0),
+        objects=objects,
+    )
+
+
+@pytest.fixture
+def correlated_rpc() -> RelationalProbabilisticCircuit:
+    rng = np.random.default_rng(0)
+    rooms = [_room_with_chair_count(rng, 1) for _ in range(20)] + [
+        _room_with_chair_count(rng, 3) for _ in range(20)
+    ]
+    model = RelationalProbabilisticCircuit(SceneRoom)
+    model.fit([to_dao(room) for room in rooms])
+    return model
+
+
+@pytest.fixture
+def correlated_room_query():
+    query = a(SceneRoom)(
+        position=a(KRROODPosition)(x=..., y=..., z=...),
+        orientation=a(KRROODOrientation)(x=..., y=..., z=..., w=...),
+        objects=[a(SceneObject)(type=...) for _ in range(3)],
+    )
+    query.resolve()
+    return query
+
+
+def test_causal_exact_grounding_preserves_correlation_with_the_retained_latent(
+    correlated_rpc, correlated_room_query
+):
+    """
+    Regression test: the retained chair_count latent must stay statistically tied to the
+    object-type distribution it was fitted alongside.
+
+    Before this was fixed, _representative_value passed a whole mode region (not a
+    point) into conditioning, which always failed and silently fell back to grounding
+    every branch from the same unconditioned distribution -- and even after fixing that,
+    a single, undifferentiated partition branch was treated as trivially valid instead
+    of triggering a fall back to sampling, discarding the correlation either way.
+    P(objects[0].type=CHAIR | do(chair_count=1)) and P(objects[0].type=CHAIR |
+    do(chair_count=3)) must therefore differ, reflecting chair_count=1 rooms never
+    having their first object be a chair and chair_count=3 rooms always having it be
+    one.
+    """
+    np.random.seed(0)
+    grounded = correlated_rpc.ground(
+        correlated_room_query, grounding_mode=GroundingMode.CAUSAL_EXACT
+    )
+    chair_count_variable = next(
+        v for v in grounded.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in grounded.variables if v.name == "SceneRoom.objects[0].type"
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        grounded, tree, [chair_count_variable], [object_type_variable]
+    )
+    interventional_circuit = causal_circuit.backdoor_adjustment(
+        cause_variable=chair_count_variable, effect_variable=object_type_variable
+    )
+
+    def probability_of_chair_given_chair_count(chair_count: int) -> float:
+        cause_event = (
+            SimpleEvent.from_data({chair_count_variable: chair_count})
+            .as_composite_set()
+            .fill_missing_variables_pure(interventional_circuit.variables)
+        )
+        chair_event = (
+            SimpleEvent.from_data({object_type_variable: SceneObjectType.CHAIR})
+            .as_composite_set()
+            .fill_missing_variables_pure(interventional_circuit.variables)
+        )
+        cause_probability = interventional_circuit.probability(cause_event)
+        assert cause_probability > 0
+        return (
+            interventional_circuit.probability(cause_event & chair_event)
+            / cause_probability
+        )
+
+    assert probability_of_chair_given_chair_count(
+        1
+    ) < probability_of_chair_given_chair_count(3)
+
+
+def test_representative_value_returns_a_point_not_a_region():
+    """
+    Regression test: _representative_value must collapse each leaf's mode to a single
+    point.
+
+    Passing the mode region itself into conditioning always fails silently (see
+    test_causal_exact_grounding_preserves_correlation_with_the_retained_latent).
+    """
+    variable = Integer("value")
+    circuit = ProbabilisticCircuit()
+    branch = _integer_leaf(variable, {2: 0.5, 3: 0.5}, circuit)
+
+    representative_value = RelationalProbabilisticCircuit._representative_value(
+        branch, SortedSet([variable])
+    )
+
+    assert representative_value == {variable: 2.0}
+    conditioning_result, log_likelihood = branch.distribution.log_conditional(
+        representative_value
+    )
+    assert conditioning_result is not None
+    assert log_likelihood > -np.inf
+
+
+def test_node_local_branch_log_probabilities_reflect_each_nodes_own_correlation():
+    """
+    Regression test: two mounting nodes that each correlate the undetermined latent with
+    a different other variable must get different weights over the same global partition
+    branches, not one weighting shared across every node.
+    """
+    other_variable = Continuous("other_variable")
+    chair_count = Integer("chair_count")
+
+    circuit = ProbabilisticCircuit()
+    node_favoring_one = ProductUnit(probabilistic_circuit=circuit)
+    node_favoring_one.add_subcircuit(
+        leaf(
+            UniformDistribution(
+                variable=other_variable, interval=closed(0, 1).simple_sets[0]
+            ),
+            circuit,
+        )
+    )
+    node_favoring_one.add_subcircuit(_integer_leaf(chair_count, {1: 1.0}, circuit))
+
+    node_favoring_three = ProductUnit(probabilistic_circuit=circuit)
+    node_favoring_three.add_subcircuit(
+        leaf(
+            UniformDistribution(
+                variable=other_variable, interval=closed(2, 3).simple_sets[0]
+            ),
+            circuit,
+        )
+    )
+    node_favoring_three.add_subcircuit(_integer_leaf(chair_count, {3: 1.0}, circuit))
+
+    root = SumUnit(probabilistic_circuit=circuit)
+    root.add_subcircuit(node_favoring_one, 0.0)
+    root.add_subcircuit(node_favoring_three, 0.0)
+    root.normalize()
+
+    region_one = SimpleEvent.from_data({chair_count: 1}).as_composite_set()
+    region_three = SimpleEvent.from_data({chair_count: 3}).as_composite_set()
+
+    weights_for_node_favoring_one = (
+        RelationalProbabilisticCircuit._node_local_branch_log_probabilities(
+            node_favoring_one, SortedSet([chair_count]), [region_one, region_three]
+        )
+    )
+    weights_for_node_favoring_three = (
+        RelationalProbabilisticCircuit._node_local_branch_log_probabilities(
+            node_favoring_three, SortedSet([chair_count]), [region_one, region_three]
+        )
+    )
+
+    assert weights_for_node_favoring_one[0] > weights_for_node_favoring_one[1]
+    assert weights_for_node_favoring_three[1] > weights_for_node_favoring_three[0]
+
+
 # %% RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly
 
 
@@ -415,12 +611,21 @@ def _integer_leaf(variable, probabilities, circuit):
     )
 
 
-def test_partition_disjointly_true_for_a_single_branch():
+def test_partition_disjointly_false_for_a_single_branch():
+    """
+    A single, undifferentiated branch fails the precondition rather than trivially
+    passing it: the fitted circuit never actually split on this latent, so every
+    exchangeable instance would be grounded from the same representative point
+    regardless of which value the latent takes, discarding the correlation between
+    them.
+    """
     variable = Integer("value")
     circuit = ProbabilisticCircuit()
     _integer_leaf(variable, {1: 1.0}, circuit)
-    assert RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
-        circuit
+    assert (
+        not RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+            circuit
+        )
     )
 
 

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -244,6 +244,26 @@ def test_causal_sampled_grounding_is_valid(rpc, room_query_4):
     assert model.is_valid()
 
 
+def _causal_circuit_for(model):
+    """
+    Build a CausalCircuit registering ``chair_count()`` as the cause and
+    ``objects[0].type`` as the effect over a grounded circuit, the pair every
+    GroundingMode.CAUSAL_SAMPLED/CAUSAL_EXACT causal-registration test below exercises.
+    """
+    chair_count_variable = next(
+        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
+    )
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    return CausalCircuit.from_probabilistic_circuit(
+        model, tree, [chair_count_variable], [object_type_variable]
+    )
+
+
 def test_causal_sampled_grounding_supports_causal_circuit_registration(
     rpc, room_query_4
 ):
@@ -255,19 +275,7 @@ def test_causal_sampled_grounding_supports_causal_circuit_registration(
     """
     np.random.seed(0)
     model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    chair_count_variable = next(
-        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
-    )
-    object_type_variable = next(
-        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
-    )
-
-    tree = MarginalDeterminismTreeNode.from_causal_graph(
-        [chair_count_variable], [object_type_variable]
-    )
-    causal_circuit = CausalCircuit.from_probabilistic_circuit(
-        model, tree, [chair_count_variable], [object_type_variable]
-    )
+    causal_circuit = _causal_circuit_for(model)
 
     result = causal_circuit.verify_support_determinism()
     assert result.passed
@@ -283,22 +291,11 @@ def test_causal_sampled_grounding_backdoor_adjustment_runs(rpc, room_query_4):
     """
     np.random.seed(0)
     model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
-    chair_count_variable = next(
-        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
-    )
-    object_type_variable = next(
-        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
-    )
-
-    tree = MarginalDeterminismTreeNode.from_causal_graph(
-        [chair_count_variable], [object_type_variable]
-    )
-    causal_circuit = CausalCircuit.from_probabilistic_circuit(
-        model, tree, [chair_count_variable], [object_type_variable]
-    )
+    causal_circuit = _causal_circuit_for(model)
 
     interventional_circuit = causal_circuit.backdoor_adjustment(
-        cause_variable=chair_count_variable, effect_variable=object_type_variable
+        cause_variable=causal_circuit.causal_variables[0],
+        effect_variable=causal_circuit.effect_variables[0],
     )
     assert interventional_circuit.is_valid()
 
@@ -345,19 +342,7 @@ def test_causal_exact_grounding_is_reproducible_across_calls(rpc, room_query_4):
 
 def test_causal_exact_grounding_supports_causal_circuit_registration(rpc, room_query_4):
     model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
-    chair_count_variable = next(
-        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
-    )
-    object_type_variable = next(
-        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
-    )
-
-    tree = MarginalDeterminismTreeNode.from_causal_graph(
-        [chair_count_variable], [object_type_variable]
-    )
-    causal_circuit = CausalCircuit.from_probabilistic_circuit(
-        model, tree, [chair_count_variable], [object_type_variable]
-    )
+    causal_circuit = _causal_circuit_for(model)
 
     result = causal_circuit.verify_support_determinism()
     assert result.passed
@@ -365,22 +350,11 @@ def test_causal_exact_grounding_supports_causal_circuit_registration(rpc, room_q
 
 def test_causal_exact_grounding_backdoor_adjustment_runs(rpc, room_query_4):
     model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_EXACT)
-    chair_count_variable = next(
-        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
-    )
-    object_type_variable = next(
-        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
-    )
-
-    tree = MarginalDeterminismTreeNode.from_causal_graph(
-        [chair_count_variable], [object_type_variable]
-    )
-    causal_circuit = CausalCircuit.from_probabilistic_circuit(
-        model, tree, [chair_count_variable], [object_type_variable]
-    )
+    causal_circuit = _causal_circuit_for(model)
 
     interventional_circuit = causal_circuit.backdoor_adjustment(
-        cause_variable=chair_count_variable, effect_variable=object_type_variable
+        cause_variable=causal_circuit.causal_variables[0],
+        effect_variable=causal_circuit.effect_variables[0],
     )
     assert interventional_circuit.is_valid()
 

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -3,11 +3,16 @@ import pytest
 
 from krrood.entity_query_language.factories import a, an
 from krrood.ormatic.data_access_objects.helper import to_dao
+from probabilistic_model.probabilistic_circuit.causal.causal_circuit import (
+    CausalCircuit,
+    MarginalDeterminismTreeNode,
+)
 from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     CircuitNotFittedError,
     InvalidMonteCarloSampleCountError,
 )
 from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    GroundingMode,
     RelationalProbabilisticCircuit,
 )
 from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import SumUnit
@@ -183,3 +188,72 @@ def test_ground_variable_count_scales_with_query_size(rpc):
     )
     query_4.resolve()
     assert len(rpc.ground(query_4).variables) > len(rpc.ground(query_2).variables)
+
+
+# %% GroundingMode.CAUSAL_SAMPLED retains undetermined latents instead of discarding them
+
+
+def test_predictive_grounding_is_unaffected_by_the_explicit_default(rpc, room_query_4):
+    np.random.seed(0)
+    implicit_default = {v.name for v in rpc.ground(room_query_4).variables}
+    np.random.seed(0)
+    explicit_predictive = {
+        v.name
+        for v in rpc.ground(
+            room_query_4, grounding_mode=GroundingMode.PREDICTIVE
+        ).variables
+    }
+    assert implicit_default == explicit_predictive
+
+
+def test_causal_sampled_grounding_retains_undetermined_latents_as_variables(
+    rpc, room_query_4
+):
+    np.random.seed(0)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    names = {v.name for v in model.variables}
+    assert "SceneRoomAggregations.chair_count()" in names
+    assert "SceneRoomAggregations.table_count()" in names
+
+
+def test_causal_sampled_grounding_preserves_object_type_variables(rpc, room_query_4):
+    np.random.seed(0)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    names = {v.name for v in model.variables}
+    for i in range(4):
+        assert f"SceneRoom.objects[{i}].type" in names
+
+
+def test_causal_sampled_grounding_is_valid(rpc, room_query_4):
+    np.random.seed(0)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    assert model.is_valid()
+
+
+def test_causal_sampled_grounding_supports_causal_circuit_registration(
+    rpc, room_query_4
+):
+    """
+    The whole point of ``GroundingMode.CAUSAL_SAMPLED``: a latent that predictive
+    grounding would have discarded must be usable as a registered cause in a
+    ``CausalCircuit`` -- i.e. verified support-deterministic against it, the structural
+    precondition ``backdoor_adjustment`` relies on.
+    """
+    np.random.seed(0)
+    model = rpc.ground(room_query_4, grounding_mode=GroundingMode.CAUSAL_SAMPLED)
+    chair_count_variable = next(
+        v for v in model.variables if v.name == "SceneRoomAggregations.chair_count()"
+    )
+    object_type_variable = next(
+        v for v in model.variables if v.name == "SceneRoom.objects[0].type"
+    )
+
+    tree = MarginalDeterminismTreeNode.from_causal_graph(
+        [chair_count_variable], [object_type_variable]
+    )
+    causal_circuit = CausalCircuit.from_probabilistic_circuit(
+        model, tree, [chair_count_variable], [object_type_variable]
+    )
+
+    result = causal_circuit.verify_support_determinism()
+    assert result.passed

--- a/test/krrood_test/test_feature_extraction/test_rspns.py
+++ b/test/krrood_test/test_feature_extraction/test_rspns.py
@@ -17,6 +17,7 @@ from probabilistic_model.probabilistic_circuit.relational.exceptions import (
     InvalidMonteCarloSampleCountError,
 )
 from probabilistic_model.probabilistic_circuit.relational.rspn import (
+    ExchangeablePartGrounder,
     GroundingMode,
     RelationalProbabilisticCircuit,
 )
@@ -347,7 +348,7 @@ def test_exact_grounding_falls_back_to_sampled_when_partition_overlaps(
     """
     np.random.seed(0)
     with patch.object(
-        RelationalProbabilisticCircuit,
+        ExchangeablePartGrounder,
         "_undetermined_latents_partition_disjointly",
         return_value=False,
     ):
@@ -484,7 +485,7 @@ def test_representative_value_returns_a_point_not_a_region():
     circuit = ProbabilisticCircuit()
     branch = _integer_leaf(variable, {2: 0.5, 3: 0.5}, circuit)
 
-    representative_value = RelationalProbabilisticCircuit._representative_value(
+    representative_value = ExchangeablePartGrounder._representative_value(
         branch, SortedSet([variable])
     )
 
@@ -537,12 +538,12 @@ def test_node_local_branch_log_probabilities_reflect_each_nodes_own_correlation(
     region_three = SimpleEvent.from_data({chair_count: 3}).as_composite_set()
 
     weights_for_node_favoring_one = (
-        RelationalProbabilisticCircuit._node_local_branch_log_probabilities(
+        ExchangeablePartGrounder._node_local_branch_log_probabilities(
             node_favoring_one, SortedSet([chair_count]), [region_one, region_three]
         )
     )
     weights_for_node_favoring_three = (
-        RelationalProbabilisticCircuit._node_local_branch_log_probabilities(
+        ExchangeablePartGrounder._node_local_branch_log_probabilities(
             node_favoring_three, SortedSet([chair_count]), [region_one, region_three]
         )
     )
@@ -551,7 +552,7 @@ def test_node_local_branch_log_probabilities_reflect_each_nodes_own_correlation(
     assert weights_for_node_favoring_three[1] > weights_for_node_favoring_three[0]
 
 
-# %% RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly
+# %% ExchangeablePartGrounder._undetermined_latents_partition_disjointly
 
 
 def _integer_leaf(variable, probabilities, circuit):
@@ -575,7 +576,7 @@ def test_partition_disjointly_false_for_a_single_branch():
     circuit = ProbabilisticCircuit()
     _integer_leaf(variable, {1: 1.0}, circuit)
     assert (
-        not RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+        not ExchangeablePartGrounder._undetermined_latents_partition_disjointly(
             circuit
         )
     )
@@ -588,7 +589,7 @@ def test_partition_disjointly_true_for_disjoint_branches():
     root.add_subcircuit(_integer_leaf(variable, {1: 1.0}, circuit), 0.0)
     root.add_subcircuit(_integer_leaf(variable, {2: 1.0}, circuit), 0.0)
     root.normalize()
-    assert RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+    assert ExchangeablePartGrounder._undetermined_latents_partition_disjointly(
         circuit
     )
 
@@ -601,7 +602,7 @@ def test_partition_disjointly_false_for_overlapping_branches():
     root.add_subcircuit(_integer_leaf(variable, {2: 0.5, 3: 0.5}, circuit), 0.0)
     root.normalize()
     assert (
-        not RelationalProbabilisticCircuit._undetermined_latents_partition_disjointly(
+        not ExchangeablePartGrounder._undetermined_latents_partition_disjointly(
             circuit
         )
     )

--- a/test/probabilistic_model_test/test_causal/test_causal_circuit.py
+++ b/test/probabilistic_model_test/test_causal/test_causal_circuit.py
@@ -299,6 +299,65 @@ def _build_unnormalized_circuit() -> tuple:
     return circuit, x, y
 
 
+def _build_shared_cause_subcircuit_circuit() -> tuple:
+    """
+    A DAG, not a tree: the SumUnit over the cause x is mounted as a shared child of two
+    different ProductUnits, matching the mounting pattern RSPN grounding uses when one
+    exchangeable instance is attached under several class-level product nodes.
+
+        SumUnit(root)
+          ProductUnit_a(SumUnit_x [shared], leaf y∈[0,1])
+          ProductUnit_b(SumUnit_x [shared], leaf y∈[2,3])
+
+        SumUnit_x [x∈[0,1] w=0.6, x∈[1,2] w=0.4]  -- same node object under both parents
+
+    Ground truth: x's two branches are disjoint regardless of which parent reaches
+    them, so verify_support_determinism must pass.
+    """
+    x = Continuous("x")
+    y = Continuous("y")
+    circuit = ProbabilisticCircuit()
+    root = SumUnit(probabilistic_circuit=circuit)
+
+    shared_sum_x = SumUnit(probabilistic_circuit=circuit)
+    shared_sum_x.add_subcircuit(
+        leaf(
+            UniformDistribution(variable=x, interval=closed(0, 1).simple_sets[0]),
+            circuit,
+        ),
+        math.log(0.6),
+    )
+    shared_sum_x.add_subcircuit(
+        leaf(
+            UniformDistribution(variable=x, interval=closed(1, 2).simple_sets[0]),
+            circuit,
+        ),
+        math.log(0.4),
+    )
+
+    product_a = ProductUnit(probabilistic_circuit=circuit)
+    product_a.add_subcircuit(shared_sum_x)
+    product_a.add_subcircuit(
+        leaf(
+            UniformDistribution(variable=y, interval=closed(0, 1).simple_sets[0]),
+            circuit,
+        )
+    )
+
+    product_b = ProductUnit(probabilistic_circuit=circuit)
+    product_b.add_subcircuit(shared_sum_x)
+    product_b.add_subcircuit(
+        leaf(
+            UniformDistribution(variable=y, interval=closed(2, 3).simple_sets[0]),
+            circuit,
+        )
+    )
+
+    root.add_subcircuit(product_a, math.log(0.5))
+    root.add_subcircuit(product_b, math.log(0.5))
+    return circuit, x, y
+
+
 def _marginal_probability(
     circuit: ProbabilisticCircuit,
     variable: Continuous,
@@ -619,6 +678,31 @@ class VerifySupportDeterminismDisjointnessTestCase(unittest.TestCase):
         cc = CausalCircuit.from_probabilistic_circuit(circuit, tree, [x], [y])
         result = cc.verify_support_determinism()
         self.assertTrue(result.passed, msg=f"Violations: {result.violations}")
+
+
+class VerifySupportDeterminismSharedSubcircuitTestCase(unittest.TestCase):
+    """
+    A shared child (a node with more than one parent) must be visited once by
+    _check_support_disjointness's traversal and its disjointness result attributed
+    correctly to every parent -- the pattern RSPN's exact-partition and Monte-Carlo
+    grounding both rely on when one grounded instance is mounted under several class-
+    level product nodes.
+    """
+
+    def test_shared_cause_subcircuit_passes(self):
+        circuit, x, y = _build_shared_cause_subcircuit_circuit()
+        tree = MarginalDeterminismTreeNode.from_causal_graph([x], [y])
+        cc = CausalCircuit.from_probabilistic_circuit(circuit, tree, [x], [y])
+        result = cc.verify_support_determinism()
+        self.assertTrue(result.passed, msg=f"Violations: {result.violations}")
+
+    def test_backdoor_adjustment_runs_on_a_shared_cause_subcircuit(self):
+        circuit, x, y = _build_shared_cause_subcircuit_circuit()
+        tree = MarginalDeterminismTreeNode.from_causal_graph([x], [y])
+        cc = CausalCircuit.from_probabilistic_circuit(circuit, tree, [x], [y])
+        interventional_circuit = cc.backdoor_adjustment(x, y, [])
+        self.assertIsInstance(interventional_circuit, ProbabilisticCircuit)
+        self.assertTrue(interventional_circuit.is_valid())
 
 
 class BackdoorAdjustmentStructuralTestCase(unittest.TestCase):

--- a/test/probabilistic_model_test/test_jpts/test_jpt.py
+++ b/test/probabilistic_model_test/test_jpts/test_jpt.py
@@ -104,6 +104,23 @@ class InferFromDataFrameTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             infer_variables_from_dataframe(df)
 
+    def test_string_dtype_column_is_treated_as_symbolic(self):
+        """
+        Regression test: with pandas' ``future.infer_string`` option enabled (the
+        default from pandas 3.0 onward), a string column's dtype no longer equals
+        ``object``, so relying on that equality alone stops recognizing it.
+        """
+        previous_infer_string = pd.options.future.infer_string
+        pd.options.future.infer_string = True
+        try:
+            df = pd.DataFrame({"symbol": ["a", "b", "c"]})
+            (annotated_variable,) = infer_variables_from_dataframe(df)
+        finally:
+            pd.options.future.infer_string = previous_infer_string
+
+        self.assertEqual(annotated_variable.variable.name, "symbol")
+        self.assertIsInstance(annotated_variable.variable, Symbolic)
+
 
 class JPTTestCase(unittest.TestCase):
     data: pd.DataFrame

--- a/test/probabilistic_model_test/test_rx/test_probabilistic_circuit.py
+++ b/test/probabilistic_model_test/test_rx/test_probabilistic_circuit.py
@@ -441,5 +441,36 @@ class MixedLeafTruncationTestCase(unittest.TestCase):
         self.assertAlmostEqual(truncated.probability(event), 1.0, places=9)
 
 
+# %% a leaf is its own only leaf
+
+
+class SingleLeafCircuitTestCase(unittest.TestCase):
+    """
+    A circuit whose root is itself a leaf, with no wrapping product or sum unit.
+    """
+
+    x = Continuous("x")
+
+    def setUp(self):
+        self.circuit = ProbabilisticCircuit()
+        self.leaf = leaf(
+            UniformDistribution(
+                variable=self.x, interval=SimpleInterval.from_data(0, 1)
+            ),
+            self.circuit,
+        )
+
+    def test_leaf_unit_lists_itself_as_its_own_leaf(self):
+        self.assertEqual(self.leaf.leaves, [self.leaf])
+
+    def test_circuit_rooted_at_a_single_leaf_lists_that_leaf(self):
+        self.assertEqual(self.circuit.leaves, [self.leaf])
+
+    def test_update_variables_renames_a_single_leaf_root(self):
+        renamed_x = Continuous("renamed_x")
+        self.circuit.update_variables({self.x: renamed_x})
+        self.assertEqual(self.leaf.distribution.variable, renamed_x)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/probabilistic_model_test/test_rx/test_probabilistic_circuit.py
+++ b/test/probabilistic_model_test/test_rx/test_probabilistic_circuit.py
@@ -472,5 +472,51 @@ class SingleLeafCircuitTestCase(unittest.TestCase):
         self.assertEqual(self.leaf.distribution.variable, renamed_x)
 
 
+class NestedProductUnitSimplifyTestCase(unittest.TestCase):
+    """
+    A ProductUnit whose own child is another ProductUnit -- the same-type nesting
+    ProductUnit.simplify() is meant to flatten.
+    """
+
+    x = Continuous("x")
+    y = Continuous("y")
+    z = Continuous("z")
+
+    def setUp(self):
+        self.circuit = ProbabilisticCircuit()
+        self.outer = ProductUnit(probabilistic_circuit=self.circuit)
+        self.inner = ProductUnit(probabilistic_circuit=self.circuit)
+        self.leaf_x = leaf(
+            UniformDistribution(
+                variable=self.x, interval=SimpleInterval.from_data(0, 1)
+            ),
+            self.circuit,
+        )
+        self.leaf_y = leaf(
+            UniformDistribution(
+                variable=self.y, interval=SimpleInterval.from_data(0, 1)
+            ),
+            self.circuit,
+        )
+        self.leaf_z = leaf(
+            UniformDistribution(
+                variable=self.z, interval=SimpleInterval.from_data(0, 1)
+            ),
+            self.circuit,
+        )
+        self.inner.add_subcircuit(self.leaf_x)
+        self.inner.add_subcircuit(self.leaf_y)
+        self.outer.add_subcircuit(self.inner)
+        self.outer.add_subcircuit(self.leaf_z)
+
+    def test_simplify_flattens_the_nested_product_unit(self):
+        self.circuit.simplify()
+        self.assertEqual(
+            set(self.outer.subcircuits), {self.leaf_x, self.leaf_y, self.leaf_z}
+        )
+        self.assertIsNone(self.inner.probabilistic_circuit)
+        self.assertEqual(len(self.circuit.nodes()), 4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### **Summary of the Relationship**
Adds relational causal reasoning: a relational model can now keep values it used to discard while grounding, so they can be registered as causes in a causal circuit and queried through cause/causes_effect.

- Lets a relational model (RSPN) keep values it used to throw away while grounding a query, so those values can be used as causes in a causal circuit.                                                    
- Adds a new setting, **_GroundingMode_**, with three choices: keep the old behavior (default), keep a value by sampling it, or keep a value using the exact split the model already learned from training data.                     
- Adds a new function that grounds a relational model for a query and returns a ready-to-use causal circuit in one step.                                                                                                       
- Adds a way to look up a variable in a grounded circuit by a short, readable name instead of its full internal name.                                                                                                          
- Extends the existing query system so **_cause/causes_effect_** questions now work on relational facts after this. 
- Fixes three bugs found while building and reviewing this: a grounding bug that produced a broken circuit, a bug where a single-item circuit failed to rename its own value, and a bug in the exact-split path that silently dropped the connection between a cause and its effect.                                                                                                                                                                       
- Added tests for the new settings, the new function, the query extension, and each bug fix, including tests that check results stay reproducible and that correlations are actually preserved.

### **Why this Relationship**

**_cause and causes_effect_** work only for flat, pre-built circuits registered per class via **_CausalCircuitRegistry_**, like a fixed class-to-circuit mapping. A relational fact (e.g., number of objects) doesn't have one fixed circuit; it depends on the specific scene being queried, and RSPN discarded that fact during grounding regardless of whether anyone wanted to query it. This PR gives relational queries a circuit to route through by grounding one for the specific query on demand, keeping the fact instead of dropping it.