### PR TITLE
Rewriting world reasoner rules

### DIFF
--- a/krrood/src/krrood/entity_query_language/core/expression_structure.py
+++ b/krrood/src/krrood/entity_query_language/core/expression_structure.py
@@ -1,13 +1,13 @@
 """
 Pure structural and semantic queries over EQL expression trees.
 
-These helpers answer questions about an expression's *shape* — its navigation chain, its
-chain root, whether it ends in a boolean attribute, whether it denotes a temporal value
-— without building anything or touching any rendering concern. They live in the core
-(next to the expression classes) because the facts they expose are domain knowledge of
-the query algebra, usable by any consumer (evaluation, optimization, verbalization, …),
+These helpers answer questions about an expression's *shape* — its navigation chain,
+its chain root, whether it reaches a boolean, whether it denotes a temporal value —
+without building anything or touching any rendering concern. They live in the core (next
+to the expression classes) because the facts they expose are domain knowledge of the
+query algebra, usable by any consumer (evaluation, optimization, verbalization, …),
 and they delegate to the existing :class:`MappedVariable` access-path properties rather
-than re-walking the tree.
+than re- walking the tree.
 """
 
 from __future__ import annotations
@@ -15,10 +15,14 @@ from __future__ import annotations
 import datetime
 import uuid
 
-from typing_extensions import Iterable, List, Set, Tuple
+from typing_extensions import Iterable, List, Optional, Set, Tuple
 
 from krrood.entity_query_language.core.base_expressions import SymbolicExpression
-from krrood.entity_query_language.core.mapped_variable import Attribute, MappedVariable
+from krrood.entity_query_language.core.mapped_variable import (
+    Attribute,
+    Call,
+    MappedVariable,
+)
 from krrood.entity_query_language.core.variable import Literal, Variable
 
 
@@ -69,13 +73,38 @@ def root_variable_ids(expressions: Iterable[SymbolicExpression]) -> Set[uuid.UUI
     }
 
 
-def chain_ends_in_boolean_attribute(chain: List[MappedVariable]) -> bool:
+def boolean_terminal_attribute(chain: List[MappedVariable]) -> Optional[Attribute]:
     """
     :param chain: A walked chain (root-adjacent first).
-    :return: ``True`` when the walked *chain* ends in a ``bool``-typed attribute (the
-        predicative *"<navigation> is <attribute>"* form).
+    :return: The attribute the walked *chain* reaches a ``bool`` through, or ``None`` when
+        the chain reaches something else.
+
+    A method that returns a ``bool`` is read as such an attribute too: the call adds
+    nothing a reader can name, so ``body.has_collision()`` reaches its ``bool`` through
+    ``has_collision`` exactly as a ``bool`` field would.
     """
-    return bool(chain) and isinstance(chain[-1], Attribute) and chain[-1]._type_ is bool
+    if not chain:
+        return None
+    terminal = chain[-1]
+    if isinstance(terminal, Call):
+        called = terminal._child_
+        return (
+            called
+            if terminal._type_ is bool and isinstance(called, Attribute)
+            else None
+        )
+    if isinstance(terminal, Attribute) and terminal._type_ is bool:
+        return terminal
+    return None
+
+
+def chain_ends_in_boolean_terminal(chain: List[MappedVariable]) -> bool:
+    """
+    :param chain: A walked chain (root-adjacent first).
+    :return: ``True`` when the walked *chain* reaches a ``bool`` (the predicative
+        *"<navigation> is <attribute>"* form).
+    """
+    return boolean_terminal_attribute(chain) is not None
 
 
 def is_date_type(type_: object) -> bool:

--- a/krrood/src/krrood/entity_query_language/core/mapped_variable.py
+++ b/krrood/src/krrood/entity_query_language/core/mapped_variable.py
@@ -55,7 +55,10 @@ from krrood.entity_query_language.utils import (
     merge_args_and_kwargs,
     convert_args_and_kwargs_into_hashable_key,
 )
