### PR TITLE
Recognize pandas string dtype in infer_variables_from_dataframe

### DIFF
--- a/probabilistic_model/src/probabilistic_model/learning/jpt/variables.py
+++ b/probabilistic_model/src/probabilistic_model/learning/jpt/variables.py
@@ -4,7 +4,12 @@ import pandas as pd
 
 from krrood.utils import get_default_value
 from random_events.variable import Continuous, Integer, Symbolic, Variable
-from pandas.core.dtypes.common import is_integer_dtype, is_float_dtype, is_bool_dtype
+from pandas.core.dtypes.common import (
+    is_integer_dtype,
+    is_float_dtype,
+    is_bool_dtype,
+    is_string_dtype,
+)
 from random_events.set import Set
 from typing_extensions import List, Any
 
@@ -94,7 +99,7 @@ def infer_variables_from_dataframe(
         elif is_bool_dtype(datatype):
             variable_class = Symbolic
             domain = Set.from_iterable([True, False])
-        elif data[column].dtype == object:
+        elif data[column].dtype == object or is_string_dtype(datatype):
             unique_values = data[column].unique()
             variable_class = Symbolic
             domain = Set.from_iterable(unique_values)


### PR DESCRIPTION
## Summary
- Pandas 3.0 gives plain string columns their own `str` dtype instead of the old generic `object` dtype, so `infer_variables_from_dataframe` no longer classified them as `Symbolic` and instead raised `ValueError: Unsupported datatype: str`.
- Seen failing in CI job `test_each_lib (probabilistic_model) / test` (e.g. run 33858590374), hitting `BreastCancerTestCase` (7 tests) and `MNISTTestCase::test_serialization` in `test/probabilistic_model_test/test_jpts/test_jpt.py`.
- Fix: also match `is_string_dtype(datatype)` alongside the existing `dtype == object` check, so both dtype regimes route into the `Symbolic` branch.

## Test plan
- [x] `BreastCancerTestCase` and `MNISTTestCase::test_serialization` pass under `pandas==3.0.5` (previously failing with this exact error)
- [x] Full `probabilistic_model` suite: 408 passed, 1 skipped, no regressions (same as baseline under `pandas==2.3.3`)

Made with the help of Claude