-from krrood.symbol_graph.helpers import get_field_type_endpoint
+from krrood.symbol_graph.helpers import (
+    get_field_type_endpoint,
+    get_method_return_type,
+)
 
 if TYPE_CHECKING:
     from krrood.entity_query_language.operators.arithmetic import (
@@ -586,10 +589,9 @@ class Index(MappedVariable[T], ABC):
         Narrow ``_type_`` to the child's element type: indexing a ``List[X]``-like
         attribute reaches a single ``X``, not the container type itself.
 
-        Without this, an indexed attribute's ``_type_`` stayed the child's raw
-        container type (e.g. ``List[PlanNode]``), which later broke any
-        ``issubclass()`` check against it -- subscripted generics aren't valid
-        ``issubclass()`` arguments.
+        Without this, an indexed attribute's ``_type_`` stayed the child's raw container
+        type (e.g. ``List[PlanNode]``), which later broke any ``issubclass()`` check
+        against it -- subscripted generics aren't valid ``issubclass()`` arguments.
         """
         if self._type_ is not None:
             return
@@ -684,9 +686,19 @@ class Call(SingleValueMapping[T]):
         return f"{self._child_._var_._name_}()"
 
     def _update_type_(self) -> None:
-        if self._child_._type_ is None:
+        """
+        Resolve ``_type_`` to what the called thing returns.
+
+        A method is not a field, so the attribute naming it resolves to no type of its
+        own; the return annotation is then read off the method on its owner class.
+        """
+        if self._child_._type_ is not None:
+            self._type_ = get_type_hints_of_object(self._child_._type_)["return"]
             return
-        self._type_ = get_type_hints_of_object(self._child_._type_)["return"]
+        if isinstance(self._child_, Attribute):
+            self._type_ = get_method_return_type(
+                self._child_._owner_class_, self._child_._attribute_name_
+            )
 
 
 @dataclass(eq=False, repr=False)

--- a/krrood/src/krrood/entity_query_language/verbalization/attribute_predicates.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/attribute_predicates.py
@@ -16,9 +16,10 @@ import), so the chain assembler can call it without a cycle.
 from __future__ import annotations
 
 from dataclasses import replace
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from typing_extensions import List
+from typing_extensions import List, Optional, Type
 
 from krrood.entity_query_language.verbalization import morphology
 from krrood.entity_query_language.verbalization.boolean_predicate import (
@@ -49,10 +50,49 @@ if TYPE_CHECKING:
     from krrood.entity_query_language.core.mapped_variable import Attribute
 
 
+class SpelledOutHead(StrEnum):
+    """
+    A word a boolean attribute's name can open with that already spells the head of the
+    predicate the attribute reads as.
+
+    ``has_collision`` says *have* itself, so the predicate it reads as must take the
+    rest of the name as its object and not say *have* a second time (*"has collision"*,
+    never *"has has collision"*).
+    """
+
+    HAS = "has"
+    HAVE = "have"
+    IS = "is"
+    ARE = "are"
+
+    @classmethod
+    def opening(cls, words: List[str]) -> Optional[SpelledOutHead]:
+        """:param words: The words of an attribute's name, in order.
+
+        :return: The head *words* opens with and also says something about, or ``None`` when it
+            opens with no head or says nothing beyond it (a field simply called ``has``).
+        """
+        if len(words) < 2:
+            return None
+        return next((head for head in cls if head == words[0]), None)
+
+    @property
+    def predicate_type(self) -> Type[BooleanPredicate]:
+        """
+        The predicate whose head this word spells.
+        """
+        return (
+            PossessivePredicate
+            if self in (SpelledOutHead.HAS, SpelledOutHead.HAVE)
+            else AdjectivalPredicate
+        )
+
+
 def default_boolean_predicate(attribute_name: str) -> BooleanPredicate:
     """:param attribute_name: The boolean attribute's name.
 
-    :return: The predicate inferred from *attribute_name*'s shape — adjectival for a
+    :return: The predicate inferred from *attribute_name*'s shape — the one whose head the name
+        already spells (*"has_collision"* → *"has collision"*), else adjectival for a
         participle/adjective-shaped name (*"completed"*, *"operational"*), else possessive (*"milk"* →
         *"has milk"*).
 
@@ -65,8 +105,13 @@ def default_boolean_predicate(attribute_name: str) -> BooleanPredicate:
     reliable source of the classification is an explicit definition through the field's grammar
     metadata.
     """
-    last = attribute_name.split("_")[-1]
-    if morphology.is_past_participle(last) or morphology.is_likely_adjective(last):
+    words = attribute_name.split("_")
+    spelled_head = SpelledOutHead.opening(words)
+    if spelled_head is not None:
+        return spelled_head.predicate_type(" ".join(words[1:]))
+    if morphology.is_past_participle(words[-1]) or morphology.is_likely_adjective(
+        words[-1]
+    ):
         return AdjectivalPredicate()
     return PossessivePredicate()
 

--- a/krrood/src/krrood/entity_query_language/verbalization/grammar/chain/assembler.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/grammar/chain/assembler.py
@@ -4,6 +4,9 @@ from krrood.entity_query_language.core.base_expressions import SymbolicExpressio
 from krrood.entity_query_language.core.mapped_variable import (
     MappedVariable,
 )
+from krrood.entity_query_language.core.expression_structure import (
+    boolean_terminal_attribute,
+)
 from krrood.entity_query_language.core.variable import Variable
 from krrood.entity_query_language.verbalization.attribute_predicates import (
     boolean_alternative_clause,
@@ -171,6 +174,6 @@ class ChainAssembler(Assembler[MappedVariable, ChainPlan]):
         >>> verbalize_expression(variable(Worker, []).tasks[0].completed)
         'the first task of a Worker is completed'
         """
-        terminal = plan.chain[-1]
+        terminal = boolean_terminal_attribute(plan.chain)
         navigation_fragment = self.context.child(terminal._child_, inline=True)
         return navigation_fragment, terminal

--- a/krrood/src/krrood/entity_query_language/verbalization/grammar/chain/planner.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/grammar/chain/planner.py
@@ -11,7 +11,7 @@ from krrood.entity_query_language.core.mapped_variable import (
 )
 from krrood.entity_query_language.core.variable import Variable
 from krrood.entity_query_language.core.expression_structure import (
-    chain_ends_in_boolean_attribute,
+    chain_ends_in_boolean_terminal,
     walk_chain,
 )
 from krrood.entity_query_language.verbalization.navigation_path import (
@@ -31,8 +31,7 @@ from krrood.entity_query_language.verbalization.grammar.framework.planner import
 class ChainPlan:
     """
     A ``MappedVariable`` chain analysed once into the values its rendering needs: the
-    walked chain, its root, the display path-parts, and whether it ends in a boolean
-    attribute.
+    walked chain, its root, the display path-parts, and whether it reaches a boolean.
     """
 
     chain: List[MappedVariable]
@@ -52,7 +51,7 @@ class ChainPlan:
 
     is_boolean_terminal: bool
     """
-    ``True`` when the chain ends in a ``bool``-typed attribute (predicative form).
+    ``True`` when the chain reaches a ``bool`` (predicative form).
     """
 
     @property
@@ -89,8 +88,8 @@ class ChainPlan:
 class ChainPlanner(Planner[MappedVariable, ChainPlan]):
     """
     Analyse a ``MappedVariable`` chain into a ``ChainPlan``: its root, the display path-
-    parts, and whether it ends in a boolean attribute (predicative form) — the chain
-    decisions of *what to say*, before any surface form is chosen.
+    parts, and whether it reaches a boolean (predicative form) — the chain decisions of
+    *what to say*, before any surface form is chosen.
 
     Reference: :cite:t:`reiter2000building` — content/structure determination (microplanning).
 
@@ -109,5 +108,5 @@ class ChainPlanner(Planner[MappedVariable, ChainPlan]):
             chain=chain,
             root=root,
             parts=build_path_parts(chain, relational_verb),
-            is_boolean_terminal=chain_ends_in_boolean_attribute(chain),
+            is_boolean_terminal=chain_ends_in_boolean_terminal(chain),
         )

--- a/krrood/src/krrood/entity_query_language/verbalization/grammar/conditions/recognition.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/grammar/conditions/recognition.py
@@ -14,7 +14,7 @@ from krrood.entity_query_language.operators.aggregators import Aggregator, Extre
 from krrood.entity_query_language.operators.comparator import Comparator
 from krrood.entity_query_language.query.query import Entity
 from krrood.entity_query_language.core.expression_structure import (
-    chain_ends_in_boolean_attribute,
+    chain_ends_in_boolean_terminal,
     chain_root,
     walk_chain,
 )
@@ -161,8 +161,8 @@ def references(expression: SymbolicExpression, subject_variable: Variable) -> bo
 def is_boolean_attribute_chain(expression: SymbolicExpression) -> bool:
     """
     :param expression: Candidate expression.
-    :return: ``True`` when *expression* is a ``MappedVariable`` chain ending in a ``bool``-typed
-        attribute.
+    :return: ``True`` when *expression* is a ``MappedVariable`` chain reaching a ``bool``,
+        through either a ``bool``-typed attribute or a ``bool``-returning method.
 
     >>> is_boolean_attribute_chain(variable(Task, []).completed)
     True
@@ -172,7 +172,7 @@ def is_boolean_attribute_chain(expression: SymbolicExpression) -> bool:
     if not isinstance(expression, MappedVariable):
         return False
     chain, _ = walk_chain(expression)
-    return chain_ends_in_boolean_attribute(chain)
+    return chain_ends_in_boolean_terminal(chain)
 
 
 def fold_shared_subject_comparisons(

--- a/krrood/src/krrood/entity_query_language/verbalization/navigation_path.py
+++ b/krrood/src/krrood/entity_query_language/verbalization/navigation_path.py
@@ -66,10 +66,10 @@ class PathStep:
     """
 
     name: str
-    """The display text for this hop (e.g. ``"amount"``, ``"handle[0]"``, ``"()"``)."""
+    """The display text for this hop (e.g. ``"amount"``, ``"handle[0]"``, ``"first"``)."""
 
     source_reference: Optional[SourceReference] = None
-    """The attribute's source reference, or ``None`` for composite / index / call hops."""
+    """The attribute's source reference, or ``None`` for composite / index hops."""
 
     relation: Optional[RelationStep] = None
     """When set, this hop is a *relation* named as a verb (``assigned_to``) and renders as a relative
@@ -125,7 +125,8 @@ def build_path_parts(
       of …"* or a raw subscript (``"tasks[0]"``). An index that does not follow a plain attribute
       (e.g. on a call result) stays a standalone ordinal hop. Non-integer keys keep the ``"[key]"``
       bracket form.
-    * ``Call`` nodes appear as ``"()"`` with no source reference.
+    * ``Call`` nodes name no hop of their own: the attribute hop before them already names the
+      method, so *"the collision of a Body"* rather than *"the () of the collision of a Body"*.
     * Nodes that are not a :class:`SingleValueMapping` are skipped.
 
     :param chain: Innermost-first chain list (nearest the root first).
@@ -168,7 +169,8 @@ def build_path_parts(
         elif isinstance(node, Index):
             _append_index(parts, node)
         elif isinstance(node, Call):
-            parts.append(PathStep("()", None))
+            # A call names no step of its own: the attribute it invokes already named it.
+            pass
         elif not isinstance(node, SingleValueMapping):
             # A flattening names no step of its own: it chooses among the values the
             # step before it reached, which the path already names.

--- a/krrood/src/krrood/symbol_graph/helpers.py
+++ b/krrood/src/krrood/symbol_graph/helpers.py
@@ -23,6 +23,25 @@ from krrood.class_diagrams.wrapped_field import WrappedField
 from krrood.symbol_graph.symbol_graph import SymbolGraph
 
 
+def get_method_return_type(owner_class: Type, method_name: str) -> Optional[Type]:
+    """
+    :param owner_class: The class that owns the method.
+    :param method_name: The name of the method.
+    :return: The type the method is annotated to return, or ``None`` when *owner_class* has
+        no such method, the method carries no return annotation, or that annotation cannot
+        be resolved.
+    """
+    if owner_class is None:
+        return None
+    method = inspect.getattr_static(owner_class, method_name, None)
+    if not inspect.isfunction(method):
+        return None
+    try:
+        return get_type_hints_of_object(method).get("return")
+    except CouldNotResolveType:
+        return None
+
+
 def get_field_type_endpoint(owner_class: Type, field_name: str) -> Optional[Type]:
     """
     :param owner_class: The class of that owns the field.

--- a/semantic_digital_twin/doc/semantic_annotation.md
+++ b/semantic_digital_twin/doc/semantic_annotation.md
@@ -13,6 +13,5 @@ Semantic annotations can be inferred automatically by specifying rules that make
 Semantic annotations and any other attribute of the world that can be inferred or should be inferred through reasoning can be used
 through the world reasoner, you can check how to use the world reasoner [here](world_reasoner.md).
 
-Some helper methods exist in the world reasoner just for the semantic annotations like {py:func}`semantic_digital_twin.reasoner.WorldReasoner.infer_semantic_annotations`
-and {py:func}`semantic_digital_twin.reasoner.WorldReasoner.fit_semantic_annotations`.
+Some helper methods exist in the world reasoner just for the semantic annotations like {py:func}`semantic_digital_twin.reasoning.world_reasoner.WorldReasoner.infer_semantic_annotations`.
 

--- a/semantic_digital_twin/doc/world_reasoner.md
+++ b/semantic_digital_twin/doc/world_reasoner.md
@@ -16,9 +16,10 @@ joints of a parsed world model into semantic annotations: the body a slider pull
 {py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Drawer`, the body it slides out of becomes a
 {py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Cabinet`, and so on.
 
-It is a rule based classifier built on [Ripple Down Rules](https://github.com/AbdelrhmanBassiouny/ripple_down_rules/tree/main).
-The rules live in the semantic digital twin repository and are versioned and migrated with the world data structures
-they read, so they keep working as those data structures change.
+It is a rule based classifier built on [Ripple Down Rules](https://cram2.github.io/cognitive_robot_abstract_machine/krrood/ripple_down_rules/intro.html),
+which live in this workspace as {py:mod}`krrood.ripple_down_rules`. The rules live in the semantic digital twin
+package and are versioned and migrated with the world data structures they read, so they keep working as those data
+structures change.
 
 ## Using the reasoner
 
@@ -119,9 +120,10 @@ def drawers(world: World) -> List[Drawer]:
     )
 ```
 
-Rules are written in the [entity query language](https://github.com/tomsch420/krrood), which is what lets the reasoner
-explain itself afterwards (see below). Say as much as possible as a query over the joints rather than as a Python
-predicate: a join is what the explanation and the verbalization are able to read back.
+Rules are written in the [Entity Query Language](https://cram2.github.io/cognitive_robot_abstract_machine/krrood/eql/intro.html)
+({py:mod}`krrood.entity_query_language`), which is what lets the reasoner explain itself afterwards (see below).
+Say as much as possible as a query over the joints rather than as a Python predicate: a join is what the explanation
+and the verbalization are able to read back.
 
 Two things to keep in mind when writing one:
 

--- a/semantic_digital_twin/doc/world_reasoner.md
+++ b/semantic_digital_twin/doc/world_reasoner.md
@@ -11,25 +11,18 @@ kernelspec:
 
 # World Reasoner
 
-The world reasoner {py:class}`semantic_digital_twin.reasoner.WorldReasoner` is a class that uses [Ripple Down Rules](https://github.com/AbdelrhmanBassiouny/ripple_down_rules/tree/main)
-to classify concepts and attributes of the world. This is done using a rule based classifier that benefits from incremental
-rule addition through querying the system and answering the prompts that pop up using python code.
+The world reasoner {py:class}`semantic_digital_twin.reasoning.world_reasoner.WorldReasoner` turns the bodies and
+joints of a parsed world model into semantic annotations: the body a slider pulls out becomes a
+{py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Drawer`, the body it slides out of becomes a
+{py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Cabinet`, and so on.
 
-The benefit of that is the rules of the reasoner are based on the world datastructures and are updates as the datastructures
-are updated. Thus, the rules become a part of the semantic digital twin repository and are update, migrated, and versioned with it.
+It is a rule based classifier built on [Ripple Down Rules](https://github.com/AbdelrhmanBassiouny/ripple_down_rules/tree/main).
+The rules live in the semantic digital twin repository and are versioned and migrated with the world data structures
+they read, so they keep working as those data structures change.
 
-## How to use:
+## Using the reasoner
 
-There are two ways in which the reasoner can be used, classification mode, and fitting mode, both of which are explained
-bellow.
-
-### A: Classification Mode
-
-In classification mode, the reasoner is used as is with it's latest knowledge or rule trees to classify concepts about the
-world.
-
-For example lets say the reasoner now has rules that enable it find specific types of semantic annotations like the Drawer and the Cabinet.
-The way to use the reasoner is like the following example:
+Hand the reasoner a world and ask it what it can work out:
 
 ```{code-cell} ipython3
 from os.path import join, dirname
@@ -38,139 +31,132 @@ from semantic_digital_twin.adapters.urdf import URDFParser
 
 kitchen_world = URDFParser.from_file(join(dirname(__file__), '..', 'resources', 'urdf', 'kitchen-small.urdf')).parse()
 reasoner = WorldReasoner(kitchen_world)
-found_concepts = reasoner.reason()
 
-# 1st method, access the semantic annotations directly from the reasoning result
-new_semantic_annotations = found_concepts['semantic_annotations']
+# The annotations this run inferred.
+new_semantic_annotations = reasoner.infer_semantic_annotations()
 print(new_semantic_annotations)
 
-# Or 2nd method, access all the semantic annotations from the world.semantic_annotations, but this will include all semantic annotations not just the new ones.
-all_semantic_annotations = kitchen_world.semantic_annotations
-print(all_semantic_annotations)
+# Every annotation the world now holds, including any it already had.
+print(kitchen_world.semantic_annotations)
 ```
 
-Similarly, for any other world attribute that the reasoner can infer values for, just replace the 'semantic_annotations' with the 
-appropriate attribute name.
+Inferring also wires up what belongs together: a drawer is given the handle mounted on it, a cabinet is given the
+drawers and doors that open out of it, and every drawer and door is given the
+{py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Slider` or
+{py:class}`semantic_digital_twin.semantic_annotations.semantic_annotations.Hinge` that already moves it.
 
-### B: Fitting Mode
+{py:meth}`~semantic_digital_twin.reasoning.world_reasoner.WorldReasoner.reason` returns every world attribute the
+reasoner has rules for, keyed by attribute name, and only re-runs when the world model has changed since the last call.
 
-In fitting mode, the reasoner can be used to improve and enlarge it's rule tree or even to widen it's application to even
-more attributes of the world.
+## How a body is recognised
 
-For example, let's say you want to improve an existing rule that classifies Drawers, you can do that as follows:
+Two things decide what a body is, in this order.
+
+**The kinematic structure**, which settles everything that opens, never the name. The child of a prismatic
+connection is a drawer and the child of a revolute connection is a door. A handle is a body of its own that nothing
+hangs off, fixed to a part an active joint moves — so a drawer front's grip is a handle, while a tap's lever, which
+swings on a joint of its own, is part of the mechanism rather than a handle on it. A container is whatever rigidly
+mounted body has drawers or doors opening out of it.
+
+Bodies carrying no collision geometry are skipped, because world models use them as shapeless helpers to build up a
+compound motion: a door that pops out before it swings hangs off such a helper, and the rules look past it to the
+container the door really belongs to. A joint whose multiplier is not `1` only repeats another joint's motion — a
+URDF mimic — so the part it moves is a leaf of one mechanism rather than something that opens by itself. That is how
+a front folding out of two leaves is recognised as one door opened by the single handle on its lower leaf, while a
+dishwasher is not mistaken for its own door.
+
+All of this is asked as a query over the joints, so a rule reads as the shape it is looking for:
 
 ```{code-cell} ipython3
-from os.path import join, dirname
-from semantic_digital_twin.reasoning.world_reasoner import WorldReasoner
-from semantic_digital_twin.adapters.urdf import URDFParser
+from krrood.entity_query_language.factories import entity, inference, variable
+from semantic_digital_twin.semantic_annotations.semantic_annotations import Handle
+from semantic_digital_twin.world_description.connections import ActiveConnection, FixedConnection
+
+# A handle is a body fixed to a part that an active joint moves.
+mount = variable(FixedConnection, kitchen_world.connections)
+joint = variable(ActiveConnection, kitchen_world.connections)
+grip = mount.child
+print(
+    entity(inference(Handle)(root=grip))
+    .where(joint.child == mount.parent, grip.has_collision())
+    .tolist()
+)
+```
+
+**The body's name**, but only for the things no joint gives away: an oven, a sink, a worktop, a wall, a sofa, a table.
+Names are read through the annotation classes' own vocabulary — the words of the class name, plus any `_synonyms` the
+class declares — so the vocabulary lives on the class where every world benefits from it, rather than as strings
+spelled inside a rule. To teach the reasoner a new spelling for something, add it to that class's `_synonyms`.
+
+Compound names mention more than one kind: `sink_area_left_upper_drawer` says *where* the body is before it says
+*what* it is. Such a name is settled by the kind still being spoken about at its end, so that body is a drawer rather
+than a sink. A name is also allowed to stop the structure from claiming a body — a shelf board mounted inside a
+drawer looks exactly like a handle to the joints alone, and is kept apart by being called a board.
+
+## Changing or adding a rule
+
+The rules are ordinary, documented source in
+{py:mod}`semantic_digital_twin.reasoning.world_rdr.rules` — one function per annotation type, each returning
+every annotation of that type. To change what the reasoner infers, edit that function:
+
+```{code-cell} ipython3
+from krrood.entity_query_language.factories import entity, inference, variable
 from semantic_digital_twin.semantic_annotations.semantic_annotations import Drawer
-
-
-def create_kitchen_world():
-    return URDFParser.from_file(join(dirname(__file__), '..', 'resources', 'urdf', 'kitchen-small.urdf')).parse()
-
-
-kitchen_world = create_kitchen_world()
-reasoner = WorldReasoner(kitchen_world)
-
-reasoner.fit_attribute("semantic_annotations", [Drawer], update_existing_semantic_annotations=True,
-                       world_factory=create_kitchen_world)
-```
-
-Then you will be prompted to write a rule for Drawer, and you can see the currently detected drawers shown in the Ipyton
-shell. Maybe you see a mistake and not all the currently detected drawers are actual drawers, so you want to filter the
-results. To start writing your rule, just type `%edit` in the Ipython terminal as shown the image bellow, or if using
-the GUI just press the `Edit` button.
-
-```{figure} _static/images/write_edit_in_ipython.png
----
-width: 800px
----
-Open the Template File in Editor from the Ipython Shell.
-```
-
-Now, a template file with some imports and an empty function is openned for you to write your rule inside the body of
-the function as shown bellow:
-
-```{code-cell} ipython3
-from dataclasses import dataclass, field
-from posixpath import dirname
-from typing_extensions import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
-from krrood.ripple_down_rules.rdr import GeneralRDR
-from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
-from semantic_digital_twin.world_description.world_entity import SemanticAnnotation
-from semantic_digital_twin.reasoning.world_reasoner import WorldReasoner
 from semantic_digital_twin.world import World
-from semantic_digital_twin.semantic_annotations.semantic_annotations import Drawer
+from semantic_digital_twin.world_description.connections import PrismaticConnection
+from typing_extensions import List
 
 
-def world_semantic_annotations_of_type_drawer(case: World) -> List[Drawer]:
-    """Get possible value(s) for World.semantic_annotations  of type Drawer."""
-    # Write code here
-    pass
+def drawers(world: World) -> List[Drawer]:
+    """
+    Every body a slider pulls straight out of a container.
+    """
+    slider = variable(PrismaticConnection, world.connections)
+    return (
+        entity(inference(Drawer)(root=slider.child))
+        .where(slider.child.has_collision())
+        .tolist()
+    )
 ```
 
-You can write a filter on the current semantic annotations of type Drawer as follows:
+Rules are written in the [entity query language](https://github.com/tomsch420/krrood), which is what lets the reasoner
+explain itself afterwards (see below). Say as much as possible as a query over the joints rather than as a Python
+predicate: a join is what the explanation and the verbalization are able to read back.
+
+Two things to keep in mind when writing one:
+
+- **Read the annotations you depend on from the world you were handed**, as `world.semantic_annotations`. Rules run
+  repeatedly until nothing new appears, so a rule can build on what earlier rules concluded, but those conclusions
+  have not reached the world itself yet while the rules are still running.
+- **Keep rules for the same type disjoint.** An annotation is identified by its type together with the bodies it
+  refers to, so a drawer with a handle and the same drawer without one are two different annotations and the world
+  would end up with both. That is why the drawer and door rules come in pairs, one for the parts that carry a handle
+  and one for those that do not.
+
+Beside it, `world_semantic_annotations_mcrdr_defs.py` holds the `conditions_`/`conclusion_` pairs the classifier
+actually calls: each names the precondition of one rule and the rule that runs under it. A new rule needs a pair
+added there, its type added to the `conclusion_type` of `world_semantic_annotations_mcrdr.py`, and — because the
+classifier rebuilds each rule from that file's imports — the rule itself has to be importable, which is why the
+rules sit in `rules.py` rather than inside the pairs.
+
+```{note}
+Rules used to be written by prompting for them in an interactive shell, through
+{py:meth}`~semantic_digital_twin.reasoning.reasoner.CaseReasoner.fit_attribute`. That way of authoring them is no
+longer used here: edit the rules in `world_rdr/rules.py` directly instead.
+```
+
+## Asking why
+
+Because rules are queries rather than opaque code, the reasoner can say what made it reach a conclusion, and say it in
+English:
 
 ```{code-cell} ipython3
-from dataclasses import dataclass, field
-from posixpath import dirname
-from typing_extensions import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
-from krrood.ripple_down_rules.rdr import GeneralRDR
-from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
-from semantic_digital_twin.world_description.world_entity import SemanticAnnotation
-from semantic_digital_twin.reasoning.world_reasoner import WorldReasoner
-from semantic_digital_twin.world import World
-from semantic_digital_twin.semantic_annotations.semantic_annotations import Drawer
+from krrood.entity_query_language.explanation.explanation import explain_inference
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
 
+drawer = next(a for a in new_semantic_annotations if isinstance(a, Drawer))
+explanation = explain_inference(drawer)
 
-def world_semantic_annotations_of_type_drawer(case: World) -> List[Drawer]:
-    """Get possible value(s) for World.semantic_annotations  of type Drawer."""
-    known_drawers = [v for v in case.semantic_annotations if isinstance(v, Drawer)]
-    good_drawers = [d for d in known_drawers if d.name.name != "bad_drawer"]
-    return good_drawers
+print(explanation.get_satisfied_conditions_as_string())
+print(verbalize_expression(explanation.query_root))
 ```
-
-So the above is the generated template, and I just filled in the body of the function with my rule logic. After that
-you write `%load` in the Ipython and the function you just wrote will be available to you to test it out in the Ipython
-shell as shown bellow (in the GUI just pres the Load button):
-
-```{figure} _static/images/load_rule_and_test_it.png
----
-width: 1600px
----
-Load the written Rule into the Ipython Shell.
-```
-
-Then if you want to change the rule, just edit the already open template file and do `load` again. Once you are happy
-with your rule results just return the function output as follows (in the GUI just press the Accept button):
-
-```{figure} _static/images/accept_rule.png
----
-width: 600px
----
-Accept the Rule in Ipython.
-```
-
-If you also want to contribute to the semantic digital twin package, then it's better to do that in the `test_semantic_annotations/test_semantic_annotations.py`
-test file. Since there is already rules for Drawer, there would already be a test method for that. All you need to do is
-set the `update_existing_semantic_annotations` to `True` like this:
-
-```{code-cell} ipython3
-def test_drawer_semantic_annotation(self):
-    self.fit_rules_for_a_semantic_annotation_in_apartment(Drawer, scenario=self.test_drawer_semantic_annotation, update_existing_semantic_annotations=True)
-```
-then run the test from the terminal using `pytest` as follows:
-```bash
-cd semantic_digital_twin/test/test_semantic_annotations && pytest -s -k "test_drawer_semantic_annotation"
-```
-Then answer the prompt with the rule as described before. Now the rules for the Drawer semantic annotation has been updated, Nice Work!
-
-You could also create a new test method if your world is not the apartment or if you want to add a specific test for a
-specific context, more tests are always welcome :D. Just make sure you set the scenario to be the new test method name,
-and set the world factory to the method that creates your world (if it doesn't exist create one and put it in the test 
-file).
-
-In addition you can fit the reasoner on a totally new concept/attribute of the world instead of `semantic_annotations`, maybe `regions`
-or `predicates` , ...etc. What's great is that inside your rules you can use the semantic annotations that were classified already by
-the semantic annotations rules, and vice verse, you can add semantic annotations rules that use outputs from rules on other attributes as well.

--- a/semantic_digital_twin/scripts/generate_orm.py
+++ b/semantic_digital_twin/scripts/generate_orm.py
@@ -17,8 +17,11 @@ import semantic_digital_twin.orm.model
 
 import semantic_digital_twin.adapters.procthor.procthor_resolver
 from krrood.adapters.json_serializer import SubclassJSONSerializer
+from krrood.entity_query_language.predicate import SymbolicCallable
 from krrood.ormatic.ormatic import ORMatic
-from semantic_digital_twin.reasoning.predicates import ContainsType
+from krrood.utils import recursive_subclasses
+import semantic_digital_twin.reasoning.predicates
+import semantic_digital_twin.reasoning.world_rdr.rules
 from semantic_digital_twin.semantic_annotations.position_descriptions import (
     SemanticDirection,
 )
@@ -42,11 +45,13 @@ ignore_classes = {
     ForwardKinematicsManager,
     MeshFileStorage,
     semantic_digital_twin.adapters.procthor.procthor_resolver.ProcthorResolver,
-    ContainsType,
     SemanticDirection,
     SubclassJSONSerializer,
+    # A symbolic operation is a step of a query, not something a world stores, so none of
+    # them is mapped. The modules defining them are imported above so that they are all
+    # declared by the time this is read.
+    *recursive_subclasses(SymbolicCallable),
 }
-
 
 
 def generate_orm():

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/reasoner.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/reasoner.py
@@ -6,16 +6,13 @@ from os.path import dirname
 
 from typing_extensions import (
     ClassVar,
-    List,
     Dict,
     Any,
-    TYPE_CHECKING,
     Optional,
     Type,
 )
 
 from krrood.ripple_down_rules.rdr import GeneralRDR
-from krrood.ripple_down_rules.datastructures.dataclasses import CaseQuery
 
 
 class ReasoningResult(UserDict[str, Any]): ...
@@ -27,17 +24,14 @@ class CaseRDRs(UserDict[Type, GeneralRDR]): ...
 @dataclass
 class CaseReasoner:
     """
-    The case reasoner is a class that uses Ripple Down Rules to reason on case related concepts.
-    The reasoner can be used in two ways:
-    1. Classification mode, where the reasoner infers all concepts that it has rules for at that time.
+    Uses Ripple Down Rules to infer concepts about a case.
+
+    The rules are read from the model directory and applied to the case, inferring every
+    concept they have a rule for:
+
     >>> reasoner = CaseReasoner(case)
     >>> inferred_concepts = reasoner.reason()
     >>> inferred_attribute_values = inferred_concepts['attribute_name']
-    2. Fitting mode, where the reasoner prompts the expert for answers given a query on a world concept. This allows
-    incremental knowledge gain, improved reasoning capabilities, and an increased breadth of application with more
-     usage.
-     >>> reasoner = CaseReasoner(case)
-     >>> reasoner.fit_attribute("attribute_name", [attribute_types,...], False)
     """
 
     case: Any
@@ -86,29 +80,3 @@ class CaseReasoner:
         """
         self.result = self.rdr.classify(self.case, modify_case=True)
         return self.result
-
-    def fit_attribute(
-        self,
-        attribute_name: str,
-        attribute_types: List[Type[Any]],
-        mutually_exclusive: bool,
-        update_existing_rules: bool = False,
-    ) -> None:
-        """
-        Fit the semantic annotation RDR to the required attribute types.
-
-        :param attribute_name: The attribute name that the RDR should be fitted to.
-        :param attribute_types: A list of attribute types that the RDR should be fitted
-            to.
-        :param mutually_exclusive: whether the attribute values are mutually exclusive
-            or not.
-        :param update_existing_rules: If True, existing rules of the given types will be
-            updated with new rules, else they will be skipped.
-        """
-        case_query = CaseQuery(
-            self.case,
-            attribute_name,
-            tuple(attribute_types),
-            mutually_exclusive,
-        )
-        self.rdr.fit_case(case_query, update_existing_rules=update_existing_rules)

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
@@ -1,0 +1,636 @@
+"""
+The rules of the world semantic-annotation classifier.
+
+Each rule returns every annotation of one type. Everything that opens is recognised from
+the kinematic structure alone, as a query over the joints; body names are read only for
+the kinds no joint distinguishes, and then through the annotation classes' own vocabulary
+(:meth:`~semantic_digital_twin.world_description.world_entity.WorldEntity.class_name_tokens`
+and ``_synonyms``) rather than through literals spelled here.
+
+.. note:: The rules live beside the classifier rather than inside it because the
+    classifier rebuilds each rule from the imports of
+    ``world_semantic_annotations_mcrdr_defs``, so a rule has to be importable to be
+    callable from there.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from krrood.entity_query_language.factories import (
+    and_,
+    entity,
+    exists,
+    inference,
+    not_,
+    variable,
+)
+from krrood.entity_query_language.predicate import symbolic_function
+from typing_extensions import Iterable, List, Optional, Sequence, Tuple, Type, Union
+
+from semantic_digital_twin.semantic_annotations.mixins import (
+    HasRootKinematicStructureEntity,
+)
+from semantic_digital_twin.semantic_annotations.semantic_annotations import (
+    Cabinet,
+    CoffeeMachine,
+    CoffeeTable,
+    Cooktop,
+    CounterTop,
+    Dishwasher,
+    Door,
+    Drawer,
+    Fridge,
+    Handle,
+    Oven,
+    ShelfLayer,
+    SideTable,
+    Sink,
+    Sofa,
+    Table,
+    Wall,
+    Wardrobe,
+)
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.connections import (
+    ActiveConnection,
+    ActiveConnection1DOF,
+    FixedConnection,
+    PrismaticConnection,
+    RevoluteConnection,
+)
+from semantic_digital_twin.world_description.world_entity import (
+    Body,
+    SemanticAnnotation,
+)
+
+# %% the vocabulary the rules recognise
+
+
+class NamedKind(Enum):
+    """
+    A kind a body name can mention.
+
+    A compound name mentions more than one: ``sink_area_left_drawer`` says where the body
+    is before it says what it is. Every kind that can appear in a name has to be a member
+    here for :func:`asserted_kind` to work out which one the name settles on, including
+    the kinds the rules recognise from the joints rather than from a name.
+
+    .. note:: :class:`Handle` is deliberately absent, because a handle is recognised
+        entirely from how it is jointed. See :func:`handles`.
+    """
+
+    DOOR = Door
+    DRAWER = Drawer
+    OVEN = Oven
+    SINK = Sink
+    COOKTOP = Cooktop
+    COUNTER_TOP = CounterTop
+    SOFA = Sofa
+    WALL = Wall
+    SHELF_LAYER = ShelfLayer
+    COFFEE_MACHINE = CoffeeMachine
+    TABLE = Table
+    COFFEE_TABLE = CoffeeTable
+    SIDE_TABLE = SideTable
+
+    @classmethod
+    def recognised_from_the_joints(cls) -> Tuple[NamedKind, ...]:
+        """
+        The kinds a joint gives away, which a name is therefore never asked to decide.
+
+        They still take part in reading a name, so that a name mentioning one of them
+        settles on it rather than on the furniture it also mentions.
+        """
+        return cls.DOOR, cls.DRAWER
+
+    @property
+    def is_furniture(self) -> bool:
+        """
+        Whether nothing but a name gives this kind away.
+        """
+        return self not in self.recognised_from_the_joints()
+
+
+class ContainerKind(Enum):
+    """
+    The kinds of container that are more specific than a plain :class:`Cabinet`.
+
+    A container is named after its kind either directly or through one of its parts, so
+    an appliance whose front carries the name is still recognised.
+    """
+
+    WARDROBE = Wardrobe
+    DISHWASHER = Dishwasher
+    FRIDGE = Fridge
+
+
+AnnotationKind = Union[NamedKind, ContainerKind]
+"""
+A member of either vocabulary a name can be read against, each standing for one
+annotation class.
+"""
+
+# %% what a body's name asserts
+
+
+def _name_words(body: Body, word_separator: str = "_") -> List[str]:
+    """
+    The words of a body's name, in order, with numbering removed.
+
+    Numbering distinguishes repetitions of the same thing, so ``shelf_level4`` says the
+    same about what the body *is* as ``shelf_level`` does.
+
+    :param word_separator: What separates the words of a name in the world model being
+        read, as in ``handle_cabinet5_top``.
+    """
+    return [
+        re.sub(r"\d+", "", word)
+        for word in body.name.name.lower().split(word_separator)
+    ]
+
+
+@dataclass
+class NameMatch:
+    """
+    What a body's name says about one kind.
+    """
+
+    kind: AnnotationKind
+    """
+    The kind the name mentions.
+    """
+
+    covered_words: int
+    """
+    How many of the name's words the kind accounts for.
+    """
+
+    last_word_index: int
+    """
+    How far into the name the kind is still being spoken about.
+    """
+
+
+def _match_name(words: Sequence[str], kind: AnnotationKind) -> Optional[NameMatch]:
+    """
+    What ``words`` say about ``kind``, or ``None`` when they do not mention it.
+
+    A name mentions a kind by spelling out every word of the kind's own name, or by
+    using one of its synonyms.
+    """
+    annotation_type = kind.value
+    class_words = annotation_type.class_name_tokens()
+    if not (class_words <= set(words) or annotation_type._synonyms & set(words)):
+        return None
+    vocabulary = class_words | annotation_type._synonyms
+    matched = [index for index, word in enumerate(words) if word in vocabulary]
+    return NameMatch(kind, len(matched), max(matched))
+
+
+def asserted_kind(
+    words: Sequence[str], candidates: Iterable[AnnotationKind]
+) -> Optional[AnnotationKind]:
+    """
+    The kind a name settles on, or ``None`` when it mentions none of ``candidates``.
+
+    A compound name qualifies from the left, so the kind still being spoken about at the
+    end of the name is the one the body is; among kinds that reach equally far, the one
+    accounting for more of the name wins, and then the more specific one.
+    """
+    matches = [
+        match
+        for match in (_match_name(words, candidate) for candidate in candidates)
+        if match is not None
+    ]
+    if not matches:
+        return None
+    last_word_index = max(match.last_word_index for match in matches)
+    return max(
+        (match for match in matches if match.last_word_index == last_word_index),
+        key=lambda match: (
+            match.covered_words,
+            len(match.kind.value.__mro__),
+        ),
+    ).kind
+
+
+@symbolic_function
+def is_named_after(body: Body, annotation_type: Type[SemanticAnnotation]) -> bool:
+    """
+    Whether the body's name settles on ``annotation_type`` rather than on any other kind
+    it mentions.
+    """
+    kind = asserted_kind(_name_words(body), NamedKind)
+    return kind is not None and kind.value is annotation_type
+
+
+@symbolic_function
+def names_no_recognised_kind(body: Body) -> bool:
+    """
+    Whether the body's name claims none of the kinds the rules recognise by name, and so
+    leaves the body to be decided by how it is jointed.
+    """
+    return asserted_kind(_name_words(body), NamedKind) is None
+
+
+@symbolic_function
+def is_not_named_after_furniture(body: Body) -> bool:
+    """
+    Whether the body's name refrains from claiming a kind of furniture.
+
+    Nothing about how a body is jointed tells a shelf board mounted inside a drawer
+    apart from the drawer's handle, so a body the model calls furniture is left to the
+    rules that go by name.
+    """
+    kind = asserted_kind(_name_words(body), NamedKind)
+    return kind is None or not kind.is_furniture
+
+
+@symbolic_function
+def container_kind_of(body: Body) -> Optional[ContainerKind]:
+    """
+    The kind of container the body is, read from its own name and those of its parts, or
+    ``None`` when nothing names a kind more specific than a cabinet.
+    """
+    for part in body._world.get_kinematic_structure_entities_of_branch(body):
+        kind = asserted_kind(_name_words(part), ContainerKind)
+        if kind is not None:
+            return kind
+    return None
+
+
+# %% identities the world already holds
+
+
+@symbolic_function
+def is_not_already_something_else(
+    body: Body,
+    kind: Type[SemanticAnnotation],
+    annotations: Sequence[SemanticAnnotation],
+) -> bool:
+    """
+    Whether nothing but ``kind`` has been annotated on the body yet.
+
+    An object put away in a drawer is jointed exactly as a handle is, so a body whose
+    identity the world already holds keeps it instead of being claimed by a rule that
+    only looks at the joints.
+    """
+    return not any(
+        annotation.root is body
+        for annotation in annotations
+        if isinstance(annotation, HasRootKinematicStructureEntity)
+        and not isinstance(annotation, kind)
+    )
+
+
+# %% the parts a container holds
+
+
+def _holder_of(body: Body) -> Optional[Body]:
+    """
+    The nearest body above this one that is a real part of the furniture.
+
+    Bodies without geometry are skipped, because world models use them to carry a joint
+    and nothing else, so a door reached through a pop-out helper still resolves to the
+    container it belongs to.
+    """
+    holder = body.parent_kinematic_structure_entity
+    while holder is not None and not holder.has_collision():
+        holder = holder.parent_kinematic_structure_entity
+    return holder
+
+
+def _parts_held_by(
+    body: Body,
+    annotations: Sequence[SemanticAnnotation],
+    part_type: Type[SemanticAnnotation],
+) -> List:
+    """
+    The annotations of ``part_type`` whose body opens out of ``body``.
+
+    Rules read the annotations inferred so far from what they are given rather than from
+    the world, because a rule runs before its conclusions reach the world.
+    """
+    return [
+        annotation
+        for annotation in annotations
+        if isinstance(annotation, part_type) and _holder_of(annotation.root) is body
+    ]
+
+
+@symbolic_function
+def drawers_of(body: Body, annotations: Sequence[SemanticAnnotation]) -> List[Drawer]:
+    """
+    The drawers that slide out of the body.
+    """
+    return _parts_held_by(body, annotations, Drawer)
+
+
+@symbolic_function
+def doors_of(body: Body, annotations: Sequence[SemanticAnnotation]) -> List[Door]:
+    """
+    The doors that swing off the body.
+    """
+    return _parts_held_by(body, annotations, Door)
+
+
+@symbolic_function
+def holds_openable_parts(body: Body, annotations: Sequence[SemanticAnnotation]) -> bool:
+    """
+    Whether anything opens out of the body, which is what makes it a container.
+    """
+    return bool(
+        _parts_held_by(body, annotations, Drawer)
+        or _parts_held_by(body, annotations, Door)
+    )
+
+
+# %% graspable parts
+
+
+def handles(world: World) -> List[Handle]:
+    """
+    Every body that is a grip for opening something.
+
+    A handle is a body of its own fixed to a part that an active joint moves, so it
+    travels with what it opens without moving by itself. A lever that swings on a joint
+    of its own, such as a tap's, is part of the mechanism rather than a grip on it.
+    """
+    mount = variable(FixedConnection, world.connections)
+    joint = variable(ActiveConnection, world.connections)
+    grip = mount.child
+    return (
+        entity(inference(Handle)(root=grip))
+        .where(
+            joint.child == mount.parent,
+            grip.has_collision(),
+            is_not_named_after_furniture(grip),
+            is_not_already_something_else(grip, Handle, world.semantic_annotations),
+        )
+        .tolist()
+    )
+
+
+# %% things that open
+
+
+def drawers_with_a_handle(world: World) -> List[Drawer]:
+    """
+    Every body a slider pulls straight out of a container, opened by a handle.
+    """
+    slider = variable(PrismaticConnection, world.connections)
+    mount = variable(FixedConnection, world.connections)
+    handle = variable(Handle, world.semantic_annotations)
+    return (
+        entity(inference(Drawer)(root=slider.child, handle=handle))
+        .where(
+            slider.child.has_collision(),
+            mount.parent == slider.child,
+            mount.child == handle.root,
+        )
+        .tolist()
+    )
+
+
+def drawers_without_a_handle(world: World) -> List[Drawer]:
+    """
+    Every body a slider pulls straight out of a container that offers nothing to pull it
+    by.
+    """
+    slider = variable(PrismaticConnection, world.connections)
+    mount = variable(FixedConnection, world.connections)
+    handle = variable(Handle, world.semantic_annotations)
+    return (
+        entity(inference(Drawer)(root=slider.child))
+        .where(
+            slider.child.has_collision(),
+            not_(
+                exists(
+                    mount,
+                    and_(mount.parent == slider.child, mount.child == handle.root),
+                )
+            ),
+        )
+        .tolist()
+    )
+
+
+def doors_with_a_handle(world: World) -> List[Door]:
+    """
+    Every body a hinge swings to uncover an opening, opened by a handle.
+    """
+    hinge = variable(RevoluteConnection, world.connections)
+    mount = variable(FixedConnection, world.connections)
+    handle = variable(Handle, world.semantic_annotations)
+    return (
+        entity(inference(Door)(root=hinge.child, handle=handle))
+        .where(
+            hinge.child.has_collision(),
+            mount.parent == hinge.child,
+            mount.child == handle.root,
+        )
+        .tolist()
+    )
+
+
+def doors_without_a_handle(
+    world: World, independent_joint_multiplier: float = 1.0
+) -> List[Door]:
+    """
+    Every leaf of a folding front that carries no handle itself, but that another leaf
+    follows and is opened by.
+
+    A front of several leaves is jointed so that the others only repeat the motion of the
+    one they hang off, and is opened by a single handle on one of them. Asking for that
+    keeps two things out: the linkages of a mechanism, such as a tap's joints, where
+    nothing is a grip at all, and a container, whose door opens by its own joint rather
+    than by following it.
+
+    :param independent_joint_multiplier: The multiplier of a joint that moves on its own.
+        Any other value means the joint only repeats another joint's motion - what URDF
+        calls a mimic - so the part it moves is a leaf of the same front.
+    """
+    hinge = variable(RevoluteConnection, world.connections)
+    follower = variable(ActiveConnection1DOF, world.connections)
+    mount = variable(FixedConnection, world.connections)
+    handle = variable(Handle, world.semantic_annotations)
+    own_mount = variable(FixedConnection, world.connections)
+    return (
+        entity(inference(Door)(root=hinge.child))
+        .where(
+            hinge.child.has_collision(),
+            follower.parent == hinge.child,
+            follower.multiplier != independent_joint_multiplier,
+            mount.parent == follower.child,
+            mount.child == handle.root,
+            not_(
+                exists(
+                    own_mount,
+                    and_(
+                        own_mount.parent == hinge.child,
+                        own_mount.child == handle.root,
+                    ),
+                )
+            ),
+        )
+        .tolist()
+    )
+
+
+# %% containers
+
+
+def _containers_of_kind(world: World, kind: Optional[ContainerKind]) -> List[Cabinet]:
+    """
+    Every body that things open out of and whose name speaks for ``kind``.
+
+    :param kind: The kind the body must resolve to, or ``None`` for a container that
+        names no kind more specific than a cabinet, which is inferred as a plain
+        :class:`Cabinet`.
+    """
+    container_type = Cabinet if kind is None else kind.value
+    mount = variable(FixedConnection, world.connections)
+    container = mount.child
+    annotations = world.semantic_annotations
+    return (
+        entity(
+            inference(container_type)(
+                root=container,
+                drawers=drawers_of(container, annotations),
+                doors=doors_of(container, annotations),
+            )
+        )
+        .where(
+            holds_openable_parts(container, annotations),
+            container_kind_of(container) == kind,
+            names_no_recognised_kind(container),
+        )
+        .tolist()
+    )
+
+
+def cabinets(world: World) -> List[Cabinet]:
+    """
+    Every container whose name says nothing more than that it holds things.
+    """
+    return _containers_of_kind(world, None)
+
+
+def wardrobes(world: World) -> List[Wardrobe]:
+    """
+    Every container named as a wardrobe.
+    """
+    return _containers_of_kind(world, ContainerKind.WARDROBE)
+
+
+def dishwashers(world: World) -> List[Dishwasher]:
+    """
+    Every container named as a dishwasher, by itself or by one of its parts.
+    """
+    return _containers_of_kind(world, ContainerKind.DISHWASHER)
+
+
+def fridges(world: World) -> List[Fridge]:
+    """
+    Every container named as a fridge, by itself or by one of its parts.
+    """
+    return _containers_of_kind(world, ContainerKind.FRIDGE)
+
+
+# %% furniture recognised by name
+
+
+def _furniture_named_after(
+    world: World, annotation_type: Type[SemanticAnnotation]
+) -> List:
+    """
+    Every body with geometry that nothing moves and whose name speaks for
+    ``annotation_type``.
+    """
+    mount = variable(FixedConnection, world.connections)
+    body = mount.child
+    return (
+        entity(inference(annotation_type)(root=body))
+        .where(body.has_collision(), is_named_after(body, annotation_type))
+        .tolist()
+    )
+
+
+def ovens(world: World) -> List[Oven]:
+    """
+    Every oven.
+    """
+    return _furniture_named_after(world, Oven)
+
+
+def sinks(world: World) -> List[Sink]:
+    """
+    Every sink.
+    """
+    return _furniture_named_after(world, Sink)
+
+
+def cooktops(world: World) -> List[Cooktop]:
+    """
+    Every cooktop.
+    """
+    return _furniture_named_after(world, Cooktop)
+
+
+def counter_tops(world: World) -> List[CounterTop]:
+    """
+    Every worktop.
+    """
+    return _furniture_named_after(world, CounterTop)
+
+
+def sofas(world: World) -> List[Sofa]:
+    """
+    Every sofa.
+    """
+    return _furniture_named_after(world, Sofa)
+
+
+def walls(world: World) -> List[Wall]:
+    """
+    Every wall.
+    """
+    return _furniture_named_after(world, Wall)
+
+
+def shelf_layers(world: World) -> List[ShelfLayer]:
+    """
+    Every board that things are stored on.
+    """
+    return _furniture_named_after(world, ShelfLayer)
+
+
+def coffee_machines(world: World) -> List[CoffeeMachine]:
+    """
+    Every coffee machine.
+    """
+    return _furniture_named_after(world, CoffeeMachine)
+
+
+def tables(world: World) -> List[Table]:
+    """
+    Every table that is no more specific kind of table.
+    """
+    return _furniture_named_after(world, Table)
+
+
+def coffee_tables(world: World) -> List[CoffeeTable]:
+    """
+    Every coffee table.
+    """
+    return _furniture_named_after(world, CoffeeTable)
+
+
+def side_tables(world: World) -> List[SideTable]:
+    """
+    Every table that stands beside something.
+    """
+    return _furniture_named_after(world, SideTable)

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
@@ -30,6 +30,7 @@ from krrood.entity_query_language.factories import (
 from krrood.entity_query_language.predicate import symbolic_function
 from typing_extensions import Iterable, List, Optional, Sequence, Tuple, Type, Union
 
+from semantic_digital_twin.robots.robot_parts import AbstractRobot
 from semantic_digital_twin.semantic_annotations.mixins import (
     HasRootKinematicStructureEntity,
 )
@@ -262,6 +263,33 @@ def container_kind_of(body: Body) -> Optional[ContainerKind]:
     return None
 
 
+# %% what the rules leave alone
+
+
+@symbolic_function
+def is_not_part_of_a_robot(body: Body) -> bool:
+    """
+    Whether the body belongs to the environment rather than to a robot.
+
+    A robot is jointed exactly like furniture - a gripper finger slides as a drawer does,
+    an arm link swings as a door does, and the link bolted to it looks like the handle
+    that opens it - so without this a robot's own links would be annotated as furniture
+    and its kinematic chain rewired around the joints that inserts.
+    """
+    robot_roots = {
+        robot.root
+        for robot in body._world.get_semantic_annotations_by_type(AbstractRobot)
+    }
+    if not robot_roots:
+        return True
+    ancestor = body
+    while ancestor is not None:
+        if ancestor in robot_roots:
+            return False
+        ancestor = ancestor.parent_kinematic_structure_entity
+    return True
+
+
 # %% identities the world already holds
 
 
@@ -367,6 +395,7 @@ def handles(world: World) -> List[Handle]:
         .where(
             joint.child == mount.parent,
             grip.has_collision(),
+            is_not_part_of_a_robot(grip),
             is_not_named_after_furniture(grip),
             is_not_already_something_else(grip, Handle, world.semantic_annotations),
         )
@@ -388,6 +417,7 @@ def drawers_with_a_handle(world: World) -> List[Drawer]:
         entity(inference(Drawer)(root=slider.child, handle=handle))
         .where(
             slider.child.has_collision(),
+            is_not_part_of_a_robot(slider.child),
             mount.parent == slider.child,
             mount.child == handle.root,
         )
@@ -407,6 +437,7 @@ def drawers_without_a_handle(world: World) -> List[Drawer]:
         entity(inference(Drawer)(root=slider.child))
         .where(
             slider.child.has_collision(),
+            is_not_part_of_a_robot(slider.child),
             not_(
                 exists(
                     mount,
@@ -429,6 +460,7 @@ def doors_with_a_handle(world: World) -> List[Door]:
         entity(inference(Door)(root=hinge.child, handle=handle))
         .where(
             hinge.child.has_collision(),
+            is_not_part_of_a_robot(hinge.child),
             mount.parent == hinge.child,
             mount.child == handle.root,
         )
@@ -462,6 +494,7 @@ def doors_without_a_handle(
         entity(inference(Door)(root=hinge.child))
         .where(
             hinge.child.has_collision(),
+            is_not_part_of_a_robot(hinge.child),
             follower.parent == hinge.child,
             follower.multiplier != independent_joint_multiplier,
             mount.parent == follower.child,
@@ -504,6 +537,7 @@ def _containers_of_kind(world: World, kind: Optional[ContainerKind]) -> List[Cab
             )
         )
         .where(
+            is_not_part_of_a_robot(container),
             holds_openable_parts(container, annotations),
             container_kind_of(container) == kind,
             names_no_recognised_kind(container),
@@ -554,7 +588,11 @@ def _furniture_named_after(
     body = mount.child
     return (
         entity(inference(annotation_type)(root=body))
-        .where(body.has_collision(), is_named_after(body, annotation_type))
+        .where(
+            body.has_collision(),
+            is_not_part_of_a_robot(body),
+            is_named_after(body, annotation_type),
+        )
         .tolist()
     )
 

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/rules.py
@@ -27,7 +27,23 @@ from krrood.entity_query_language.factories import (
     not_,
     variable,
 )
-from krrood.entity_query_language.predicate import symbolic_function
+from krrood.entity_query_language.predicate import (
+    Predicate,
+    RenderedFields,
+    SymbolicFunction,
+    symbolic_function,
+)
+from krrood.entity_query_language.verbalization.fragments.base import (
+    VerbalizationFragment,
+)
+from krrood.entity_query_language.verbalization.vocabulary.english import Prepositions
+from krrood.entity_query_language.verbalization.vocabulary.parts_of_speech import (
+    FunctionVerbalizationTemplates,
+    Noun,
+    Verb,
+    clause,
+    predicate_clause,
+)
 from typing_extensions import Iterable, List, Optional, Sequence, Tuple, Type, Union
 
 from semantic_digital_twin.robots.robot_parts import AbstractRobot
@@ -144,8 +160,10 @@ def _name_words(body: Body, word_separator: str = "_") -> List[str]:
     Numbering distinguishes repetitions of the same thing, so ``shelf_level4`` says the
     same about what the body *is* as ``shelf_level`` does.
 
+    :param body: The body whose name is read.
     :param word_separator: What separates the words of a name in the world model being
         read, as in ``handle_cabinet5_top``.
+    :return: The name's words, in the order they are spoken.
     """
     return [
         re.sub(r"\d+", "", word)
@@ -181,6 +199,10 @@ def _match_name(words: Sequence[str], kind: AnnotationKind) -> Optional[NameMatc
 
     A name mentions a kind by spelling out every word of the kind's own name, or by
     using one of its synonyms.
+
+    :param words: The words of a body's name, in order.
+    :param kind: The kind the words are read against.
+    :return: What the words say about the kind, or ``None`` when they do not mention it.
     """
     annotation_type = kind.value
     class_words = annotation_type.class_name_tokens()
@@ -200,6 +222,10 @@ def asserted_kind(
     A compound name qualifies from the left, so the kind still being spoken about at the
     end of the name is the one the body is; among kinds that reach equally far, the one
     accounting for more of the name wins, and then the more specific one.
+
+    :param words: The words of a body's name, in order.
+    :param candidates: The kinds the name is read against.
+    :return: The kind the name settles on, or ``None`` when it mentions none of them.
     """
     matches = [
         match
@@ -218,100 +244,242 @@ def asserted_kind(
     ).kind
 
 
-@symbolic_function
-def is_named_after(body: Body, annotation_type: Type[SemanticAnnotation]) -> bool:
+@dataclass(eq=False)
+class IsNamedAfter(Predicate):
     """
-    Whether the body's name settles on ``annotation_type`` rather than on any other kind
+    Whether the body's name settles on one annotation type rather than on any other kind
     it mentions.
     """
-    kind = asserted_kind(_name_words(body), NamedKind)
-    return kind is not None and kind.value is annotation_type
 
-
-@symbolic_function
-def names_no_recognised_kind(body: Body) -> bool:
+    body: Body
     """
-    Whether the body's name claims none of the kinds the rules recognise by name, and so
-    leaves the body to be decided by how it is jointed.
+    The body whose name is read.
     """
-    return asserted_kind(_name_words(body), NamedKind) is None
+
+    annotation_type: Type[SemanticAnnotation]
+    """
+    The type the name has to settle on.
+    """
+
+    def __call__(self) -> bool:
+        kind = asserted_kind(_name_words(self.body), NamedKind)
+        return kind is not None and kind.value is self.annotation_type
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> is named after <annotation type>"*.
+        """
+        return predicate_clause(
+            cls, Noun(fields["body"]), Noun(fields["annotation_type"])
+        )
 
 
-@symbolic_function
-def is_not_named_after_furniture(body: Body) -> bool:
+@dataclass(eq=False)
+class NamesARecognisedKind(Predicate):
     """
-    Whether the body's name refrains from claiming a kind of furniture.
+    Whether the body's name claims one of the kinds the rules recognise by name.
+
+    A body whose name claims none of them is left to be decided by how it is jointed.
+    """
+
+    body: Body
+    """
+    The body whose name is read.
+    """
+
+    def __call__(self) -> bool:
+        return asserted_kind(_name_words(self.body), NamedKind) is not None
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> names a recognised kind"*.
+        """
+        return predicate_clause(cls, Noun(fields["body"]))
+
+
+@dataclass(eq=False)
+class IsNamedAfterFurniture(Predicate):
+    """
+    Whether the body's name claims a kind of furniture.
 
     Nothing about how a body is jointed tells a shelf board mounted inside a drawer
     apart from the drawer's handle, so a body the model calls furniture is left to the
     rules that go by name.
     """
-    kind = asserted_kind(_name_words(body), NamedKind)
-    return kind is None or not kind.is_furniture
+
+    body: Body
+    """
+    The body whose name is read.
+    """
+
+    def __call__(self) -> bool:
+        kind = asserted_kind(_name_words(self.body), NamedKind)
+        return kind is not None and kind.is_furniture
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> is named after furniture"*.
+        """
+        return predicate_clause(cls, Noun(fields["body"]))
 
 
-@symbolic_function
-def container_kind_of(body: Body) -> Optional[ContainerKind]:
+@dataclass(eq=False)
+class NamedContainerKind(SymbolicFunction):
     """
-    The kind of container the body is, read from its own name and those of its parts, or
-    ``None`` when nothing names a kind more specific than a cabinet.
+    The kind of container the names give away - the body's own and those of its parts -
+    or ``None`` when none of them names a kind more specific than a cabinet.
     """
-    for part in body._world.get_kinematic_structure_entities_of_branch(body):
-        kind = asserted_kind(_name_words(part), ContainerKind)
-        if kind is not None:
-            return kind
-    return None
+
+    body: Body
+    """
+    The body whose branch is read.
+    """
+
+    def __call__(self) -> Optional[ContainerKind]:
+        for part in self.body._world.get_kinematic_structure_entities_of_branch(
+            self.body
+        ):
+            kind = asserted_kind(_name_words(part), ContainerKind)
+            if kind is not None:
+                return kind
+        return None
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The noun phrase *"the named container kind of <body>"*.
+        """
+        return FunctionVerbalizationTemplates.possessive(cls, *fields.values())
 
 
 # %% what the rules leave alone
 
 
-@symbolic_function
-def is_not_part_of_a_robot(body: Body) -> bool:
+@dataclass(eq=False)
+class IsPartOfARobot(Predicate):
     """
-    Whether the body belongs to the environment rather than to a robot.
+    Whether the body belongs to a robot rather than to the environment.
 
     A robot is jointed exactly like furniture - a gripper finger slides as a drawer does,
     an arm link swings as a door does, and the link bolted to it looks like the handle
     that opens it - so without this a robot's own links would be annotated as furniture
     and its kinematic chain rewired around the joints that inserts.
     """
-    robot_roots = {
-        robot.root
-        for robot in body._world.get_semantic_annotations_by_type(AbstractRobot)
-    }
-    if not robot_roots:
-        return True
-    ancestor = body
-    while ancestor is not None:
-        if ancestor in robot_roots:
-            return False
-        ancestor = ancestor.parent_kinematic_structure_entity
-    return True
+
+    body: Body
+    """
+    The body whose ancestry is walked.
+    """
+
+    def __call__(self) -> bool:
+        robot_roots = {
+            robot.root
+            for robot in self.body._world.get_semantic_annotations_by_type(
+                AbstractRobot
+            )
+        }
+        ancestor = self.body
+        while ancestor is not None:
+            if ancestor in robot_roots:
+                return True
+            ancestor = ancestor.parent_kinematic_structure_entity
+        return False
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> is part of a robot"*.
+        """
+        return predicate_clause(cls, Noun(fields["body"]))
+
+
+# %% the geometry a body carries
+
+
+@dataclass(eq=False)
+class HasCollisionGeometry(Predicate):
+    """
+    Whether the body carries collision geometry of its own.
+
+    World models use a body without geometry to carry a joint and nothing else, so it is
+    part of the mechanism rather than something that can be annotated.
+    """
+
+    body: Body
+    """
+    The body whose geometry is read.
+    """
+
+    def __call__(self) -> bool:
+        return self.body.has_collision()
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> has collision geometry"*.
+        """
+        return predicate_clause(cls, Noun(fields["body"]))
 
 
 # %% identities the world already holds
 
 
-@symbolic_function
-def is_not_already_something_else(
-    body: Body,
-    kind: Type[SemanticAnnotation],
-    annotations: Sequence[SemanticAnnotation],
-) -> bool:
+@dataclass(eq=False)
+class HasAnotherAnnotation(Predicate):
     """
-    Whether nothing but ``kind`` has been annotated on the body yet.
+    Whether something other than one annotation type has been annotated on the body.
 
     An object put away in a drawer is jointed exactly as a handle is, so a body whose
     identity the world already holds keeps it instead of being claimed by a rule that
     only looks at the joints.
     """
-    return not any(
-        annotation.root is body
-        for annotation in annotations
-        if isinstance(annotation, HasRootKinematicStructureEntity)
-        and not isinstance(annotation, kind)
-    )
+
+    body: Body
+    """
+    The body whose identity is looked up.
+    """
+
+    annotation_type: Type[SemanticAnnotation]
+    """
+    The type being inferred, which therefore does not count as another one.
+    """
+
+    annotations: Sequence[SemanticAnnotation]
+    """
+    The annotations to look the body up in.
+    """
+
+    def __call__(self) -> bool:
+        return any(
+            annotation.root is self.body
+            for annotation in self.annotations
+            if isinstance(annotation, HasRootKinematicStructureEntity)
+            and not isinstance(annotation, self.annotation_type)
+        )
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> has an annotation besides <annotation type>"*, which
+            names the annotations it was looked up in no more than the rule does.
+        """
+        return clause(
+            Noun(fields["body"]),
+            Verb("have"),
+            Noun("annotation"),
+            Prepositions.BESIDES,
+            Noun(fields["annotation_type"]),
+        )
 
 
 # %% the parts a container holds
@@ -324,6 +492,10 @@ def _holder_of(body: Body) -> Optional[Body]:
     Bodies without geometry are skipped, because world models use them to carry a joint
     and nothing else, so a door reached through a pop-out helper still resolves to the
     container it belongs to.
+
+    :param body: The body to look above.
+    :return: The nearest such body, or ``None`` when nothing above this one has
+        geometry.
     """
     holder = body.parent_kinematic_structure_entity
     while holder is not None and not holder.has_collision():
@@ -341,6 +513,11 @@ def _parts_held_by(
 
     Rules read the annotations inferred so far from what they are given rather than from
     the world, because a rule runs before its conclusions reach the world.
+
+    :param body: The body the parts have to open out of.
+    :param annotations: The annotations inferred so far.
+    :param part_type: The type of part to collect.
+    :return: The parts of that type the body holds.
     """
     return [
         annotation
@@ -352,7 +529,9 @@ def _parts_held_by(
 @symbolic_function
 def drawers_of(body: Body, annotations: Sequence[SemanticAnnotation]) -> List[Drawer]:
     """
-    The drawers that slide out of the body.
+    :param body: The body the drawers have to slide out of.
+    :param annotations: The annotations inferred so far.
+    :return: The drawers that slide out of the body.
     """
     return _parts_held_by(body, annotations, Drawer)
 
@@ -360,20 +539,43 @@ def drawers_of(body: Body, annotations: Sequence[SemanticAnnotation]) -> List[Dr
 @symbolic_function
 def doors_of(body: Body, annotations: Sequence[SemanticAnnotation]) -> List[Door]:
     """
-    The doors that swing off the body.
+    :param body: The body the doors have to swing off.
+    :param annotations: The annotations inferred so far.
+    :return: The doors that swing off the body.
     """
     return _parts_held_by(body, annotations, Door)
 
 
-@symbolic_function
-def holds_openable_parts(body: Body, annotations: Sequence[SemanticAnnotation]) -> bool:
+@dataclass(eq=False)
+class HoldsOpenableParts(Predicate):
     """
     Whether anything opens out of the body, which is what makes it a container.
     """
-    return bool(
-        _parts_held_by(body, annotations, Drawer)
-        or _parts_held_by(body, annotations, Door)
-    )
+
+    body: Body
+    """
+    The body the parts are looked for on.
+    """
+
+    annotations: Sequence[SemanticAnnotation]
+    """
+    The annotations inferred so far, which the parts are looked up in.
+    """
+
+    def __call__(self) -> bool:
+        return bool(
+            _parts_held_by(self.body, self.annotations, Drawer)
+            or _parts_held_by(self.body, self.annotations, Door)
+        )
+
+    @classmethod
+    def _verbalization_fragment_(cls, fields: RenderedFields) -> VerbalizationFragment:
+        """
+        :param fields: The rendered fragment for each field.
+        :return: The clause *"<body> holds openable parts"*, which names the annotations
+            it looked them up in no more than the rule does.
+        """
+        return clause(Noun(fields["body"]), Verb("hold"), Noun.bare("openable parts"))
 
 
 # %% graspable parts
@@ -386,6 +588,9 @@ def handles(world: World) -> List[Handle]:
     A handle is a body of its own fixed to a part that an active joint moves, so it
     travels with what it opens without moving by itself. A lever that swings on a joint
     of its own, such as a tap's, is part of the mechanism rather than a grip on it.
+
+    :param world: The world to read.
+    :return: Every handle in it.
     """
     mount = variable(FixedConnection, world.connections)
     joint = variable(ActiveConnection, world.connections)
@@ -394,10 +599,10 @@ def handles(world: World) -> List[Handle]:
         entity(inference(Handle)(root=grip))
         .where(
             joint.child == mount.parent,
-            grip.has_collision(),
-            is_not_part_of_a_robot(grip),
-            is_not_named_after_furniture(grip),
-            is_not_already_something_else(grip, Handle, world.semantic_annotations),
+            HasCollisionGeometry(grip),
+            not_(IsPartOfARobot(grip)),
+            not_(IsNamedAfterFurniture(grip)),
+            not_(HasAnotherAnnotation(grip, Handle, world.semantic_annotations)),
         )
         .tolist()
     )
@@ -408,7 +613,8 @@ def handles(world: World) -> List[Handle]:
 
 def drawers_with_a_handle(world: World) -> List[Drawer]:
     """
-    Every body a slider pulls straight out of a container, opened by a handle.
+    :param world: The world to read.
+    :return: Every body a slider pulls straight out of a container, opened by a handle.
     """
     slider = variable(PrismaticConnection, world.connections)
     mount = variable(FixedConnection, world.connections)
@@ -416,8 +622,8 @@ def drawers_with_a_handle(world: World) -> List[Drawer]:
     return (
         entity(inference(Drawer)(root=slider.child, handle=handle))
         .where(
-            slider.child.has_collision(),
-            is_not_part_of_a_robot(slider.child),
+            HasCollisionGeometry(slider.child),
+            not_(IsPartOfARobot(slider.child)),
             mount.parent == slider.child,
             mount.child == handle.root,
         )
@@ -427,8 +633,9 @@ def drawers_with_a_handle(world: World) -> List[Drawer]:
 
 def drawers_without_a_handle(world: World) -> List[Drawer]:
     """
-    Every body a slider pulls straight out of a container that offers nothing to pull it
-    by.
+    :param world: The world to read.
+    :return: Every body a slider pulls straight out of a container that offers nothing to
+        pull it by.
     """
     slider = variable(PrismaticConnection, world.connections)
     mount = variable(FixedConnection, world.connections)
@@ -436,8 +643,8 @@ def drawers_without_a_handle(world: World) -> List[Drawer]:
     return (
         entity(inference(Drawer)(root=slider.child))
         .where(
-            slider.child.has_collision(),
-            is_not_part_of_a_robot(slider.child),
+            HasCollisionGeometry(slider.child),
+            not_(IsPartOfARobot(slider.child)),
             not_(
                 exists(
                     mount,
@@ -451,7 +658,8 @@ def drawers_without_a_handle(world: World) -> List[Drawer]:
 
 def doors_with_a_handle(world: World) -> List[Door]:
     """
-    Every body a hinge swings to uncover an opening, opened by a handle.
+    :param world: The world to read.
+    :return: Every body a hinge swings to uncover an opening, opened by a handle.
     """
     hinge = variable(RevoluteConnection, world.connections)
     mount = variable(FixedConnection, world.connections)
@@ -459,8 +667,8 @@ def doors_with_a_handle(world: World) -> List[Door]:
     return (
         entity(inference(Door)(root=hinge.child, handle=handle))
         .where(
-            hinge.child.has_collision(),
-            is_not_part_of_a_robot(hinge.child),
+            HasCollisionGeometry(hinge.child),
+            not_(IsPartOfARobot(hinge.child)),
             mount.parent == hinge.child,
             mount.child == handle.root,
         )
@@ -481,9 +689,11 @@ def doors_without_a_handle(
     nothing is a grip at all, and a container, whose door opens by its own joint rather
     than by following it.
 
+    :param world: The world to read.
     :param independent_joint_multiplier: The multiplier of a joint that moves on its own.
         Any other value means the joint only repeats another joint's motion - what URDF
         calls a mimic - so the part it moves is a leaf of the same front.
+    :return: Every such leaf.
     """
     hinge = variable(RevoluteConnection, world.connections)
     follower = variable(ActiveConnection1DOF, world.connections)
@@ -493,8 +703,8 @@ def doors_without_a_handle(
     return (
         entity(inference(Door)(root=hinge.child))
         .where(
-            hinge.child.has_collision(),
-            is_not_part_of_a_robot(hinge.child),
+            HasCollisionGeometry(hinge.child),
+            not_(IsPartOfARobot(hinge.child)),
             follower.parent == hinge.child,
             follower.multiplier != independent_joint_multiplier,
             mount.parent == follower.child,
@@ -518,11 +728,11 @@ def doors_without_a_handle(
 
 def _containers_of_kind(world: World, kind: Optional[ContainerKind]) -> List[Cabinet]:
     """
-    Every body that things open out of and whose name speaks for ``kind``.
-
+    :param world: The world to read.
     :param kind: The kind the body must resolve to, or ``None`` for a container that
         names no kind more specific than a cabinet, which is inferred as a plain
         :class:`Cabinet`.
+    :return: Every body that things open out of and whose name speaks for the kind.
     """
     container_type = Cabinet if kind is None else kind.value
     mount = variable(FixedConnection, world.connections)
@@ -537,10 +747,10 @@ def _containers_of_kind(world: World, kind: Optional[ContainerKind]) -> List[Cab
             )
         )
         .where(
-            is_not_part_of_a_robot(container),
-            holds_openable_parts(container, annotations),
-            container_kind_of(container) == kind,
-            names_no_recognised_kind(container),
+            not_(IsPartOfARobot(container)),
+            HoldsOpenableParts(container, annotations),
+            NamedContainerKind(container) == kind,
+            not_(NamesARecognisedKind(container)),
         )
         .tolist()
     )
@@ -548,28 +758,32 @@ def _containers_of_kind(world: World, kind: Optional[ContainerKind]) -> List[Cab
 
 def cabinets(world: World) -> List[Cabinet]:
     """
-    Every container whose name says nothing more than that it holds things.
+    :param world: The world to read.
+    :return: Every container whose name says nothing more than that it holds things.
     """
     return _containers_of_kind(world, None)
 
 
 def wardrobes(world: World) -> List[Wardrobe]:
     """
-    Every container named as a wardrobe.
+    :param world: The world to read.
+    :return: Every container named as a wardrobe.
     """
     return _containers_of_kind(world, ContainerKind.WARDROBE)
 
 
 def dishwashers(world: World) -> List[Dishwasher]:
     """
-    Every container named as a dishwasher, by itself or by one of its parts.
+    :param world: The world to read.
+    :return: Every container named as a dishwasher, by itself or by one of its parts.
     """
     return _containers_of_kind(world, ContainerKind.DISHWASHER)
 
 
 def fridges(world: World) -> List[Fridge]:
     """
-    Every container named as a fridge, by itself or by one of its parts.
+    :param world: The world to read.
+    :return: Every container named as a fridge, by itself or by one of its parts.
     """
     return _containers_of_kind(world, ContainerKind.FRIDGE)
 
@@ -581,17 +795,19 @@ def _furniture_named_after(
     world: World, annotation_type: Type[SemanticAnnotation]
 ) -> List:
     """
-    Every body with geometry that nothing moves and whose name speaks for
-    ``annotation_type``.
+    :param world: The world to read.
+    :param annotation_type: The type the name must settle on.
+    :return: Every body with geometry that nothing moves and whose name speaks for that
+        type.
     """
     mount = variable(FixedConnection, world.connections)
     body = mount.child
     return (
         entity(inference(annotation_type)(root=body))
         .where(
-            body.has_collision(),
-            is_not_part_of_a_robot(body),
-            is_named_after(body, annotation_type),
+            HasCollisionGeometry(body),
+            not_(IsPartOfARobot(body)),
+            IsNamedAfter(body, annotation_type),
         )
         .tolist()
     )
@@ -599,76 +815,87 @@ def _furniture_named_after(
 
 def ovens(world: World) -> List[Oven]:
     """
-    Every oven.
+    :param world: The world to read.
+    :return: Every oven.
     """
     return _furniture_named_after(world, Oven)
 
 
 def sinks(world: World) -> List[Sink]:
     """
-    Every sink.
+    :param world: The world to read.
+    :return: Every sink.
     """
     return _furniture_named_after(world, Sink)
 
 
 def cooktops(world: World) -> List[Cooktop]:
     """
-    Every cooktop.
+    :param world: The world to read.
+    :return: Every cooktop.
     """
     return _furniture_named_after(world, Cooktop)
 
 
 def counter_tops(world: World) -> List[CounterTop]:
     """
-    Every worktop.
+    :param world: The world to read.
+    :return: Every worktop.
     """
     return _furniture_named_after(world, CounterTop)
 
 
 def sofas(world: World) -> List[Sofa]:
     """
-    Every sofa.
+    :param world: The world to read.
+    :return: Every sofa.
     """
     return _furniture_named_after(world, Sofa)
 
 
 def walls(world: World) -> List[Wall]:
     """
-    Every wall.
+    :param world: The world to read.
+    :return: Every wall.
     """
     return _furniture_named_after(world, Wall)
 
 
 def shelf_layers(world: World) -> List[ShelfLayer]:
     """
-    Every board that things are stored on.
+    :param world: The world to read.
+    :return: Every board that things are stored on.
     """
     return _furniture_named_after(world, ShelfLayer)
 
 
 def coffee_machines(world: World) -> List[CoffeeMachine]:
     """
-    Every coffee machine.
+    :param world: The world to read.
+    :return: Every coffee machine.
     """
     return _furniture_named_after(world, CoffeeMachine)
 
 
 def tables(world: World) -> List[Table]:
     """
-    Every table that is no more specific kind of table.
+    :param world: The world to read.
+    :return: Every table that is no more specific kind of table.
     """
     return _furniture_named_after(world, Table)
 
 
 def coffee_tables(world: World) -> List[CoffeeTable]:
     """
-    Every coffee table.
+    :param world: The world to read.
+    :return: Every coffee table.
     """
     return _furniture_named_after(world, CoffeeTable)
 
 
 def side_tables(world: World) -> List[SideTable]:
     """
-    Every table that stands beside something.
+    :param world: The world to read.
+    :return: Every table that stands beside something.
     """
     return _furniture_named_after(world, SideTable)

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/world_semantic_annotations_mcrdr.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/world_semantic_annotations_mcrdr.py
@@ -1,15 +1,28 @@
 from krrood.ripple_down_rules.utils import make_set
-from typing_extensions import Optional, Set, Union
+from typing_extensions import Set, Union
 from krrood.ripple_down_rules.datastructures.case import Case, create_case
 from semantic_digital_twin.reasoning.world_rdr.world_semantic_annotations_mcrdr_defs import *
 
 attribute_name = "semantic_annotations"
 conclusion_type = (
-    Drawer,
     Handle,
+    Drawer,
     Door,
-    Fridge,
     Wardrobe,
+    Dishwasher,
+    Fridge,
+    Cabinet,
+    Oven,
+    Sink,
+    Cooktop,
+    CounterTop,
+    Sofa,
+    Wall,
+    ShelfLayer,
+    CoffeeMachine,
+    CoffeeTable,
+    SideTable,
+    Table,
 )
 mutually_exclusive = False
 name = "semantic_annotations"
@@ -17,35 +30,130 @@ case_type = World
 case_name = "World"
 
 
-def classify(
-    case: World, **kwargs
-) -> Set[Union[Drawer, Handle, Door, Fridge, Wardrobe]]:
+def classify(case: World, **kwargs) -> Set[
+    Union[
+        Handle,
+        Drawer,
+        Door,
+        Wardrobe,
+        Dishwasher,
+        Fridge,
+        Cabinet,
+        Oven,
+        Sink,
+        Cooktop,
+        CounterTop,
+        Sofa,
+        Wall,
+        ShelfLayer,
+        CoffeeMachine,
+        CoffeeTable,
+        SideTable,
+        Table,
+    ]
+]:
     if not isinstance(case, Case):
         case = create_case(case, max_recursion_idx=3)
     conclusions = set()
 
-    if conditions_90574698325129464513441443063592862114(case):
+    if conditions_111115858654502671279494400838612635168(case):
         conclusions.update(
-            make_set(conclusion_90574698325129464513441443063592862114(case))
+            make_set(conclusion_111115858654502671279494400838612635168(case))
         )
 
-    if conditions_331345798360792447350644865254855982739(case):
+    if conditions_248676565933633239858802311504377126882(case):
         conclusions.update(
-            make_set(conclusion_331345798360792447350644865254855982739(case))
+            make_set(conclusion_248676565933633239858802311504377126882(case))
         )
 
-    if conditions_35528769484583703815352905256802298589(case):
+    if conditions_317079062995625045064213599855869838805(case):
         conclusions.update(
-            make_set(conclusion_35528769484583703815352905256802298589(case))
+            make_set(conclusion_317079062995625045064213599855869838805(case))
         )
 
-    if conditions_59112619694893607910753808758642808601(case):
+    if conditions_326953014145210418398679055851359282662(case):
         conclusions.update(
-            make_set(conclusion_59112619694893607910753808758642808601(case))
+            make_set(conclusion_326953014145210418398679055851359282662(case))
         )
 
-    if conditions_10840634078579061471470540436169882059(case):
+    if conditions_218985522231414995632246132988515574217(case):
         conclusions.update(
-            make_set(conclusion_10840634078579061471470540436169882059(case))
+            make_set(conclusion_218985522231414995632246132988515574217(case))
         )
+
+    if conditions_26541319268144667585806659965812960774(case):
+        conclusions.update(
+            make_set(conclusion_26541319268144667585806659965812960774(case))
+        )
+
+    if conditions_158937834096912333482822714868490776940(case):
+        conclusions.update(
+            make_set(conclusion_158937834096912333482822714868490776940(case))
+        )
+
+    if conditions_316106723856289315485855687643584759560(case):
+        conclusions.update(
+            make_set(conclusion_316106723856289315485855687643584759560(case))
+        )
+
+    if conditions_273868058932563223747162125459578705794(case):
+        conclusions.update(
+            make_set(conclusion_273868058932563223747162125459578705794(case))
+        )
+
+    if conditions_48470732943666389031275241446759040158(case):
+        conclusions.update(
+            make_set(conclusion_48470732943666389031275241446759040158(case))
+        )
+
+    if conditions_30511584820652557323555645212699735534(case):
+        conclusions.update(
+            make_set(conclusion_30511584820652557323555645212699735534(case))
+        )
+
+    if conditions_53140626725687000784569602523600018998(case):
+        conclusions.update(
+            make_set(conclusion_53140626725687000784569602523600018998(case))
+        )
+
+    if conditions_91766461504596272560719260519280649820(case):
+        conclusions.update(
+            make_set(conclusion_91766461504596272560719260519280649820(case))
+        )
+
+    if conditions_64426787522073749385484386687820455248(case):
+        conclusions.update(
+            make_set(conclusion_64426787522073749385484386687820455248(case))
+        )
+
+    if conditions_127273513110689344453536255694523763442(case):
+        conclusions.update(
+            make_set(conclusion_127273513110689344453536255694523763442(case))
+        )
+
+    if conditions_66825188434526833455942009106856873396(case):
+        conclusions.update(
+            make_set(conclusion_66825188434526833455942009106856873396(case))
+        )
+
+    if conditions_129346935101384221720160031395011916810(case):
+        conclusions.update(
+            make_set(conclusion_129346935101384221720160031395011916810(case))
+        )
+
+    if conditions_269752152718035292505919835246449120303(case):
+        conclusions.update(
+            make_set(conclusion_269752152718035292505919835246449120303(case))
+        )
+
+    if conditions_206298218301184229027724450338144229416(case):
+        conclusions.update(
+            make_set(conclusion_206298218301184229027724450338144229416(case))
+        )
+
+    if conditions_289159079186754023252507394066467767351(case):
+        conclusions.update(
+            make_set(conclusion_289159079186754023252507394066467767351(case))
+        )
+
     return conclusions

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/world_semantic_annotations_mcrdr_defs.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_rdr/world_semantic_annotations_mcrdr_defs.py
@@ -1,176 +1,460 @@
-from krrood.entity_query_language.factories import (
-    contains,
-    entity,
-    inference,
-    variable,
+"""
+What the world semantic-annotation classifier calls.
+
+Each ``conditions_``/``conclusion_`` pair names the precondition of one rule and the rule
+that runs under it. The rules themselves are in
+:mod:`semantic_digital_twin.reasoning.world_rdr.rules`.
+"""
+
+from semantic_digital_twin.reasoning.world_rdr.rules import (
+    cabinets,
+    coffee_machines,
+    coffee_tables,
+    cooktops,
+    counter_tops,
+    dishwashers,
+    doors_with_a_handle,
+    doors_without_a_handle,
+    drawers_with_a_handle,
+    drawers_without_a_handle,
+    fridges,
+    handles,
+    ovens,
+    shelf_layers,
+    side_tables,
+    sinks,
+    sofas,
+    tables,
+    walls,
+    wardrobes,
 )
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
-    Wardrobe,
+    Cabinet,
+    CoffeeMachine,
+    CoffeeTable,
+    Cooktop,
+    CounterTop,
+    Dishwasher,
     Door,
     Drawer,
     Fridge,
     Handle,
+    Oven,
+    ShelfLayer,
+    SideTable,
+    Sink,
+    Sofa,
+    Table,
+    Wall,
+    Wardrobe,
 )
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.connections import (
-    FixedConnection,
     PrismaticConnection,
     RevoluteConnection,
 )
-from semantic_digital_twin.world_description.world_entity import Body
 from typing_extensions import List
 
 
-def conditions_90574698325129464513441443063592862114(case) -> bool:
-    def has_bodies_named_handle(case: World) -> bool:
+def conditions_111115858654502671279494400838612635168(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
         """
-        Get conditions on whether it's possible to conclude a value for
-        World.semantic_annotations  of type Handle.
+        Whether the world holds anything that could be named.
         """
-        return True
+        return len(case.kinematic_structure_entities) > 0
 
-    return has_bodies_named_handle(case)
+    return world_holds_bodies(case)
 
 
-def conclusion_90574698325129464513441443063592862114(case) -> List[Handle]:
+def conclusion_111115858654502671279494400838612635168(case) -> List[Handle]:
     def get_handles(case: World) -> List[Handle]:
         """
-        Get possible value(s) for World.semantic_annotations of types list/set of
-        Handle.
+        Get possible value(s) for World.semantic_annotations of type Handle.
         """
-        kse = variable(Body, case.kinematic_structure_entities)
-        return (
-            entity(inference(Handle)(root=kse))
-            .where(contains(kse.name.name.lower(), "handle"))
-            .tolist()
-        )
+        return handles(case)
 
     return get_handles(case)
 
 
-def conditions_331345798360792447350644865254855982739(case) -> bool:
-    def has_handles_and_HasCaseAsMainBodys(case: World) -> bool:
+def conditions_248676565933633239858802311504377126882(case) -> bool:
+    def world_holds_sliders(case: World) -> bool:
         """
-        Get conditions on whether it's possible to conclude a value for
-        World.semantic_annotations  of type Drawer.
+        Whether anything in the world slides, which is what a drawer needs.
         """
-        return True
+        return any(isinstance(c, PrismaticConnection) for c in case.connections)
 
-    return has_handles_and_HasCaseAsMainBodys(case)
+    return world_holds_sliders(case)
 
 
-def conclusion_331345798360792447350644865254855982739(case) -> List[Drawer]:
-    def get_drawers(case: World) -> List[Drawer]:
+def conclusion_248676565933633239858802311504377126882(case) -> List[Drawer]:
+    def get_drawers_without_a_handle(case: World) -> List[Drawer]:
         """
-        Get possible value(s) for World.semantic_annotations of types list/set of
-        Drawer.
+        Get possible value(s) for World.semantic_annotations of type Drawer.
         """
-        handle = variable(Handle, case.semantic_annotations)
-        prismatic_connection = variable(PrismaticConnection, case.connections)
-        fixed_connection = variable(FixedConnection, case.connections)
-        return (
-            entity(inference(Drawer)(root=fixed_connection.parent, handle=handle))
-            .where(
-                handle.root == fixed_connection.child,
-                fixed_connection.parent == prismatic_connection.child,
-            )
-            .tolist()
-        )
+        return drawers_without_a_handle(case)
 
-    return get_drawers(case)
+    return get_drawers_without_a_handle(case)
 
 
-def conditions_35528769484583703815352905256802298589(case) -> bool:
-    def has_drawers(case: World) -> bool:
+def conditions_317079062995625045064213599855869838805(case) -> bool:
+    def world_holds_hinges(case: World) -> bool:
         """
-        Get conditions on whether it's possible to conclude a value for
-        World.semantic_annotations  of type Wardrobe.
+        Whether anything in the world swings, which is what a door needs.
         """
-        return True
+        return any(isinstance(c, RevoluteConnection) for c in case.connections)
 
-    return has_drawers(case)
+    return world_holds_hinges(case)
 
 
-def conclusion_35528769484583703815352905256802298589(case) -> List[Wardrobe]:
+def conclusion_317079062995625045064213599855869838805(case) -> List[Door]:
+    def get_doors_without_a_handle(case: World) -> List[Door]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Door.
+        """
+        return doors_without_a_handle(case)
+
+    return get_doors_without_a_handle(case)
+
+
+def conditions_326953014145210418398679055851359282662(case) -> bool:
+    def world_holds_handles(case: World) -> bool:
+        """
+        Whether any handle is already known, since it takes one to say what it opens.
+        """
+        return any(isinstance(a, Handle) for a in case.semantic_annotations)
+
+    return world_holds_handles(case)
+
+
+def conclusion_326953014145210418398679055851359282662(case) -> List[Drawer]:
+    def get_drawers_with_a_handle(case: World) -> List[Drawer]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Drawer.
+        """
+        return drawers_with_a_handle(case)
+
+    return get_drawers_with_a_handle(case)
+
+
+def conditions_218985522231414995632246132988515574217(case) -> bool:
+    def world_holds_handles(case: World) -> bool:
+        """
+        Whether any handle is already known, since it takes one to say what it opens.
+        """
+        return any(isinstance(a, Handle) for a in case.semantic_annotations)
+
+    return world_holds_handles(case)
+
+
+def conclusion_218985522231414995632246132988515574217(case) -> List[Door]:
+    def get_doors_with_a_handle(case: World) -> List[Door]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Door.
+        """
+        return doors_with_a_handle(case)
+
+    return get_doors_with_a_handle(case)
+
+
+def conditions_26541319268144667585806659965812960774(case) -> bool:
+    def world_holds_openable_parts(case: World) -> bool:
+        """
+        Whether any door or drawer is already known, since a container is recognised by
+        what opens out of it.
+        """
+        return any(isinstance(a, (Door, Drawer)) for a in case.semantic_annotations)
+
+    return world_holds_openable_parts(case)
+
+
+def conclusion_26541319268144667585806659965812960774(case) -> List[Wardrobe]:
     def get_wardrobes(case: World) -> List[Wardrobe]:
         """
-        Get possible value(s) for World.semantic_annotations of types list/set of
-        Wardrobe.
+        Get possible value(s) for World.semantic_annotations of type Wardrobe.
         """
-        drawer = variable(Drawer, case.semantic_annotations)
-        prismatic_connection = variable(PrismaticConnection, case.connections)
-        return (
-            entity(
-                inference(Wardrobe)(
-                    root=prismatic_connection.parent,
-                    drawers=drawer,
-                )
-            )
-            .where(prismatic_connection.child == drawer.root)
-            .grouped_by(prismatic_connection.parent)
-            .tolist()
-        )
+        return wardrobes(case)
 
     return get_wardrobes(case)
 
 
-def conditions_59112619694893607910753808758642808601(case) -> bool:
-    def has_handles_and_revolute_connections(case: World) -> bool:
+def conditions_158937834096912333482822714868490776940(case) -> bool:
+    def world_holds_openable_parts(case: World) -> bool:
         """
-        Get conditions on whether it's possible to conclude a value for
-        World.semantic_annotations  of type Door.
+        Whether any door or drawer is already known, since a container is recognised by
+        what opens out of it.
         """
-        return True
+        return any(isinstance(a, (Door, Drawer)) for a in case.semantic_annotations)
 
-    return has_handles_and_revolute_connections(case)
+    return world_holds_openable_parts(case)
 
 
-def conclusion_59112619694893607910753808758642808601(case) -> List[Door]:
-    def get_doors(case: World) -> List[Door]:
+def conclusion_158937834096912333482822714868490776940(case) -> List[Dishwasher]:
+    def get_dishwashers(case: World) -> List[Dishwasher]:
         """
-        Get possible value(s) for World.semantic_annotations  of type Door.
+        Get possible value(s) for World.semantic_annotations of type Dishwasher.
         """
-        handle = variable(Handle, case.semantic_annotations)
-        revolute_connection = variable(RevoluteConnection, case.connections)
-        fixed_connection = variable(FixedConnection, case.connections)
-        return (
-            entity(inference(Door)(root=fixed_connection.parent, handle=handle))
-            .where(
-                fixed_connection.parent == revolute_connection.child,
-                fixed_connection.child == handle.root,
-            )
-            .tolist()
-        )
+        return dishwashers(case)
 
-    return get_doors(case)
+    return get_dishwashers(case)
 
 
-def conditions_10840634078579061471470540436169882059(case) -> bool:
-    def has_doors_with_fridge_in_their_name(case: World) -> bool:
+def conditions_316106723856289315485855687643584759560(case) -> bool:
+    def world_holds_openable_parts(case: World) -> bool:
         """
-        Get conditions on whether it's possible to conclude a value for
-        World.semantic_annotations  of type Fridge.
+        Whether any door or drawer is already known, since a container is recognised by
+        what opens out of it.
         """
-        return True
+        return any(isinstance(a, (Door, Drawer)) for a in case.semantic_annotations)
 
-    return has_doors_with_fridge_in_their_name(case)
+    return world_holds_openable_parts(case)
 
 
-def conclusion_10840634078579061471470540436169882059(case) -> List[Fridge]:
+def conclusion_316106723856289315485855687643584759560(case) -> List[Fridge]:
     def get_fridges(case: World) -> List[Fridge]:
         """
         Get possible value(s) for World.semantic_annotations of type Fridge.
         """
-        door = variable(Door, case.semantic_annotations)
-        revolute_connection = variable(RevoluteConnection, case.connections)
-        return (
-            entity(inference(Fridge)(root=revolute_connection.parent, doors=door))
-            .where(
-                revolute_connection.child == door.root,
-                contains(door.root.name.name.lower(), "fridge"),
-            )
-            .grouped_by(revolute_connection.parent)
-            .tolist()
-        )
+        return fridges(case)
 
     return get_fridges(case)
+
+
+def conditions_273868058932563223747162125459578705794(case) -> bool:
+    def world_holds_openable_parts(case: World) -> bool:
+        """
+        Whether any door or drawer is already known, since a container is recognised by
+        what opens out of it.
+        """
+        return any(isinstance(a, (Door, Drawer)) for a in case.semantic_annotations)
+
+    return world_holds_openable_parts(case)
+
+
+def conclusion_273868058932563223747162125459578705794(case) -> List[Cabinet]:
+    def get_cabinets(case: World) -> List[Cabinet]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Cabinet.
+        """
+        return cabinets(case)
+
+    return get_cabinets(case)
+
+
+def conditions_48470732943666389031275241446759040158(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_48470732943666389031275241446759040158(case) -> List[Oven]:
+    def get_ovens(case: World) -> List[Oven]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Oven.
+        """
+        return ovens(case)
+
+    return get_ovens(case)
+
+
+def conditions_30511584820652557323555645212699735534(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_30511584820652557323555645212699735534(case) -> List[Sink]:
+    def get_sinks(case: World) -> List[Sink]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Sink.
+        """
+        return sinks(case)
+
+    return get_sinks(case)
+
+
+def conditions_53140626725687000784569602523600018998(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_53140626725687000784569602523600018998(case) -> List[Cooktop]:
+    def get_cooktops(case: World) -> List[Cooktop]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Cooktop.
+        """
+        return cooktops(case)
+
+    return get_cooktops(case)
+
+
+def conditions_91766461504596272560719260519280649820(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_91766461504596272560719260519280649820(case) -> List[CounterTop]:
+    def get_counter_tops(case: World) -> List[CounterTop]:
+        """
+        Get possible value(s) for World.semantic_annotations of type CounterTop.
+        """
+        return counter_tops(case)
+
+    return get_counter_tops(case)
+
+
+def conditions_64426787522073749385484386687820455248(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_64426787522073749385484386687820455248(case) -> List[Sofa]:
+    def get_sofas(case: World) -> List[Sofa]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Sofa.
+        """
+        return sofas(case)
+
+    return get_sofas(case)
+
+
+def conditions_127273513110689344453536255694523763442(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_127273513110689344453536255694523763442(case) -> List[Wall]:
+    def get_walls(case: World) -> List[Wall]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Wall.
+        """
+        return walls(case)
+
+    return get_walls(case)
+
+
+def conditions_66825188434526833455942009106856873396(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_66825188434526833455942009106856873396(case) -> List[ShelfLayer]:
+    def get_shelf_layers(case: World) -> List[ShelfLayer]:
+        """
+        Get possible value(s) for World.semantic_annotations of type ShelfLayer.
+        """
+        return shelf_layers(case)
+
+    return get_shelf_layers(case)
+
+
+def conditions_129346935101384221720160031395011916810(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_129346935101384221720160031395011916810(case) -> List[CoffeeMachine]:
+    def get_coffee_machines(case: World) -> List[CoffeeMachine]:
+        """
+        Get possible value(s) for World.semantic_annotations of type CoffeeMachine.
+        """
+        return coffee_machines(case)
+
+    return get_coffee_machines(case)
+
+
+def conditions_269752152718035292505919835246449120303(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_269752152718035292505919835246449120303(case) -> List[CoffeeTable]:
+    def get_coffee_tables(case: World) -> List[CoffeeTable]:
+        """
+        Get possible value(s) for World.semantic_annotations of type CoffeeTable.
+        """
+        return coffee_tables(case)
+
+    return get_coffee_tables(case)
+
+
+def conditions_206298218301184229027724450338144229416(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_206298218301184229027724450338144229416(case) -> List[SideTable]:
+    def get_side_tables(case: World) -> List[SideTable]:
+        """
+        Get possible value(s) for World.semantic_annotations of type SideTable.
+        """
+        return side_tables(case)
+
+    return get_side_tables(case)
+
+
+def conditions_289159079186754023252507394066467767351(case) -> bool:
+    def world_holds_bodies(case: World) -> bool:
+        """
+        Whether the world holds anything that could be named.
+        """
+        return len(case.kinematic_structure_entities) > 0
+
+    return world_holds_bodies(case)
+
+
+def conclusion_289159079186754023252507394066467767351(case) -> List[Table]:
+    def get_tables(case: World) -> List[Table]:
+        """
+        Get possible value(s) for World.semantic_annotations of type Table.
+        """
+        return tables(case)
+
+    return get_tables(case)

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_reasoner.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_reasoner.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from os.path import dirname
 
-from typing_extensions import Optional, List, Dict, Any, Type, ClassVar
+from typing_extensions import Optional, List, Dict, Any, ClassVar
 
 from semantic_digital_twin.semantic_annotations.mixins import HasMechanicalJoint
 from semantic_digital_twin.world import World
@@ -81,26 +81,22 @@ class WorldReasoner:
                 setattr(self.world, attr_name, attr_value)
             else:
                 for semantic_annotation in attr_value:
-                    self.world.add_semantic_annotation_recursively(semantic_annotation)
-                    if isinstance(semantic_annotation, HasMechanicalJoint):
-                        semantic_annotation.create_default_mechanical_joint()
+                    self._hold_in_world(semantic_annotation)
 
-    def fit_semantic_annotations(
-        self,
-        required_semantic_annotations: List[Type[SemanticAnnotation]],
-        update_existing_semantic_annotations: bool = False,
-    ) -> None:
+    def _hold_in_world(self, semantic_annotation: SemanticAnnotation) -> None:
         """
-        Fit the world RDR to the required semantic annotation types.
+        Give the world the inferred annotation, and the joint that already moves it.
 
-        :param required_semantic_annotations: A list of semantic annotation types that
-            the RDR should be fitted to.
-        :param update_existing_semantic_annotations: If True, existing semantic
-            annotations will be updated with new rules, else they will be skipped.
+        An inferred annotation the world already holds an equal of is dropped in favour
+        of the one the world holds, so that reasoning over a world that was annotated
+        before does not store a second copy of what it recognises, and so that the joint
+        is given to the annotation everything else refers to.
         """
-        self.reasoner.fit_attribute(
-            "semantic_annotations",
-            required_semantic_annotations,
-            False,
-            update_existing_rules=update_existing_semantic_annotations,
+        annotation_in_world = self.world.get_semantic_annotation_equal_to(
+            semantic_annotation
         )
+        if annotation_in_world is None:
+            self.world.add_semantic_annotation_recursively(semantic_annotation)
+            annotation_in_world = semantic_annotation
+        if isinstance(annotation_in_world, HasMechanicalJoint):
+            annotation_in_world.create_default_mechanical_joint()

--- a/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_reasoner.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/reasoning/world_reasoner.py
@@ -91,6 +91,8 @@ class WorldReasoner:
         of the one the world holds, so that reasoning over a world that was annotated
         before does not store a second copy of what it recognises, and so that the joint
         is given to the annotation everything else refers to.
+
+        :param semantic_annotation: The annotation a rule inferred.
         """
         annotation_in_world = self.world.get_semantic_annotation_equal_to(
             semantic_annotation

--- a/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/semantic_annotations.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/semantic_annotations/semantic_annotations.py
@@ -721,6 +721,8 @@ class ShelfLayer(HasSupportingSurface):
     walls.
     """
 
+    _synonyms = {"level", "board"}
+
 
 @dataclass(eq=False)
 class Table(Furniture, HasSupportingSurface):
@@ -734,6 +736,8 @@ class CounterTop(Furniture, HasSupportingSurface, HasSink):
     """
     A semantic annotation that represents a counter top.
     """
+
+    _synonyms = {"countertop"}
 
 
 @dataclass(eq=False)
@@ -886,6 +890,8 @@ class Wall(HasApertures):
 
     Doors are a computed property.
     """
+
+    _synonyms = {"walls"}
 
     @property
     def doors(self) -> Iterable[Door]:
@@ -1263,6 +1269,8 @@ class SideTable(Table):
     """
     A side table.
     """
+
+    _synonyms = {"bedside"}
 
 
 @dataclass(eq=False)
@@ -1828,3 +1836,5 @@ class CoffeeMachine(HasRootBody):
     """
     A countertop appliance that brews coffee.
     """
+
+    _synonyms = {"coffe"}

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -1639,6 +1639,27 @@ class World(HasSimulatorProperties):
             and semantic_annotation in self.semantic_annotations
         )
 
+    def get_semantic_annotation_equal_to(
+        self, semantic_annotation: SemanticAnnotation
+    ) -> Optional[SemanticAnnotation]:
+        """
+        The annotation this world holds that describes the same thing, if it holds one.
+
+        An annotation is equal to another when it is of the same type and refers to the
+        same entities, so an annotation built separately can stand for one the world
+        already holds. Use this before adding a freshly built annotation, and wire up
+        the result rather than the argument, or the wiring lands on an annotation the
+        world does not hold.
+        """
+        return next(
+            (
+                held_annotation
+                for held_annotation in self.semantic_annotations
+                if held_annotation == semantic_annotation
+            ),
+            None,
+        )
+
     def is_body_in_world(self, body: Body) -> bool:
         return self._is_world_entity_with_hash_in_world_from_iterable(hash(body))
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -1650,6 +1650,9 @@ class World(HasSimulatorProperties):
         already holds. Use this before adding a freshly built annotation, and wire up
         the result rather than the argument, or the wiring lands on an annotation the
         world does not hold.
+
+        :param semantic_annotation: The annotation to look for an equal of.
+        :return: The equal annotation this world holds, or ``None`` when it holds none.
         """
         return next(
             (

--- a/test/krrood_test/test_eql/test_verbalization/test_method_call_chains.py
+++ b/test/krrood_test/test_eql/test_verbalization/test_method_call_chains.py
@@ -1,0 +1,148 @@
+"""
+A method call in a navigation chain reads as the method, not as an empty call.
+
+A call adds nothing a reader can name — ``body.has_collision()`` says what
+``body.has_collision`` says — so the call contributes no hop of its own, and a method
+that returns a ``bool`` reaches the predicative form a ``bool`` field reaches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from krrood.entity_query_language.core.expression_structure import (
+    boolean_terminal_attribute,
+    walk_chain,
+)
+from krrood.entity_query_language.factories import variable
+from krrood.entity_query_language.verbalization.attribute_predicates import (
+    default_boolean_predicate,
+)
+from krrood.entity_query_language.verbalization.boolean_predicate import (
+    AdjectivalPredicate,
+    PossessivePredicate,
+)
+from krrood.entity_query_language.verbalization.navigation_path import build_path_parts
+from krrood.entity_query_language.verbalization.pipeline import verbalize_expression
+
+
+@dataclass
+class Container:
+    """
+    A thing whose geometry and capacity are computed by methods rather than stored in
+    fields, so a query over it navigates through calls.
+    """
+
+    name: str
+    """
+    The container's name.
+    """
+
+    def has_collision(self) -> bool:
+        """
+        :return: Whether the container has collision geometry.
+        """
+        return True
+
+    def is_sealed(self) -> bool:
+        """
+        :return: Whether the container is sealed.
+        """
+        return False
+
+    def capacity(self) -> int:
+        """
+        :return: How much the container holds.
+        """
+        return 1
+
+
+# %% the hops a call contributes
+
+
+def test_a_call_names_no_hop_of_its_own():
+    """
+    The attribute the call invokes already names it, so the path is the method name
+    alone.
+    """
+    chain, _ = walk_chain(variable(Container, []).capacity())
+
+    assert [step.name for step in build_path_parts(chain)] == ["capacity"]
+
+
+def test_a_value_returning_method_reads_as_the_value_it_names():
+    """
+    With no hop for the call, a value method reads as the possessive path over its own
+    name.
+    """
+    assert (
+        verbalize_expression(variable(Container, []).capacity())
+        == "the capacity of a Container"
+    )
+
+
+# %% a method that returns a boolean
+
+
+def test_a_boolean_method_is_the_chains_boolean_terminal():
+    """
+    The call resolves to ``bool`` from the method's own return annotation, so the chain
+    ends in the attribute naming the method.
+    """
+    chain, _ = walk_chain(variable(Container, []).has_collision())
+
+    terminal = boolean_terminal_attribute(chain)
+
+    assert terminal is not None
+    assert terminal._attribute_name_ == "has_collision"
+
+
+def test_a_boolean_method_reads_predicatively():
+    """
+    A ``bool``-returning method reaches the predicative form a ``bool`` field reaches.
+    """
+    assert (
+        verbalize_expression(variable(Container, []).has_collision())
+        == "a Container has collision"
+    )
+
+
+def test_a_value_returning_method_is_no_boolean_terminal():
+    """
+    Only the ``bool`` return puts a call on the predicative path.
+    """
+    chain, _ = walk_chain(variable(Container, []).capacity())
+
+    assert boolean_terminal_attribute(chain) is None
+
+
+# %% a name that already spells its predicate's head
+
+
+def test_a_possessive_name_does_not_repeat_its_verb():
+    """
+    ``has_collision`` says *have* itself, so the predicate takes the rest of the name as
+    its object rather than saying *have* twice.
+    """
+    assert default_boolean_predicate("has_collision") == PossessivePredicate(
+        noun="collision"
+    )
+
+
+def test_a_copular_name_does_not_repeat_its_copula():
+    """
+    ``is_sealed`` says *is* itself, so the predicate takes the rest of the name as its
+    adjective.
+    """
+    assert default_boolean_predicate("is_sealed") == AdjectivalPredicate(
+        adjective="sealed"
+    )
+
+
+def test_a_name_spelling_no_head_is_read_by_its_shape():
+    """
+    A name that spells no head of its own is still classified by the shape of its last
+    word.
+    """
+    assert default_boolean_predicate("milk") == PossessivePredicate()
+    assert default_boolean_predicate("completed") == AdjectivalPredicate()

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
@@ -8,6 +8,7 @@ import pytest
 from typing_extensions import Dict, List, Self, Set
 
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
+from semantic_digital_twin.robots.minimal_robot import MinimalRobot
 from semantic_digital_twin.reasoning.world_rdr.rules import (
     ContainerKind,
     NamedKind,
@@ -369,6 +370,24 @@ def test_a_linkage_with_no_grip_anywhere_holds_no_door():
     )
 
     assert furniture.root_names(doors_with_a_handle, doors_without_a_handle) == set()
+
+
+# %% what the rules leave alone
+
+
+def test_a_robots_own_parts_are_not_furniture(drawer_with_a_grip):
+    """
+    A robot is jointed exactly like a drawer with a handle on it, so only knowing that
+    the branch is a robot keeps the rules off it.
+    """
+    MinimalRobot.from_branch_in_world(drawer_with_a_grip.bodies["cabinet"])
+
+    assert drawer_with_a_grip.root_names(handles) == set()
+    assert (
+        drawer_with_a_grip.root_names(drawers_with_a_handle, drawers_without_a_handle)
+        == set()
+    )
+    assert drawer_with_a_grip.root_names(cabinets) == set()
 
 
 # %% containers

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
@@ -1,0 +1,438 @@
+"""
+The world reasoner's rules, each on the smallest world that shows what it decides.
+"""
+
+from dataclasses import dataclass, field
+
+import pytest
+from typing_extensions import Dict, List, Self, Set
+
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
+from semantic_digital_twin.reasoning.world_rdr.rules import (
+    ContainerKind,
+    NamedKind,
+    asserted_kind,
+    cabinets,
+    container_kind_of,
+    dishwashers,
+    doors_with_a_handle,
+    doors_without_a_handle,
+    drawers_with_a_handle,
+    drawers_without_a_handle,
+    handles,
+)
+from semantic_digital_twin.semantic_annotations.semantic_annotations import (
+    SideTable,
+    Spoon,
+)
+from semantic_digital_twin.spatial_types import Vector3
+from semantic_digital_twin.spatial_types.spatial_types import (
+    HomogeneousTransformationMatrix,
+)
+from semantic_digital_twin.world import World
+from semantic_digital_twin.world_description.connections import (
+    ActiveConnection,
+    FixedConnection,
+    PrismaticConnection,
+    RevoluteConnection,
+)
+from semantic_digital_twin.world_description.geometry import Box, Scale
+from semantic_digital_twin.world_description.shape_collection import ShapeCollection
+from semantic_digital_twin.world_description.world_entity import Body
+
+# %% building small worlds
+
+
+@dataclass
+class FurnitureUnderTest:
+    """
+    A world holding just enough furniture to exercise one rule, and the bodies of it by
+    the name each was built under.
+    """
+
+    world: World
+    """
+    The world the bodies live in.
+    """
+
+    bodies: Dict[str, Body] = field(default_factory=dict)
+    """
+    Each body of the furniture, by the name it was built under.
+    """
+
+    @classmethod
+    def build(cls) -> Self:
+        """
+        Start a world holding nothing but a root body.
+        """
+        world = World()
+        root = Body(name=PrefixedName("root", prefix="rules"))
+        with world.modify_world():
+            world.add_kinematic_structure_entity(root)
+        return cls(world, {"root": root})
+
+    def add(self, name: str, parent: str, connection_type, **connection_kwargs) -> Self:
+        """
+        Hang a new body carrying geometry off an existing one.
+
+        :param connection_type: The type of connection to hang it by.
+        :param connection_kwargs: Passed on to the connection's factory, so that a
+            ``multiplier`` can make the new body only follow its parent.
+        """
+        return self._add(name, parent, connection_type, True, **connection_kwargs)
+
+    def add_without_geometry(
+        self, name: str, parent: str, connection_type, **connection_kwargs
+    ) -> Self:
+        """
+        Hang a new shapeless body off an existing one, as world models do to build up a
+        compound motion.
+        """
+        return self._add(name, parent, connection_type, False, **connection_kwargs)
+
+    def _add(
+        self,
+        name: str,
+        parent: str,
+        connection_type,
+        with_geometry: bool,
+        **connection_kwargs,
+    ) -> Self:
+        body = Body(name=PrefixedName(name, prefix="rules"))
+        if with_geometry:
+            body.collision = ShapeCollection(
+                [Box(scale=Scale(0.1, 0.1, 0.1))], reference_frame=body
+            )
+        parent_body = self.bodies[parent]
+        if issubclass(connection_type, ActiveConnection):
+            connection_kwargs.setdefault("axis", Vector3.X(reference_frame=parent_body))
+        with self.world.modify_world():
+            self.world.add_kinematic_structure_entity(body)
+            self.world.add_connection(
+                connection_type.create_with_dofs(
+                    world=self.world,
+                    parent=parent_body,
+                    child=body,
+                    parent_T_connection_expression=HomogeneousTransformationMatrix(
+                        reference_frame=parent_body
+                    ),
+                    **connection_kwargs,
+                )
+            )
+        self.bodies[name] = body
+        return self
+
+    def annotate(self, annotation) -> Self:
+        """
+        Give the world an annotation it already holds before any rule runs.
+        """
+        with self.world.modify_world():
+            self.world.add_semantic_annotation_recursively(annotation)
+        return self
+
+    def apply(self, *rules) -> Self:
+        """
+        Run rules in order, adding what each concludes before the next one runs, the way
+        the classifier does.
+        """
+        for rule in rules:
+            for annotation in rule(self.world):
+                with self.world.modify_world():
+                    self.world.add_semantic_annotation_recursively(annotation)
+        return self
+
+    def root_names(self, *rules) -> Set[str]:
+        """
+        The names of the bodies the given rules conclude something about.
+        """
+        return {
+            annotation.root.name.name
+            for rule in rules
+            for annotation in rule(self.world)
+        }
+
+    def name_of(self, key: str) -> str:
+        """
+        The full name of the body built under ``key``.
+        """
+        return self.bodies[key].name.name
+
+
+@pytest.fixture
+def drawer_with_a_grip() -> FurnitureUnderTest:
+    """
+    A case that slides out of a cabinet, with a grip fixed to its front.
+    """
+    return (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("case", "cabinet", PrismaticConnection)
+        .add("grip", "case", FixedConnection)
+    )
+
+
+# %% what a body's name asserts
+
+
+def test_a_compound_name_settles_on_the_kind_it_ends_on():
+    """
+    A name says where the body is before it says what it is, so the kind it is still
+    talking about at the end is the one the body is.
+    """
+    assert (
+        asserted_kind(["sink", "area", "left", "drawer"], NamedKind) is NamedKind.DRAWER
+    )
+
+
+def test_a_name_spelling_out_a_specific_kind_settles_on_it_over_its_base():
+    """
+    ``coffee_table`` names both a table and a coffee table, and means the latter.
+    """
+    assert asserted_kind(["coffee", "table"], NamedKind) is NamedKind.COFFEE_TABLE
+
+
+def test_a_name_using_a_synonym_settles_on_the_kind_declaring_it():
+    """
+    A kind is recognised through its own ``_synonyms``, which is how a word the class
+    name never spells still reaches it.
+    """
+    [synonym] = SideTable._synonyms
+
+    assert asserted_kind([synonym, "table"], NamedKind) is NamedKind.SIDE_TABLE
+
+
+def test_a_name_mentioning_no_kind_settles_on_nothing():
+    """
+    Most bodies are named after neither their kind nor anything else recognised.
+    """
+    assert asserted_kind(["cabinet"], NamedKind) is None
+
+
+# %% recognising a handle
+
+
+def test_a_grip_fixed_to_a_moving_part_is_a_handle(drawer_with_a_grip):
+    """
+    Nothing but the joints is needed: the grip cannot move by itself and travels with
+    the case, while the case moves by its own joint and the cabinet does not move at
+    all.
+    """
+    assert drawer_with_a_grip.root_names(handles) == {
+        drawer_with_a_grip.name_of("grip")
+    }
+
+
+def test_a_body_fixed_to_something_that_cannot_move_is_not_a_handle():
+    """
+    A body fixed to a body that is itself fixed travels with nothing that opens.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("worktop", "root", FixedConnection)
+        .add("appliance", "worktop", FixedConnection)
+    )
+
+    assert furniture.root_names(handles) == set()
+
+
+def test_a_body_the_world_already_identifies_is_not_a_handle(drawer_with_a_grip):
+    """
+    An object put away in a drawer is jointed exactly as a handle is, and keeps the
+    identity the world already holds for it.
+    """
+    drawer_with_a_grip.annotate(Spoon(root=drawer_with_a_grip.bodies["grip"]))
+
+    assert drawer_with_a_grip.root_names(handles) == set()
+
+
+def test_a_body_named_after_furniture_is_not_a_handle():
+    """
+    A shelf board mounted inside a drawer is jointed exactly as a handle is, and is kept
+    apart by being named a board.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("case", "cabinet", PrismaticConnection)
+        .add("board", "case", FixedConnection)
+    )
+
+    assert furniture.root_names(handles) == set()
+
+
+# %% things that open
+
+
+def test_a_case_a_slider_pulls_out_is_a_drawer_with_its_grip(drawer_with_a_grip):
+    """
+    The drawer is found by its joint, and given the handle mounted on it.
+    """
+    drawer_with_a_grip.apply(handles)
+
+    [drawer] = drawers_with_a_handle(drawer_with_a_grip.world)
+    assert drawer.root is drawer_with_a_grip.bodies["case"]
+    assert drawer.handle.root is drawer_with_a_grip.bodies["grip"]
+
+
+def test_a_case_with_nothing_to_pull_it_by_is_still_a_drawer():
+    """
+    A drawer is what a slider pulls out, whether or not the model gives it a grip.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("case", "cabinet", PrismaticConnection)
+    )
+
+    [drawer] = drawers_without_a_handle(furniture.world)
+    assert drawer.root is furniture.bodies["case"]
+    assert drawer.handle is None
+
+
+def test_a_drawer_offering_a_handle_is_claimed_by_only_one_rule(drawer_with_a_grip):
+    """
+    The two drawer rules are complements, so a drawer is never inferred twice - which
+    would leave the world holding it both with and without its handle.
+    """
+    drawer_with_a_grip.apply(handles)
+
+    assert len(drawers_with_a_handle(drawer_with_a_grip.world)) == 1
+    assert drawers_without_a_handle(drawer_with_a_grip.world) == []
+
+
+def test_a_leaf_a_hinge_swings_is_a_door_with_its_grip():
+    """
+    A door is found by its hinge, and given the handle mounted on it.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("leaf", "cabinet", RevoluteConnection)
+        .add("grip", "leaf", FixedConnection)
+        .apply(handles)
+    )
+
+    [door] = doors_with_a_handle(furniture.world)
+    assert door.root is furniture.bodies["leaf"]
+    assert door.handle.root is furniture.bodies["grip"]
+
+
+def test_a_leaf_another_follows_is_opened_by_that_leafs_handle():
+    """
+    A front of two leaves is jointed so the lower only repeats the upper's motion and
+    carries the only grip, so the upper leaf is a door too.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("upper_leaf", "cabinet", RevoluteConnection)
+        .add("lower_leaf", "upper_leaf", RevoluteConnection, multiplier=1.2)
+        .add("grip", "lower_leaf", FixedConnection)
+        .apply(handles)
+    )
+
+    assert furniture.root_names(doors_without_a_handle) == {
+        furniture.name_of("upper_leaf")
+    }
+
+
+def test_a_container_is_not_opened_by_the_handle_on_its_own_door():
+    """
+    A door opens by its own joint rather than by following the appliance it is mounted
+    on, so the appliance is not a door as well.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add("appliance", "cabinet", RevoluteConnection)
+        .add("leaf", "appliance", RevoluteConnection)
+        .add("grip", "leaf", FixedConnection)
+        .apply(handles)
+    )
+
+    assert furniture.root_names(doors_with_a_handle, doors_without_a_handle) == {
+        furniture.name_of("leaf")
+    }
+
+
+def test_a_linkage_with_no_grip_anywhere_holds_no_door():
+    """
+    A tap is a chain of hinges in which nothing is a grip for opening anything, so none
+    of its parts is a door.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("basin", "root", FixedConnection)
+        .add("spout", "basin", RevoluteConnection)
+        .add("lever", "spout", RevoluteConnection)
+        .apply(handles)
+    )
+
+    assert furniture.root_names(doors_with_a_handle, doors_without_a_handle) == set()
+
+
+# %% containers
+
+
+def test_a_body_things_open_out_of_is_a_container(drawer_with_a_grip):
+    """
+    A container is recognised by what opens out of it, and is given those parts.
+    """
+    drawer_with_a_grip.apply(handles, drawers_with_a_handle)
+
+    [cabinet] = cabinets(drawer_with_a_grip.world)
+    assert cabinet.root is drawer_with_a_grip.bodies["cabinet"]
+    assert [drawer.root for drawer in cabinet.drawers] == [
+        drawer_with_a_grip.bodies["case"]
+    ]
+
+
+def test_a_container_holds_a_part_reached_through_a_shapeless_helper():
+    """
+    A door that pops out before it swings hangs off a shapeless helper body, and belongs
+    to the container beyond it rather than to the helper.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("cabinet", "root", FixedConnection)
+        .add_without_geometry("popout", "cabinet", PrismaticConnection)
+        .add("leaf", "popout", RevoluteConnection)
+        .add("grip", "leaf", FixedConnection)
+        .apply(handles, doors_with_a_handle)
+    )
+
+    [cabinet] = cabinets(furniture.world)
+    assert cabinet.root is furniture.bodies["cabinet"]
+    assert [door.root for door in cabinet.doors] == [furniture.bodies["leaf"]]
+
+
+def test_a_container_takes_its_kind_from_the_part_that_names_it():
+    """
+    Only the front of an appliance is named after it, so the kind is read from the whole
+    branch rather than from the container's own name.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("unit", "root", FixedConnection)
+        .add("dishwasher_front", "unit", PrismaticConnection)
+        .apply(handles, drawers_without_a_handle)
+    )
+
+    assert container_kind_of(furniture.bodies["unit"]) is ContainerKind.DISHWASHER
+    assert furniture.root_names(dishwashers) == {furniture.name_of("unit")}
+    assert furniture.root_names(cabinets) == set()
+
+
+def test_a_container_naming_no_kind_is_a_plain_cabinet():
+    """
+    A container whose parts name no kind is left to the plain cabinet rule.
+    """
+    furniture = (
+        FurnitureUnderTest.build()
+        .add("unit", "root", FixedConnection)
+        .add("case", "unit", PrismaticConnection)
+        .apply(handles, drawers_without_a_handle)
+    )
+
+    assert container_kind_of(furniture.bodies["unit"]) is None
+    assert furniture.root_names(cabinets) == {furniture.name_of("unit")}

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_annotation_rules.py
@@ -11,10 +11,10 @@ from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.robots.minimal_robot import MinimalRobot
 from semantic_digital_twin.reasoning.world_rdr.rules import (
     ContainerKind,
+    NamedContainerKind,
     NamedKind,
     asserted_kind,
     cabinets,
-    container_kind_of,
     dishwashers,
     doors_with_a_handle,
     doors_without_a_handle,
@@ -437,7 +437,7 @@ def test_a_container_takes_its_kind_from_the_part_that_names_it():
         .apply(handles, drawers_without_a_handle)
     )
 
-    assert container_kind_of(furniture.bodies["unit"]) is ContainerKind.DISHWASHER
+    assert NamedContainerKind(furniture.bodies["unit"])() is ContainerKind.DISHWASHER
     assert furniture.root_names(dishwashers) == {furniture.name_of("unit")}
     assert furniture.root_names(cabinets) == set()
 
@@ -453,5 +453,5 @@ def test_a_container_naming_no_kind_is_a_plain_cabinet():
         .apply(handles, drawers_without_a_handle)
     )
 
-    assert container_kind_of(furniture.bodies["unit"]) is None
+    assert NamedContainerKind(furniture.bodies["unit"])() is None
     assert furniture.root_names(cabinets) == {furniture.name_of("unit")}

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_apartment_reasoning.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_apartment_reasoning.py
@@ -1,0 +1,492 @@
+"""
+What the world reasoner must infer from the ``iai_apartment`` world model.
+
+The expected bodies are named here rather than counted, so that a rule finding the right
+number of the wrong things fails. Every name is checked against the world itself by
+:func:`test_every_expected_body_exists`, so a typo here fails as a typo rather than as a
+missing annotation.
+"""
+
+from enum import StrEnum
+
+import pytest
+from typing_extensions import List, Set, Type
+
+from semantic_digital_twin.reasoning.world_reasoner import WorldReasoner
+from semantic_digital_twin.semantic_annotations.mixins import HasRootBody
+from semantic_digital_twin.semantic_annotations.semantic_annotations import (
+    Cabinet,
+    CoffeeMachine,
+    CoffeeTable,
+    Cooktop,
+    CounterTop,
+    Dishwasher,
+    Door,
+    Drawer,
+    Fridge,
+    Handle,
+    Hinge,
+    Oven,
+    ShelfLayer,
+    SideTable,
+    Sink,
+    Slider,
+    Sofa,
+    Table,
+    Wall,
+    Wardrobe,
+)
+from semantic_digital_twin.world import World
+
+# %% the bodies each annotation is expected on
+
+
+class ApartmentCabinet(StrEnum):
+    """
+    The bodies of the apartment that are a Cabinet.
+    """
+
+    CABINET1 = "cabinet1"
+    CABINET10 = "cabinet10"
+    CABINET11 = "cabinet11"
+    CABINET2 = "cabinet2"
+    CABINET3 = "cabinet3"
+    CABINET4 = "cabinet4"
+    CABINET5 = "cabinet5"
+    CABINET6 = "cabinet6"
+    CABINET8 = "cabinet8"
+    CABINET9 = "cabinet9"
+
+
+class ApartmentCoffeeMachine(StrEnum):
+    """
+    The bodies of the apartment that are a CoffeeMachine.
+    """
+
+    COFFE_MACHINE = "coffe_machine"
+
+
+class ApartmentCoffeeTable(StrEnum):
+    """
+    The bodies of the apartment that are a CoffeeTable.
+    """
+
+    COFFEE_TABLE = "coffee_table"
+
+
+class ApartmentCooktop(StrEnum):
+    """
+    The bodies of the apartment that are a Cooktop.
+    """
+
+    COOKTOP = "cooktop"
+
+
+class ApartmentCounterTop(StrEnum):
+    """
+    The bodies of the apartment that are a CounterTop.
+    """
+
+    COUNTERTOP = "countertop"
+    ISLAND_COUNTERTOP = "island_countertop"
+
+
+class ApartmentDishwasher(StrEnum):
+    """
+    The bodies of the apartment that are a Dishwasher.
+    """
+
+    CABINET7 = "cabinet7"
+
+
+class ApartmentDoor(StrEnum):
+    """
+    The bodies of the apartment that are a Door.
+    """
+
+    CABINET1_DOOR_TOP_LEFT = "cabinet1_door_top_left"
+    CABINET2_DOOR_LEFT = "cabinet2_door_left"
+    CABINET3_DOOR_BOTTOM_LEFT = "cabinet3_door_bottom_left"
+    CABINET3_DOOR_TOP_LEFT = "cabinet3_door_top_left"
+    CABINET4_DOOR_BOTTOM = "cabinet4_door_bottom"
+    CABINET4_DOOR_TOP = "cabinet4_door_top"
+    CABINET7_DOOR_BOTTOM_LEFT = "cabinet7_door_bottom_left"
+    WARDROBE_DOOR_LEFT = "wardrobe_door_left"
+    WARDROBE_DOOR_RIGHT = "wardrobe_door_right"
+
+
+class ApartmentDrawer(StrEnum):
+    """
+    The bodies of the apartment that are a Drawer.
+    """
+
+    CABINET10_DRAWER_BOTTOM = "cabinet10_drawer_bottom"
+    CABINET10_DRAWER_MIDDLE = "cabinet10_drawer_middle"
+    CABINET10_DRAWER_TOP = "cabinet10_drawer_top"
+    CABINET11_DRAWER_BOTTOM = "cabinet11_drawer_bottom"
+    CABINET11_DRAWER_MIDDLE = "cabinet11_drawer_middle"
+    CABINET11_DRAWER_TOP = "cabinet11_drawer_top"
+    CABINET1_DRAWER_BOTTOM = "cabinet1_drawer_bottom"
+    CABINET1_DRAWER_MIDDLE = "cabinet1_drawer_middle"
+    CABINET2_DRAWER_BIG = "cabinet2_drawer_big"
+    CABINET2_DRAWER_SMALL = "cabinet2_drawer_small"
+    CABINET5_DRAWER_BOTTOM = "cabinet5_drawer_bottom"
+    CABINET5_DRAWER_MIDDLE = "cabinet5_drawer_middle"
+    CABINET5_DRAWER_TOP = "cabinet5_drawer_top"
+    CABINET6_DRAWER_BOTTOM = "cabinet6_drawer_bottom"
+    CABINET6_DRAWER_MIDDLE = "cabinet6_drawer_middle"
+    CABINET6_DRAWER_TOP = "cabinet6_drawer_top"
+    CABINET8_DRAWER_BOTTOM = "cabinet8_drawer_bottom"
+    CABINET8_DRAWER_MIDDLE = "cabinet8_drawer_middle"
+    CABINET9_DRAWER_BOTTOM = "cabinet9_drawer_bottom"
+    CABINET9_DRAWER_MIDDLE = "cabinet9_drawer_middle"
+    CABINET9_DRAWER_TOP = "cabinet9_drawer_top"
+    COFFEE_TABLE_DRAWER = "coffee_table_drawer"
+    DISHWASHER_DRAWER_MIDDLE = "dishwasher_drawer_middle"
+
+
+class ApartmentHandle(StrEnum):
+    """
+    The bodies of the apartment that are a Handle.
+    """
+
+    HANDLE_CAB10_B = "handle_cab10_b"
+    HANDLE_CAB10_M = "handle_cab10_m"
+    HANDLE_CAB10_T = "handle_cab10_t"
+    HANDLE_CAB11_B = "handle_cab11_b"
+    HANDLE_CAB11_M = "handle_cab11_m"
+    HANDLE_CAB11_T = "handle_cab11_t"
+    HANDLE_CAB1_DRAWER_BOTTOM = "handle_cab1_drawer_bottom"
+    HANDLE_CAB1_DRAWER_MID = "handle_cab1_drawer_mid"
+    HANDLE_CAB1_TOP_DOOR = "handle_cab1_top_door"
+    HANDLE_CAB2_DOOR = "handle_cab2_door"
+    HANDLE_CAB3_DOOR_BOTTOM = "handle_cab3_door_bottom"
+    HANDLE_CAB3_DOOR_TOP = "handle_cab3_door_top"
+    HANDLE_CAB4_DOOR_BOTTOM = "handle_cab4_door_bottom"
+    HANDLE_CAB5_B = "handle_cab5_b"
+    HANDLE_CAB5_M = "handle_cab5_m"
+    HANDLE_CAB5_T = "handle_cab5_t"
+    HANDLE_CAB6_B = "handle_cab6_b"
+    HANDLE_CAB6_M = "handle_cab6_m"
+    HANDLE_CAB6_T = "handle_cab6_t"
+    HANDLE_CAB7 = "handle_cab7"
+    HANDLE_CAB7_MIDDLE = "handle_cab7_middle"
+    HANDLE_CAB8 = "handle_cab8"
+    HANDLE_CAB9_B = "handle_cab9_b"
+    HANDLE_CAB9_M = "handle_cab9_m"
+    HANDLE_CAB9_T = "handle_cab9_t"
+    WARDROBE_DOOR_LEFT_HANDLE = "wardrobe_door_left_handle"
+    WARDROBE_DOOR_RIGHT_HANDLE = "wardrobe_door_right_handle"
+
+
+class ApartmentOven(StrEnum):
+    """
+    The bodies of the apartment that are a Oven.
+    """
+
+    OVEN = "oven"
+
+
+class ApartmentShelfLayer(StrEnum):
+    """
+    The bodies of the apartment that are a ShelfLayer.
+    """
+
+    CABINET1_COLOKSU_LEVEL4 = "cabinet1_coloksu_level4"
+    CABINET1_COLOKSU_LEVEL5 = "cabinet1_coloksu_level5"
+
+
+class ApartmentSideTable(StrEnum):
+    """
+    The bodies of the apartment that are a SideTable.
+    """
+
+    BEDSIDE_TABLE = "bedside_table"
+
+
+class ApartmentSink(StrEnum):
+    """
+    The bodies of the apartment that are a Sink.
+    """
+
+    SINK = "sink"
+
+
+class ApartmentSofa(StrEnum):
+    """
+    The bodies of the apartment that are a Sofa.
+    """
+
+    SOFA = "sofa"
+
+
+class ApartmentTable(StrEnum):
+    """
+    The bodies of the apartment that are a Table.
+    """
+
+    TABLE_AREA_MAIN = "table_area_main"
+
+
+class ApartmentWall(StrEnum):
+    """
+    The bodies of the apartment that are a Wall.
+    """
+
+    WALL_COLOKSU_WALL1 = "wall_coloksu_wall1"
+    WALL_COLOKSU_WALL2 = "wall_coloksu_wall2"
+    WALL_COLOKSU_WALL3 = "wall_coloksu_wall3"
+    WALL_COLOKSU_WALL4 = "wall_coloksu_wall4"
+    WALLS = "walls"
+
+
+class ApartmentWardrobe(StrEnum):
+    """
+    The bodies of the apartment that are a Wardrobe.
+    """
+
+    WARDROBE = "wardrobe"
+
+
+# %% pairing each annotation type with what it is expected on
+
+EXPECTED_BODIES: List[tuple] = [
+    (Handle, ApartmentHandle),
+    (Drawer, ApartmentDrawer),
+    (Door, ApartmentDoor),
+    (Cabinet, ApartmentCabinet),
+    (Wardrobe, ApartmentWardrobe),
+    (Dishwasher, ApartmentDishwasher),
+    (Oven, ApartmentOven),
+    (Sink, ApartmentSink),
+    (Cooktop, ApartmentCooktop),
+    (CounterTop, ApartmentCounterTop),
+    (Sofa, ApartmentSofa),
+    (Wall, ApartmentWall),
+    (ShelfLayer, ApartmentShelfLayer),
+    (CoffeeMachine, ApartmentCoffeeMachine),
+    (Table, ApartmentTable),
+    (CoffeeTable, ApartmentCoffeeTable),
+    (SideTable, ApartmentSideTable),
+]
+"""
+Each annotation type together with the bodies the reasoner must infer it on.
+"""
+
+
+def expected_body_names(expected: Type[StrEnum]) -> Set[str]:
+    """
+    The body names one of the expectations above holds.
+    """
+    return {member.value for member in expected}
+
+
+def inferred_body_names(world: World, annotation_type: Type[HasRootBody]) -> Set[str]:
+    """
+    The names of the bodies the world's annotations of ``annotation_type`` sit on.
+
+    Subclasses are excluded, so that each expectation is checked against the type the
+    reasoner actually chose rather than against a broader family.
+    """
+    return {
+        annotation.root.name.name
+        for annotation in world.semantic_annotations
+        if type(annotation) is annotation_type
+    }
+
+
+# %% the expectations themselves
+
+
+PREANNOTATED_DRAWER_BODY_NAME = "cabinet10_drawer_top"
+"""
+The drawer the apartment fixture annotates by hand before any reasoning runs.
+"""
+
+
+@pytest.fixture
+def reasoned_apartment(apartment_world_copy) -> World:
+    """
+    The apartment with everything the reasoner can infer about it already inferred.
+    """
+    WorldReasoner(apartment_world_copy).infer_semantic_annotations()
+    return apartment_world_copy
+
+
+@pytest.mark.parametrize(
+    "annotation_type, expected",
+    EXPECTED_BODIES,
+    ids=[annotation_type.__name__ for annotation_type, _ in EXPECTED_BODIES],
+)
+def test_every_expected_body_exists(
+    annotation_type: Type[HasRootBody],
+    expected: Type[StrEnum],
+    apartment_world_copy: World,
+):
+    """
+    Every body this module expects an annotation on is really in the apartment.
+    """
+    for name in expected_body_names(expected):
+        assert apartment_world_copy.get_body_by_name(name).name.name == name
+
+
+@pytest.mark.parametrize(
+    "annotation_type, expected",
+    EXPECTED_BODIES,
+    ids=[annotation_type.__name__ for annotation_type, _ in EXPECTED_BODIES],
+)
+def test_annotations_sit_on_the_expected_bodies(
+    annotation_type: Type[HasRootBody],
+    expected: Type[StrEnum],
+    reasoned_apartment: World,
+):
+    """
+    The reasoner infers each annotation on exactly the bodies that are it, so that both
+    a missed body and a wrongly claimed one fail.
+    """
+    assert inferred_body_names(reasoned_apartment, annotation_type) == (
+        expected_body_names(expected)
+    )
+
+
+def test_the_apartment_holds_no_fridge(reasoned_apartment: World):
+    """
+    The apartment has no fridge, so the rule that recognises one must stay quiet rather
+    than mistake a cabinet for it.
+    """
+    assert inferred_body_names(reasoned_apartment, Fridge) == set()
+
+
+# %% the parts each annotation is wired to
+
+
+def test_a_drawer_is_wired_to_the_handle_mounted_on_it(
+    reasoned_apartment: World,
+):
+    """
+    A drawer carrying a handle is given that handle, and one without stays without.
+    """
+    drawers_by_body = {
+        drawer.root.name.name: drawer
+        for drawer in reasoned_apartment.get_semantic_annotations_by_type(Drawer)
+    }
+
+    handled = drawers_by_body[ApartmentDrawer.CABINET5_DRAWER_TOP]
+    assert handled.handle.root.name.name == ApartmentHandle.HANDLE_CAB5_T
+
+    assert drawers_by_body[ApartmentDrawer.COFFEE_TABLE_DRAWER].handle is None
+
+
+def test_a_door_is_wired_to_the_handle_mounted_on_it(
+    reasoned_apartment: World,
+):
+    """
+    A door carrying a handle is given that handle, and one without stays without.
+    """
+    doors_by_body = {
+        door.root.name.name: door
+        for door in reasoned_apartment.get_semantic_annotations_by_type(Door)
+    }
+
+    handled = doors_by_body[ApartmentDoor.WARDROBE_DOOR_LEFT]
+    assert handled.handle.root.name.name == ApartmentHandle.WARDROBE_DOOR_LEFT_HANDLE
+
+    assert doors_by_body[ApartmentDoor.CABINET4_DOOR_TOP].handle is None
+
+
+def test_a_container_holds_the_parts_that_open_out_of_it(
+    reasoned_apartment: World,
+):
+    """
+    A cabinet is given every drawer and door that opens out of it, including one reached
+    through the shapeless helper body of a pop-out mechanism.
+    """
+    cabinets_by_body = {
+        cabinet.root.name.name: cabinet
+        for cabinet in reasoned_apartment.get_semantic_annotations_by_type(Cabinet)
+    }
+
+    both = cabinets_by_body[ApartmentCabinet.CABINET1]
+    assert {drawer.root.name.name for drawer in both.drawers} == {
+        ApartmentDrawer.CABINET1_DRAWER_MIDDLE.value,
+        ApartmentDrawer.CABINET1_DRAWER_BOTTOM.value,
+    }
+    assert {door.root.name.name for door in both.doors} == {
+        ApartmentDoor.CABINET1_DOOR_TOP_LEFT.value
+    }
+
+    behind_a_helper_body = cabinets_by_body[ApartmentCabinet.CABINET2]
+    assert {door.root.name.name for door in behind_a_helper_body.doors} == {
+        ApartmentDoor.CABINET2_DOOR_LEFT.value
+    }
+
+
+def test_the_dishwasher_is_named_by_the_part_that_opens_out_of_it(
+    reasoned_apartment: World,
+):
+    """
+    A container takes its kind from its parts, so the cabinet holding the dishwasher
+    front is a dishwasher rather than a plain cabinet.
+    """
+    [dishwasher] = reasoned_apartment.get_semantic_annotations_by_type(Dishwasher)
+
+    assert {drawer.root.name.name for drawer in dishwasher.drawers} == {
+        ApartmentDrawer.DISHWASHER_DRAWER_MIDDLE.value
+    }
+
+
+# %% the mechanical joints the reasoner inserts
+
+
+def test_no_body_carries_the_same_kind_of_annotation_twice(
+    reasoned_apartment: World,
+):
+    """
+    Reasoning over a world that already holds some of the annotations must recognise
+    them rather than store a second copy of each.
+    """
+    for annotation_type, _ in EXPECTED_BODIES:
+        inferred = [
+            annotation.root.name.name
+            for annotation in reasoned_apartment.semantic_annotations
+            if type(annotation) is annotation_type
+        ]
+        assert len(inferred) == len(set(inferred)), annotation_type.__name__
+
+
+def test_an_annotation_the_world_already_held_is_wired_to_its_mechanical_joint(
+    reasoned_apartment: World,
+):
+    """
+    The world is given one drawer by hand before reasoning runs.
+
+    Reasoning must wire the joint onto that very drawer, since that is the one
+    everything else refers to.
+    """
+    drawers = [
+        drawer
+        for drawer in reasoned_apartment.get_semantic_annotations_by_type(Drawer)
+        if drawer.root.name.name == PREANNOTATED_DRAWER_BODY_NAME
+    ]
+
+    [drawer] = drawers
+    assert isinstance(drawer.mechanical_joint, Slider)
+
+
+def test_every_openable_part_is_carried_by_a_mechanical_joint(
+    reasoned_apartment: World,
+):
+    """
+    Every drawer and door the world ends up holding is given the joint that already
+    moves it, so the world stays valid after the reasoner rewires it.
+    """
+    drawers = reasoned_apartment.get_semantic_annotations_by_type(Drawer)
+    doors = reasoned_apartment.get_semantic_annotations_by_type(Door)
+    assert drawers and doors
+
+    for drawer in drawers:
+        assert isinstance(drawer.mechanical_joint, Slider)
+    for door in doors:
+        assert isinstance(door.mechanical_joint, Hinge)
+
+    assert reasoned_apartment.validate()

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_apartment_reasoning.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_apartment_reasoning.py
@@ -298,6 +298,11 @@ def inferred_body_names(world: World, annotation_type: Type[HasRootBody]) -> Set
 # %% the expectations themselves
 
 
+ROBOT_JOINT_NAME_ONLY_A_ROBOT_HAS = "l_upper_arm_roll_joint"
+"""
+A joint of the robot, which reasoning over a world it stands in must leave in place.
+"""
+
 PREANNOTATED_DRAWER_BODY_NAME = "cabinet10_drawer_top"
 """
 The drawer the apartment fixture annotates by hand before any reasoning runs.
@@ -490,3 +495,34 @@ def test_every_openable_part_is_carried_by_a_mechanical_joint(
         assert isinstance(door.mechanical_joint, Hinge)
 
     assert reasoned_apartment.validate()
+
+
+# %% what the reasoner leaves alone
+
+
+def test_a_robot_in_the_apartment_is_left_alone(pr2_apartment_world: World):
+    """
+    A robot standing in the apartment keeps every one of its joints.
+
+    Its links are jointed like furniture - the torso slides as a drawer does and an arm
+    link swings as a door does - so annotating them would insert mechanical joints into
+    the robot and rewire the chain its motions are addressed by.
+    """
+    robot_body_names = {
+        body.name.name for body in pr2_apartment_world.robot_body_to_robot_mapping
+    }
+    assert ROBOT_JOINT_NAME_ONLY_A_ROBOT_HAS in {
+        connection.name.name for connection in pr2_apartment_world.connections
+    }
+
+    inferred = WorldReasoner(pr2_apartment_world).infer_semantic_annotations()
+
+    claimed = {
+        annotation.root.name.name
+        for annotation in inferred
+        if isinstance(annotation, HasRootBody)
+    } & robot_body_names
+    assert claimed == set()
+    assert ROBOT_JOINT_NAME_ONLY_A_ROBOT_HAS in {
+        connection.name.name for connection in pr2_apartment_world.connections
+    }

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
@@ -335,6 +335,7 @@ def test_explain_inferred_semantic_annotations(apartment_world_copy):
     assert explanation.get_satisfied_conditions_as_string() == (
         "PrismaticConnection.child.has_collision()"
         " (PrismaticConnection.child.has_collision)"
+        "\nAND is_not_part_of_a_robot (PrismaticConnection.child)"
         "\nAND (FixedConnection.parent == PrismaticConnection.child)"
         "\nAND (FixedConnection.child == Handle.root)"
     )
@@ -353,19 +354,23 @@ def test_verbalize_query_that_inferred_semantic_annotations(apartment_world_copy
     ).verbalize(explanation.query_root)
     assert verbalization_paragraph == (
         "If the () of the has_collision of the child of a PrismaticConnection,"
-        " the parent of a FixedConnection is the child of the PrismaticConnection,"
+        " an is_not_part_of_a_robot, where the body of the is_not_part_of_a_robot is"
+        " the child of the PrismaticConnection,"
+        " the parent of a FixedConnection is the body of the is_not_part_of_a_robot,"
         " the child of the FixedConnection is the root of a Handle,"
-        " then there's a Drawer whose root is the child of the PrismaticConnection,"
+        " then there's a Drawer whose root is the body of the is_not_part_of_a_robot,"
         " and whose handle is the Handle"
     )
     assert verbalization_hierarchical == (
         "If\n"
         "  - the () of the has_collision of the child of a PrismaticConnection\n"
-        "  - the parent of a FixedConnection is the child of the PrismaticConnection\n"
+        "  - an is_not_part_of_a_robot, where the body of the is_not_part_of_a_robot is"
+        " the child of the PrismaticConnection\n"
+        "  - the parent of a FixedConnection is the body of the is_not_part_of_a_robot\n"
         "  - the child of the FixedConnection is the root of a Handle\n"
         "then\n"
         "  there's a Drawer\n"
-        "    - whose root is the child of the PrismaticConnection\n"
+        "    - whose root is the body of the is_not_part_of_a_robot\n"
         "    - whose handle is the Handle"
     )
 

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
@@ -250,6 +250,37 @@ def test_semantic_annotation_hash(apartment_world_copy):
     assert semantic_annotation1 == semantic_annotation2
 
 
+def test_the_world_finds_the_annotation_equal_to_a_freshly_built_one(
+    apartment_world_copy,
+):
+    """
+    An annotation is identified by its type and what it refers to, so one built
+    separately stands for the one the world already holds.
+    """
+    body = apartment_world_copy.bodies[0]
+    held = Handle(root=body)
+    with apartment_world_copy.modify_world():
+        apartment_world_copy.add_semantic_annotation(held)
+
+    assert (
+        apartment_world_copy.get_semantic_annotation_equal_to(Handle(root=body)) is held
+    )
+
+
+def test_the_world_finds_no_annotation_equal_to_one_it_does_not_hold(
+    apartment_world_copy,
+):
+    """
+    Nothing is returned for an annotation the world has never been given.
+    """
+    assert (
+        apartment_world_copy.get_semantic_annotation_equal_to(
+            Handle(root=apartment_world_copy.bodies[1])
+        )
+        is None
+    )
+
+
 def test_handle_semantic_annotation_eql(apartment_world_copy):
     body = variable(type_=Body, domain=apartment_world_copy.bodies)
     query = an(
@@ -259,29 +290,6 @@ def test_handle_semantic_annotation_eql(apartment_world_copy):
     )
     handles = list(query.evaluate())
     assert len(handles) > 0
-
-
-@pytest.mark.parametrize(
-    "semantic_annotation_type, update_existing_semantic_annotations, expected_number",
-    [
-        (Handle, False, 29),
-        (Drawer, False, 19),
-        (Wardrobe, False, 8),
-        (Door, False, 8),  # Should be 11 as there are prismatically connected doors.
-    ],
-)
-def test_infer_apartment_semantic_annotation(
-    semantic_annotation_type,
-    update_existing_semantic_annotations,
-    expected_number,
-    apartment_world_copy,
-):
-    fit_rules_and_assert_semantic_annotations(
-        apartment_world_copy,
-        semantic_annotation_type,
-        update_existing_semantic_annotations,
-        expected_number,
-    )
 
 
 @pytest.mark.skipif(world_rdr is None, reason="requires world_rdr")
@@ -294,36 +302,41 @@ def test_generated_semantic_annotations(kitchen_world):
         for v in found_semantic_annotations
         if isinstance(v, HasCaseAsRootBody)
     ]
-    assert len(drawer_container_names) == 19
+    assert len(drawer_container_names) == 17
 
 
-@pytest.mark.order("third_to_last")
-def test_apartment_semantic_annotations(apartment_world_copy):
-    world_reasoner = WorldReasoner(apartment_world_copy)
-    world_reasoner.fit_semantic_annotations(
-        [Handle, Drawer, Wardrobe],
+HANDLED_DRAWER_BODY_NAME = "cabinet5_drawer_top"
+"""
+A drawer of the apartment that carries a handle.
+
+Named so that the explanation tests always explain the same rule, since a drawer with a
+handle and one without are inferred by different rules.
+"""
+
+
+def inferred_handled_drawer(world) -> Drawer:
+    """
+    The drawer of :data:`HANDLED_DRAWER_BODY_NAME`, as the reasoner infers it.
+    """
+    return next(
+        annotation
+        for annotation in WorldReasoner(world).infer_semantic_annotations()
+        if isinstance(annotation, Drawer)
+        and annotation.root.name.name == HANDLED_DRAWER_BODY_NAME
     )
-
-    found_semantic_annotations = world_reasoner.infer_semantic_annotations()
-    drawer_container_names = [
-        v.root.name.name
-        for v in found_semantic_annotations
-        if isinstance(v, HasCaseAsRootBody)
-    ]
-    assert len(drawer_container_names) == 27
 
 
 @pytest.mark.order("second_to_last")
 def test_explain_inferred_semantic_annotations(apartment_world_copy):
-    world_reasoner = WorldReasoner(apartment_world_copy)
-    found_semantic_annotations = list(world_reasoner.infer_semantic_annotations())
-    drawer = next(ann for ann in found_semantic_annotations if isinstance(ann, Drawer))
+    drawer = inferred_handled_drawer(apartment_world_copy)
     explanation = explain_inference(drawer)
     assert explanation is not None
     assert isinstance(explanation.query_root, SymbolicExpression)
     assert explanation.get_satisfied_conditions_as_string() == (
-        "(Handle.root == FixedConnection.child)"
+        "PrismaticConnection.child.has_collision()"
+        " (PrismaticConnection.child.has_collision)"
         "\nAND (FixedConnection.parent == PrismaticConnection.child)"
+        "\nAND (FixedConnection.child == Handle.root)"
     )
     visualize = False
     if visualize:
@@ -332,55 +345,28 @@ def test_explain_inferred_semantic_annotations(apartment_world_copy):
 
 @pytest.mark.order("fourth_to_last")
 def test_verbalize_query_that_inferred_semantic_annotations(apartment_world_copy):
-    world_reasoner = WorldReasoner(apartment_world_copy)
-    found_semantic_annotations = list(world_reasoner.infer_semantic_annotations())
-    drawer = next(ann for ann in found_semantic_annotations if isinstance(ann, Drawer))
+    drawer = inferred_handled_drawer(apartment_world_copy)
     explanation = explain_inference(drawer)
     verbalization_paragraph = verbalize_expression(explanation.query_root)
     verbalization_hierarchical = VerbalizationPipeline(
         HierarchicalRenderer()
     ).verbalize(explanation.query_root)
     assert verbalization_paragraph == (
-        "If there's a FixedConnection whose parent is the child of a PrismaticConnection,"
-        " there's a Handle whose root is the child of the FixedConnection,"
-        " then there's a Drawer whose root is the parent of the FixedConnection,"
+        "If the () of the has_collision of the child of a PrismaticConnection,"
+        " the parent of a FixedConnection is the child of the PrismaticConnection,"
+        " the child of the FixedConnection is the root of a Handle,"
+        " then there's a Drawer whose root is the child of the PrismaticConnection,"
         " and whose handle is the Handle"
     )
     assert verbalization_hierarchical == (
         "If\n"
-        "  there's a FixedConnection\n"
-        "    - whose parent is the child of a PrismaticConnection\n"
-        "  there's a Handle\n"
-        "    - whose root is the child of the FixedConnection\n"
+        "  - the () of the has_collision of the child of a PrismaticConnection\n"
+        "  - the parent of a FixedConnection is the child of the PrismaticConnection\n"
+        "  - the child of the FixedConnection is the root of a Handle\n"
         "then\n"
         "  there's a Drawer\n"
-        "    - whose root is the parent of the FixedConnection\n"
+        "    - whose root is the child of the PrismaticConnection\n"
         "    - whose handle is the Handle"
-    )
-
-
-def fit_rules_and_assert_semantic_annotations(
-    world,
-    semantic_annotation_type,
-    update_existing_semantic_annotations,
-    expected_number: int,
-):
-    world_reasoner = WorldReasoner(world)
-    world_reasoner.fit_semantic_annotations(
-        [semantic_annotation_type],
-        update_existing_semantic_annotations=update_existing_semantic_annotations,
-    )
-
-    found_semantic_annotations = world_reasoner.infer_semantic_annotations()
-    assert (
-        len(
-            [
-                v
-                for v in found_semantic_annotations
-                if isinstance(v, semantic_annotation_type)
-            ]
-        )
-        == expected_number
     )
 
 

--- a/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
+++ b/test/semantic_digital_twin_test/test_semantic_annotations/test_semantic_annotations.py
@@ -328,14 +328,19 @@ def inferred_handled_drawer(world) -> Drawer:
 
 @pytest.mark.order("second_to_last")
 def test_explain_inferred_semantic_annotations(apartment_world_copy):
+    """
+    The listing names the conditions that held.
+
+    The rule's negated condition - that the body is no part of a robot - is not among
+    them: what held is the negation, and a logical operator names no condition of its
+    own. It is still stated in the verbalization of the same query.
+    """
     drawer = inferred_handled_drawer(apartment_world_copy)
     explanation = explain_inference(drawer)
     assert explanation is not None
     assert isinstance(explanation.query_root, SymbolicExpression)
     assert explanation.get_satisfied_conditions_as_string() == (
-        "PrismaticConnection.child.has_collision()"
-        " (PrismaticConnection.child.has_collision)"
-        "\nAND is_not_part_of_a_robot (PrismaticConnection.child)"
+        "HasCollisionGeometry (PrismaticConnection.child)"
         "\nAND (FixedConnection.parent == PrismaticConnection.child)"
         "\nAND (FixedConnection.child == Handle.root)"
     )
@@ -353,24 +358,22 @@ def test_verbalize_query_that_inferred_semantic_annotations(apartment_world_copy
         HierarchicalRenderer()
     ).verbalize(explanation.query_root)
     assert verbalization_paragraph == (
-        "If the () of the has_collision of the child of a PrismaticConnection,"
-        " an is_not_part_of_a_robot, where the body of the is_not_part_of_a_robot is"
-        " the child of the PrismaticConnection,"
-        " the parent of a FixedConnection is the body of the is_not_part_of_a_robot,"
+        "If the child of a PrismaticConnection has collision geometry,"
+        " the child of the PrismaticConnection is not part of a robot,"
+        " the parent of a FixedConnection is the child of the PrismaticConnection,"
         " the child of the FixedConnection is the root of a Handle,"
-        " then there's a Drawer whose root is the body of the is_not_part_of_a_robot,"
+        " then there's a Drawer whose root is the child of the PrismaticConnection,"
         " and whose handle is the Handle"
     )
     assert verbalization_hierarchical == (
         "If\n"
-        "  - the () of the has_collision of the child of a PrismaticConnection\n"
-        "  - an is_not_part_of_a_robot, where the body of the is_not_part_of_a_robot is"
-        " the child of the PrismaticConnection\n"
-        "  - the parent of a FixedConnection is the body of the is_not_part_of_a_robot\n"
+        "  - the child of a PrismaticConnection has collision geometry\n"
+        "  - the child of the PrismaticConnection is not part of a robot\n"
+        "  - the parent of a FixedConnection is the child of the PrismaticConnection\n"
         "  - the child of the FixedConnection is the root of a Handle\n"
         "then\n"
         "  there's a Drawer\n"
-        "    - whose root is the body of the is_not_part_of_a_robot\n"
+        "    - whose root is the child of the PrismaticConnection\n"
         "    - whose handle is the Handle"
     )
 


### PR DESCRIPTION
We need a baseline for the semantically annotated apartment lab, and the current world reasoner was not very good anymore. this PR updates the rules a to annotate all bodies in the apartment lab and kitchen lab.

 they are written a bit more general than the previous rules, so hopefully they will last for a while, until @AbdelrhmanBassiouny RDR rewrite hits main and all of this are updated anyways