### PR TITLE
added tests and fixes for soft connection serialization

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
@@ -43,7 +43,9 @@ class SoftTrunkSection:
     """The rest length of the section in meters."""
 
     radius: float
-    """The radius of the cylinder representing the section's volume."""
+    """
+    The radius of the cylinder representing the section's volume.
+    """
 
     resolution: int
     """The number of discrete rigid segments used to approximate the continuous curve."""
@@ -51,7 +53,9 @@ class SoftTrunkSection:
 
 @dataclass(eq=False, kw_only=True)
 class SoftEndEffector(EndEffector):
-    """Concrete implementation of EndEffector for soft robots."""
+    """
+    Concrete implementation of EndEffector for soft robots.
+    """
 
     @classmethod
     def setup_default_configuration_in_world_below_robot_root(cls, robot_root):
@@ -66,7 +70,9 @@ class SoftEndEffector(EndEffector):
 
 @dataclass(eq=False, kw_only=True)
 class SoftArm(Arm):
-    """Concrete implementation of Arm for soft robots."""
+    """
+    Concrete implementation of Arm for soft robots.
+    """
 
     @classmethod
     def setup_default_configuration_in_world_below_robot_root(cls, robot_root):
@@ -96,34 +102,54 @@ class SoftTrunk(SemanticAnnotation):
     """
 
     name: PrefixedName
-    """The unique prefixed name assigned to this soft trunk instance."""
+    """
+    The unique prefixed name assigned to this soft trunk instance.
+    """
 
     root: Body
-    """The base body representing the physical root of the trunk."""
+    """
+    The base body representing the physical root of the trunk.
+    """
 
     _world: World
-    """Reference to the parent world containing this robot."""
+    """
+    Reference to the parent world containing this robot.
+    """
 
     kappa_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of curvature DOFs (1/radius) ordered from base to tip."""
+    """
+    List of curvature DOFs (1/radius) ordered from base to tip.
+    """
 
     phi_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of bending plane DOFs ordered from base to tip."""
+    """
+    List of bending plane DOFs ordered from base to tip.
+    """
 
     bending_x_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of bending DOFs around the local X-axis ordered from base to tip."""
+    """
+    List of bending DOFs around the local X-axis ordered from base to tip.
+    """
 
     bending_y_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of bending DOFs around the local Y-axis ordered from base to tip."""
+    """
+    List of bending DOFs around the local Y-axis ordered from base to tip.
+    """
 
     torsion_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of axial torsion (twisting) DOFs ordered from base to tip."""
+    """
+    List of axial torsion (twisting) DOFs ordered from base to tip.
+    """
 
     extension_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """List of longitudinal extension (stretching) DOFs ordered from base to tip."""
+    """
+    List of longitudinal extension (stretching) DOFs ordered from base to tip.
+    """
 
     arms: list[Arm] = field(default_factory=list)
-    """List of semantic Arm structures associated with this trunk."""
+    """
+    List of semantic Arm structures associated with this trunk.
+    """
 
     def __post_init__(self):
         super().__post_init__()
@@ -132,12 +158,16 @@ class SoftTrunk(SemanticAnnotation):
     def piecewise_constant_curvature_sections(
         self,
     ) -> list[tuple[DegreeOfFreedom, DegreeOfFreedom]]:
-        """Returns a list of (kappa_dof, phi_dof) pairs, ordered from base to tip."""
+        """
+        Returns a list of (kappa_dof, phi_dof) pairs, ordered from base to tip.
+        """
         return list(zip(self.kappa_dofs, self.phi_dofs))
 
     @property
     def cosserat_sections(self) -> list[tuple[DegreeOfFreedom, ...]]:
-        """Returns a list of (bx, by, torsion, extension) tuples, ordered from base to tip."""
+        """
+        Returns a list of (bx, by, torsion, extension) tuples, ordered from base to tip.
+        """
         return list(
             zip(
                 self.bending_x_dofs,
@@ -169,7 +199,6 @@ class SoftTrunk(SemanticAnnotation):
 
         :return: A SoftTrunk robot view.
         """
-
         prefix = "piecewise_constant_curvature"
         with world.modify_world():
             root_body = Body(name=PrefixedName(name="base", prefix=prefix))
@@ -239,8 +268,6 @@ class SoftTrunk(SemanticAnnotation):
                 front_facing_orientation=Quaternion(w=1.0),
                 _world=world,
             )
-            world.add_semantic_annotation(effector)
-
             arm = SoftArm(
                 name=PrefixedName("arm", prefix),
                 root=root_body,
@@ -249,7 +276,10 @@ class SoftTrunk(SemanticAnnotation):
                 end_effector=effector,
             )
             trunk.arms.append(arm)
-            world.add_semantic_annotation(trunk)
+            # Registers the arm and its end effector along with the trunk, the way a
+            # robot registers its parts. The trunk refers to them by id, so a part the
+            # world does not hold cannot be resolved when the world is rebuilt.
+            world.add_semantic_annotation_recursively(trunk)
 
         return trunk
 
@@ -276,7 +306,6 @@ class SoftTrunk(SemanticAnnotation):
 
         :return: A SoftTrunk robot view
         """
-
         prefix = "cosserat"
         with world.modify_world():
             root_body = Body(name=PrefixedName(name="base", prefix=prefix))
@@ -367,8 +396,6 @@ class SoftTrunk(SemanticAnnotation):
                 front_facing_orientation=Quaternion(w=1.0),
                 _world=world,
             )
-            world.add_semantic_annotation(effector)
-
             arm = SoftArm(
                 name=PrefixedName("arm", prefix),
                 root=root_body,
@@ -377,6 +404,9 @@ class SoftTrunk(SemanticAnnotation):
                 end_effector=effector,
             )
             trunk.arms.append(arm)
-            world.add_semantic_annotation(trunk)
+            # Registers the arm and its end effector along with the trunk, the way a
+            # robot registers its parts. The trunk refers to them by id, so a part the
+            # world does not hold cannot be resolved when the world is rebuilt.
+            world.add_semantic_annotation_recursively(trunk)
 
         return trunk

--- a/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
@@ -276,9 +276,6 @@ class SoftTrunk(SemanticAnnotation):
                 end_effector=effector,
             )
             trunk.arms.append(arm)
-            # Registers the arm and its end effector along with the trunk, the way a
-            # robot registers its parts. The trunk refers to them by id, so a part the
-            # world does not hold cannot be resolved when the world is rebuilt.
             world.add_semantic_annotation_recursively(trunk)
 
         return trunk
@@ -404,9 +401,6 @@ class SoftTrunk(SemanticAnnotation):
                 end_effector=effector,
             )
             trunk.arms.append(arm)
-            # Registers the arm and its end effector along with the trunk, the way a
-            # robot registers its parts. The trunk refers to them by id, so a part the
-            # world does not hold cannot be resolved when the world is rebuilt.
             world.add_semantic_annotation_recursively(trunk)
 
         return trunk

--- a/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/datastructures/soft_trunk.py
@@ -51,6 +51,56 @@ class SoftTrunkSection:
     """The number of discrete rigid segments used to approximate the continuous curve."""
 
 
+@dataclass
+class PiecewiseConstantCurvatureSection:
+    """
+    The degrees of freedom one section of a piecewise constant curvature trunk bends
+    with.
+
+    Every segment of the section shares them, so the whole section bends as one arc.
+    """
+
+    curvature: DegreeOfFreedom
+    """
+    Curvature of that arc, as the reciprocal of its radius.
+    """
+
+    bending_plane: DegreeOfFreedom
+    """
+    Angle of the plane the section bends in.
+    """
+
+
+@dataclass
+class CosseratRodSection:
+    """
+    The strain degrees of freedom one section of a Cosserat rod trunk deforms with.
+
+    Every segment of the section shares them, so the whole section deforms at the same
+    rate.
+    """
+
+    bending_x: DegreeOfFreedom
+    """
+    Bending rate around the local x axis.
+    """
+
+    bending_y: DegreeOfFreedom
+    """
+    Bending rate around the local y axis.
+    """
+
+    torsion: DegreeOfFreedom
+    """
+    Twisting rate around the local z axis.
+    """
+
+    extension: DegreeOfFreedom
+    """
+    Stretching rate along the local z axis.
+    """
+
+
 @dataclass(eq=False, kw_only=True)
 class SoftEndEffector(EndEffector):
     """
@@ -116,34 +166,16 @@ class SoftTrunk(SemanticAnnotation):
     Reference to the parent world containing this robot.
     """
 
-    kappa_dofs: list[DegreeOfFreedom] = field(default_factory=list)
+    piecewise_constant_curvature_sections: list[PiecewiseConstantCurvatureSection] = (
+        field(default_factory=list)
+    )
     """
-    List of curvature DOFs (1/radius) ordered from base to tip.
-    """
-
-    phi_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """
-    List of bending plane DOFs ordered from base to tip.
+    The sections of a piecewise constant curvature trunk, ordered from base to tip.
     """
 
-    bending_x_dofs: list[DegreeOfFreedom] = field(default_factory=list)
+    cosserat_sections: list[CosseratRodSection] = field(default_factory=list)
     """
-    List of bending DOFs around the local X-axis ordered from base to tip.
-    """
-
-    bending_y_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """
-    List of bending DOFs around the local Y-axis ordered from base to tip.
-    """
-
-    torsion_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """
-    List of axial torsion (twisting) DOFs ordered from base to tip.
-    """
-
-    extension_dofs: list[DegreeOfFreedom] = field(default_factory=list)
-    """
-    List of longitudinal extension (stretching) DOFs ordered from base to tip.
+    The sections of a Cosserat rod trunk, ordered from base to tip.
     """
 
     arms: list[Arm] = field(default_factory=list)
@@ -153,29 +185,6 @@ class SoftTrunk(SemanticAnnotation):
 
     def __post_init__(self):
         super().__post_init__()
-
-    @property
-    def piecewise_constant_curvature_sections(
-        self,
-    ) -> list[tuple[DegreeOfFreedom, DegreeOfFreedom]]:
-        """
-        Returns a list of (kappa_dof, phi_dof) pairs, ordered from base to tip.
-        """
-        return list(zip(self.kappa_dofs, self.phi_dofs))
-
-    @property
-    def cosserat_sections(self) -> list[tuple[DegreeOfFreedom, ...]]:
-        """
-        Returns a list of (bx, by, torsion, extension) tuples, ordered from base to tip.
-        """
-        return list(
-            zip(
-                self.bending_x_dofs,
-                self.bending_y_dofs,
-                self.torsion_dofs,
-                self.extension_dofs,
-            )
-        )
 
     @classmethod
     def build_piecewise_constant_curvature(
@@ -217,18 +226,21 @@ class SoftTrunk(SemanticAnnotation):
             )
 
             for section_index, section in enumerate(sections):
-                kappa = DegreeOfFreedom(
+                curvature = DegreeOfFreedom(
                     name=PrefixedName(f"kappa_{section_index}", prefix), limits=limits
                 )
-                phi = DegreeOfFreedom(
+                bending_plane = DegreeOfFreedom(
                     name=PrefixedName(f"phi_{section_index}", prefix), limits=limits
                 )
-                world.add_degree_of_freedom(kappa)
-                world.add_degree_of_freedom(phi)
+                world.add_degree_of_freedom(curvature)
+                world.add_degree_of_freedom(bending_plane)
 
                 # Store references to preserve order
-                trunk.kappa_dofs.append(kappa)
-                trunk.phi_dofs.append(phi)
+                trunk.piecewise_constant_curvature_sections.append(
+                    PiecewiseConstantCurvatureSection(
+                        curvature=curvature, bending_plane=bending_plane
+                    )
+                )
 
                 segment_length = section.length / section.resolution
                 for segment_index in range(section.resolution):
@@ -254,8 +266,8 @@ class SoftTrunk(SemanticAnnotation):
                     connection = PiecewiseConstantCurvatureConnection(
                         parent=prev_body,
                         child=curr_body,
-                        kappa_dof_id=kappa.id,
-                        phi_dof_id=phi.id,
+                        kappa_dof_id=curvature.id,
+                        phi_dof_id=bending_plane.id,
                         segment_length=segment_length,
                     )
                     world.add_connection(connection)
@@ -348,10 +360,14 @@ class SoftTrunk(SemanticAnnotation):
                 world.state[extension.id].position = 1.0
 
                 # Store references to preserve order
-                trunk.bending_x_dofs.append(bending_x)
-                trunk.bending_y_dofs.append(bending_y)
-                trunk.torsion_dofs.append(torsion)
-                trunk.extension_dofs.append(extension)
+                trunk.cosserat_sections.append(
+                    CosseratRodSection(
+                        bending_x=bending_x,
+                        bending_y=bending_y,
+                        torsion=torsion,
+                        extension=extension,
+                    )
+                )
 
                 segment_length = section.length / section.resolution
                 for segment_index in range(section.resolution):

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, Self
 from uuid import UUID
@@ -21,99 +20,11 @@ from semantic_digital_twin.spatial_types.spatial_types import (
 from semantic_digital_twin.world import World
 from typing_extensions import Any
 
-# %% what every soft connection has to say about itself
+# %% piecewise constant curvature
 
 
 @dataclass(eq=False)
-class SoftConnection(Connection, ABC):
-    """
-    A connection whose child pose comes from a deformation spread along a length of
-    backbone rather than from a joint.
-
-    Subclasses state the deformation they apply in :attr:`deformation`, which copying
-    and serializing a connection both read.
-    """
-
-    segment_length: float = field(kw_only=True)
-    """
-    The length of backbone this connection spans while undeformed.
-    """
-
-    @property
-    def deformation(self) -> dict[str, Any]:
-        """
-        The deformation this connection applies, keyed by the constructor argument each
-        value is passed as.
-        """
-        return {"segment_length": self.segment_length}
-
-    @classmethod
-    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
-        """
-        Read the deformation back off a serialized connection.
-
-        :param data: The serialized connection.
-        :return: The deformation, in the form :attr:`deformation` returns it.
-        """
-        return {"segment_length": data["segment_length"]}
-
-    def copy_for_world(self, world: World) -> Self:
-        (
-            parent,
-            child,
-            parent_T_connection_expression,
-            connection_T_child_expression,
-        ) = self._find_references_in_world(world)
-        return self.__class__(
-            parent=parent,
-            child=child,
-            parent_T_connection_expression=parent_T_connection_expression,
-            connection_T_child_expression=connection_T_child_expression,
-            name=PrefixedName(self.name.name, prefix=self.name.prefix),
-            **self.deformation,
-        )
-
-    def copy_with_new_parent(
-        self,
-        new_parent: KinematicStructureEntity,
-        parent_T_connection_expression: HomogeneousTransformationMatrix,
-    ) -> Self:
-        return self.__class__(
-            parent=new_parent,
-            child=self.child,
-            parent_T_connection_expression=parent_T_connection_expression,
-            connection_T_child_expression=self.connection_T_child_expression,
-            **self.deformation,
-        )
-
-    def to_json(self) -> dict[str, Any]:
-        return {
-            **super().to_json(),
-            **{name: to_json(value) for name, value in self.deformation.items()},
-        }
-
-    @classmethod
-    def _from_json(cls, data: dict[str, Any], **kwargs) -> Self:
-        tracker = WorldEntityWithIDKwargsTracker.from_kwargs(kwargs)
-        return cls(
-            name=from_json(data["name"]),
-            parent=tracker.get_world_entity_with_id(id=from_json(data["parent_id"])),
-            child=tracker.get_world_entity_with_id(id=from_json(data["child_id"])),
-            parent_T_connection_expression=from_json(
-                data["parent_T_connection_expression"], **kwargs
-            ),
-            connection_T_child_expression=from_json(
-                data["connection_T_child_expression"], **kwargs
-            ),
-            **cls._deformation_from_json(data, **kwargs),
-        )
-
-
-# %% the models a soft connection can follow
-
-
-@dataclass(eq=False)
-class PiecewiseConstantCurvatureConnection(SoftConnection):
+class PiecewiseConstantCurvatureConnection(Connection):
     """
     A continuum connection based on the Piecewise Constant Curvature (PCC) model.
 
@@ -130,21 +41,68 @@ class PiecewiseConstantCurvatureConnection(SoftConnection):
     UUID of the Degree of Freedom representing the plane of bending.
     """
 
-    @property
-    def deformation(self) -> dict[str, Any]:
-        return {
-            **super().deformation,
-            "kappa_dof_id": self.kappa_dof_id,
-            "phi_dof_id": self.phi_dof_id,
-        }
+    segment_length: float = field(kw_only=True)
+    """
+    The physical arc length of this specific segment.
+    """
+
+    def to_json(self) -> dict[str, Any]:
+        result = super().to_json()
+        result["kappa_dof_id"] = to_json(self.kappa_dof_id)
+        result["phi_dof_id"] = to_json(self.phi_dof_id)
+        result["segment_length"] = self.segment_length
+        return result
 
     @classmethod
-    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
-        return {
-            **super()._deformation_from_json(data, **kwargs),
-            "kappa_dof_id": from_json(data["kappa_dof_id"]),
-            "phi_dof_id": from_json(data["phi_dof_id"]),
-        }
+    def _from_json(cls, data: dict[str, Any], **kwargs) -> Self:
+        tracker = WorldEntityWithIDKwargsTracker.from_kwargs(kwargs)
+        return cls(
+            name=from_json(data["name"]),
+            parent=tracker.get_world_entity_with_id(id=from_json(data["parent_id"])),
+            child=tracker.get_world_entity_with_id(id=from_json(data["child_id"])),
+            parent_T_connection_expression=from_json(
+                data["parent_T_connection_expression"], **kwargs
+            ),
+            connection_T_child_expression=from_json(
+                data["connection_T_child_expression"], **kwargs
+            ),
+            kappa_dof_id=from_json(data["kappa_dof_id"]),
+            phi_dof_id=from_json(data["phi_dof_id"]),
+            segment_length=data["segment_length"],
+        )
+
+    def copy_for_world(self, world: World) -> Self:
+        (
+            parent,
+            child,
+            parent_T_connection_expression,
+            connection_T_child_expression,
+        ) = self._find_references_in_world(world)
+        return self.__class__(
+            parent=parent,
+            child=child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=connection_T_child_expression,
+            name=PrefixedName(self.name.name, prefix=self.name.prefix),
+            kappa_dof_id=self.kappa_dof_id,
+            phi_dof_id=self.phi_dof_id,
+            segment_length=self.segment_length,
+        )
+
+    def copy_with_new_parent(
+        self,
+        new_parent: KinematicStructureEntity,
+        parent_T_connection_expression: HomogeneousTransformationMatrix,
+    ) -> Self:
+        return self.__class__(
+            parent=new_parent,
+            child=self.child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=self.connection_T_child_expression,
+            kappa_dof_id=self.kappa_dof_id,
+            phi_dof_id=self.phi_dof_id,
+            segment_length=self.segment_length,
+        )
 
     @classmethod
     def create_with_dofs(
@@ -258,8 +216,11 @@ class PiecewiseConstantCurvatureConnection(SoftConnection):
         ]
 
 
+# %% cosserat rod
+
+
 @dataclass(eq=False)
-class CosseratRodConnection(SoftConnection):
+class CosseratRodConnection(Connection):
     """
     A connection implementing Cosserat Rod Theory.
 
@@ -288,25 +249,76 @@ class CosseratRodConnection(SoftConnection):
     UUID of the Degree of Freedom for the linear stretching rate along the Z-axis (vz).
     """
 
-    @property
-    def deformation(self) -> dict[str, Any]:
-        return {
-            **super().deformation,
-            "bending_x_dof_id": self.bending_x_dof_id,
-            "bending_y_dof_id": self.bending_y_dof_id,
-            "torsion_dof_id": self.torsion_dof_id,
-            "extension_dof_id": self.extension_dof_id,
-        }
+    segment_length: float = field(kw_only=True)
+    """
+    The intrinsic rest length of the rod segment.
+    """
+
+    def to_json(self) -> dict[str, Any]:
+        result = super().to_json()
+        result["bending_x_dof_id"] = to_json(self.bending_x_dof_id)
+        result["bending_y_dof_id"] = to_json(self.bending_y_dof_id)
+        result["torsion_dof_id"] = to_json(self.torsion_dof_id)
+        result["extension_dof_id"] = to_json(self.extension_dof_id)
+        result["segment_length"] = self.segment_length
+        return result
 
     @classmethod
-    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
-        return {
-            **super()._deformation_from_json(data, **kwargs),
-            "bending_x_dof_id": from_json(data["bending_x_dof_id"]),
-            "bending_y_dof_id": from_json(data["bending_y_dof_id"]),
-            "torsion_dof_id": from_json(data["torsion_dof_id"]),
-            "extension_dof_id": from_json(data["extension_dof_id"]),
-        }
+    def _from_json(cls, data: dict[str, Any], **kwargs) -> Self:
+        tracker = WorldEntityWithIDKwargsTracker.from_kwargs(kwargs)
+        return cls(
+            name=from_json(data["name"]),
+            parent=tracker.get_world_entity_with_id(id=from_json(data["parent_id"])),
+            child=tracker.get_world_entity_with_id(id=from_json(data["child_id"])),
+            parent_T_connection_expression=from_json(
+                data["parent_T_connection_expression"], **kwargs
+            ),
+            connection_T_child_expression=from_json(
+                data["connection_T_child_expression"], **kwargs
+            ),
+            bending_x_dof_id=from_json(data["bending_x_dof_id"]),
+            bending_y_dof_id=from_json(data["bending_y_dof_id"]),
+            torsion_dof_id=from_json(data["torsion_dof_id"]),
+            extension_dof_id=from_json(data["extension_dof_id"]),
+            segment_length=data["segment_length"],
+        )
+
+    def copy_for_world(self, world: World) -> Self:
+        (
+            parent,
+            child,
+            parent_T_connection_expression,
+            connection_T_child_expression,
+        ) = self._find_references_in_world(world)
+        return self.__class__(
+            parent=parent,
+            child=child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=connection_T_child_expression,
+            name=PrefixedName(self.name.name, prefix=self.name.prefix),
+            bending_x_dof_id=self.bending_x_dof_id,
+            bending_y_dof_id=self.bending_y_dof_id,
+            torsion_dof_id=self.torsion_dof_id,
+            extension_dof_id=self.extension_dof_id,
+            segment_length=self.segment_length,
+        )
+
+    def copy_with_new_parent(
+        self,
+        new_parent: KinematicStructureEntity,
+        parent_T_connection_expression: HomogeneousTransformationMatrix,
+    ) -> Self:
+        return self.__class__(
+            parent=new_parent,
+            child=self.child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=self.connection_T_child_expression,
+            bending_x_dof_id=self.bending_x_dof_id,
+            bending_y_dof_id=self.bending_y_dof_id,
+            torsion_dof_id=self.torsion_dof_id,
+            extension_dof_id=self.extension_dof_id,
+            segment_length=self.segment_length,
+        )
 
     @classmethod
     def create_with_dofs(

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
@@ -20,8 +20,6 @@ from semantic_digital_twin.spatial_types.spatial_types import (
 from semantic_digital_twin.world import World
 from typing_extensions import Any
 
-# %% piecewise constant curvature
-
 
 @dataclass(eq=False)
 class PiecewiseConstantCurvatureConnection(Connection):
@@ -214,9 +212,6 @@ class PiecewiseConstantCurvatureConnection(Connection):
             self._world.get_degree_of_freedom_by_id(self.kappa_dof_id),
             self._world.get_degree_of_freedom_by_id(self.phi_dof_id),
         ]
-
-
-# %% cosserat rod
 
 
 @dataclass(eq=False)

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, Self
 from uuid import UUID
 
 import krrood.symbolic_math.symbolic_math as sm
+from krrood.adapters.json_serializer import from_json, to_json
+from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
+    WorldEntityWithIDKwargsTracker,
+)
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.world_description.world_entity import (
     Connection,
@@ -14,10 +19,101 @@ from semantic_digital_twin.spatial_types.spatial_types import (
     HomogeneousTransformationMatrix,
 )
 from semantic_digital_twin.world import World
+from typing_extensions import Any
+
+# %% what every soft connection has to say about itself
 
 
 @dataclass(eq=False)
-class PiecewiseConstantCurvatureConnection(Connection):
+class SoftConnection(Connection, ABC):
+    """
+    A connection whose child pose comes from a deformation spread along a length of
+    backbone rather than from a joint.
+
+    Subclasses state the deformation they apply in :attr:`deformation`, which copying
+    and serializing a connection both read.
+    """
+
+    segment_length: float = field(kw_only=True)
+    """
+    The length of backbone this connection spans while undeformed.
+    """
+
+    @property
+    def deformation(self) -> dict[str, Any]:
+        """
+        The deformation this connection applies, keyed by the constructor argument each
+        value is passed as.
+        """
+        return {"segment_length": self.segment_length}
+
+    @classmethod
+    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        """
+        Read the deformation back off a serialized connection.
+
+        :param data: The serialized connection.
+        :return: The deformation, in the form :attr:`deformation` returns it.
+        """
+        return {"segment_length": data["segment_length"]}
+
+    def copy_for_world(self, world: World) -> Self:
+        (
+            parent,
+            child,
+            parent_T_connection_expression,
+            connection_T_child_expression,
+        ) = self._find_references_in_world(world)
+        return self.__class__(
+            parent=parent,
+            child=child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=connection_T_child_expression,
+            name=PrefixedName(self.name.name, prefix=self.name.prefix),
+            **self.deformation,
+        )
+
+    def copy_with_new_parent(
+        self,
+        new_parent: KinematicStructureEntity,
+        parent_T_connection_expression: HomogeneousTransformationMatrix,
+    ) -> Self:
+        return self.__class__(
+            parent=new_parent,
+            child=self.child,
+            parent_T_connection_expression=parent_T_connection_expression,
+            connection_T_child_expression=self.connection_T_child_expression,
+            **self.deformation,
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            **super().to_json(),
+            **{name: to_json(value) for name, value in self.deformation.items()},
+        }
+
+    @classmethod
+    def _from_json(cls, data: dict[str, Any], **kwargs) -> Self:
+        tracker = WorldEntityWithIDKwargsTracker.from_kwargs(kwargs)
+        return cls(
+            name=from_json(data["name"]),
+            parent=tracker.get_world_entity_with_id(id=from_json(data["parent_id"])),
+            child=tracker.get_world_entity_with_id(id=from_json(data["child_id"])),
+            parent_T_connection_expression=from_json(
+                data["parent_T_connection_expression"], **kwargs
+            ),
+            connection_T_child_expression=from_json(
+                data["connection_T_child_expression"], **kwargs
+            ),
+            **cls._deformation_from_json(data, **kwargs),
+        )
+
+
+# %% the models a soft connection can follow
+
+
+@dataclass(eq=False)
+class PiecewiseConstantCurvatureConnection(SoftConnection):
     """
     A continuum connection based on the Piecewise Constant Curvature (PCC) model.
 
@@ -34,10 +130,21 @@ class PiecewiseConstantCurvatureConnection(Connection):
     UUID of the Degree of Freedom representing the plane of bending.
     """
 
-    segment_length: float = field(kw_only=True)
-    """
-    The physical arc length of this specific segment.
-    """
+    @property
+    def deformation(self) -> dict[str, Any]:
+        return {
+            **super().deformation,
+            "kappa_dof_id": self.kappa_dof_id,
+            "phi_dof_id": self.phi_dof_id,
+        }
+
+    @classmethod
+    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        return {
+            **super()._deformation_from_json(data, **kwargs),
+            "kappa_dof_id": from_json(data["kappa_dof_id"]),
+            "phi_dof_id": from_json(data["phi_dof_id"]),
+        }
 
     @classmethod
     def create_with_dofs(
@@ -152,7 +259,7 @@ class PiecewiseConstantCurvatureConnection(Connection):
 
 
 @dataclass(eq=False)
-class CosseratRodConnection(Connection):
+class CosseratRodConnection(SoftConnection):
     """
     A connection implementing Cosserat Rod Theory.
 
@@ -181,10 +288,25 @@ class CosseratRodConnection(Connection):
     UUID of the Degree of Freedom for the linear stretching rate along the Z-axis (vz).
     """
 
-    segment_length: float = field(kw_only=True)
-    """
-    The intrinsic rest length of the rod segment.
-    """
+    @property
+    def deformation(self) -> dict[str, Any]:
+        return {
+            **super().deformation,
+            "bending_x_dof_id": self.bending_x_dof_id,
+            "bending_y_dof_id": self.bending_y_dof_id,
+            "torsion_dof_id": self.torsion_dof_id,
+            "extension_dof_id": self.extension_dof_id,
+        }
+
+    @classmethod
+    def _deformation_from_json(cls, data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        return {
+            **super()._deformation_from_json(data, **kwargs),
+            "bending_x_dof_id": from_json(data["bending_x_dof_id"]),
+            "bending_y_dof_id": from_json(data["bending_y_dof_id"]),
+            "torsion_dof_id": from_json(data["torsion_dof_id"]),
+            "extension_dof_id": from_json(data["extension_dof_id"]),
+        }
 
     @classmethod
     def create_with_dofs(

--- a/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
+++ b/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
@@ -8,6 +8,7 @@ from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
 from semantic_digital_twin.world import World
 from semantic_digital_twin.datastructures.soft_trunk import (
     SoftArm,
+    SoftEndEffector,
     SoftTrunk,
     SoftTrunkSection,
 )
@@ -237,10 +238,10 @@ class TestSoftConnectionFactories:
 class TestSoftConnectionRebuilding:
     """
     A soft connection carries state a plain connection does not: the degrees of freedom
-    it shares with its section, and the length of backbone it spans.
+    it shares with the other segments of its section, and its own segment length.
 
-    Copying a world or sending one somewhere rebuilds every connection in it, so a
-    segment that cannot say what it carries takes its whole world with it.
+    Copying a world and serializing one both rebuild every connection in it, so a
+    segment that does not report that state comes back deformed differently.
     """
 
     def build_piecewise_constant_curvature_world(self) -> World:
@@ -329,12 +330,15 @@ class TestSoftConnectionRebuilding:
         assert restored.extension_dof_id == segment.extension_dof_id
         assert restored.segment_length == segment.segment_length
 
-    def test_a_trunks_arm_is_registered_in_the_world(self):
+    def test_a_trunks_arm_and_end_effector_are_registered_in_the_world(self):
         """
-        The trunk refers to its arm by id, so an arm the world does not hold cannot be
-        resolved when the world is rebuilt.
+        The trunk refers to the annotations below it by id, so an annotation the world
+        does not hold cannot be resolved when the world is rebuilt.
         """
         world = self.build_piecewise_constant_curvature_world()
         trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
 
         assert world.get_semantic_annotations_by_type(SoftArm) == trunk.arms
+        assert world.get_semantic_annotations_by_type(SoftEndEffector) == [
+            arm.end_effector for arm in trunk.arms
+        ]

--- a/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
+++ b/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
@@ -1,7 +1,16 @@
+from copy import deepcopy
+
 import pytest
 import numpy as np
+from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
+    WorldEntityWithIDKwargsTracker,
+)
 from semantic_digital_twin.world import World
-from semantic_digital_twin.datastructures.soft_trunk import SoftTrunk, SoftTrunkSection
+from semantic_digital_twin.datastructures.soft_trunk import (
+    SoftArm,
+    SoftTrunk,
+    SoftTrunkSection,
+)
 from semantic_digital_twin.spatial_computations.ik_solver import InverseKinematicsSolver
 from semantic_digital_twin.spatial_types import HomogeneousTransformationMatrix
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
@@ -14,7 +23,7 @@ from semantic_digital_twin.world_description.soft_connections import (
     CosseratRodConnection,
     PiecewiseConstantCurvatureConnection,
 )
-from semantic_digital_twin.world_description.world_entity import Body
+from semantic_digital_twin.world_description.world_entity import Body, Connection
 
 
 class TestSoftTrunk:
@@ -220,3 +229,112 @@ class TestSoftConnectionFactories:
 
         root_T_tip = world.compute_forward_kinematics_np(world.root, tip)
         np.testing.assert_allclose(root_T_tip[:3, 3], [0.4, 0.0, 1.0], atol=1e-5)
+
+
+# %% carrying a segment's own state across a copy and a wire
+
+
+class TestSoftConnectionRebuilding:
+    """
+    A soft connection carries state a plain connection does not: the degrees of freedom
+    it shares with its section, and the length of backbone it spans.
+
+    Copying a world or sending one somewhere rebuilds every connection in it, so a
+    segment that cannot say what it carries takes its whole world with it.
+    """
+
+    def build_piecewise_constant_curvature_world(self) -> World:
+        """
+        :return: A world holding a two section piecewise constant curvature trunk.
+        """
+        world = World()
+        SoftTrunk.build_piecewise_constant_curvature(
+            world, [SoftTrunkSection(length=0.3, radius=0.02, resolution=2)] * 2
+        )
+        world.notify_state_change()
+        return world
+
+    def build_cosserat_world(self) -> World:
+        """
+        :return: A world holding a two section Cosserat rod trunk.
+        """
+        world = World()
+        SoftTrunk.build_cosserat(
+            world, [SoftTrunkSection(length=0.3, radius=0.02, resolution=2)] * 2
+        )
+        world.notify_state_change()
+        return world
+
+    def test_a_copied_piecewise_constant_curvature_world_bends_the_same_way(self):
+        world = self.build_piecewise_constant_curvature_world()
+        trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
+        for dof in trunk.kappa_dofs:
+            world.state[dof.id].position = 0.8
+        world.notify_state_change()
+        expected = world.compute_forward_kinematics_np(world.root, trunk.arms[0].tip)
+
+        copied_world = deepcopy(world)
+
+        copied_trunk = copied_world.get_semantic_annotations_by_type(SoftTrunk)[0]
+        np.testing.assert_allclose(
+            copied_world.compute_forward_kinematics_np(
+                copied_world.root, copied_trunk.arms[0].tip
+            ),
+            expected,
+            atol=1e-9,
+        )
+
+    def test_a_copied_cosserat_world_deforms_the_same_way(self):
+        world = self.build_cosserat_world()
+        trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
+        for dof in trunk.bending_x_dofs:
+            world.state[dof.id].position = 0.5
+        world.notify_state_change()
+        expected = world.compute_forward_kinematics_np(world.root, trunk.arms[0].tip)
+
+        copied_world = deepcopy(world)
+
+        copied_trunk = copied_world.get_semantic_annotations_by_type(SoftTrunk)[0]
+        np.testing.assert_allclose(
+            copied_world.compute_forward_kinematics_np(
+                copied_world.root, copied_trunk.arms[0].tip
+            ),
+            expected,
+            atol=1e-9,
+        )
+
+    def test_a_piecewise_constant_curvature_segment_survives_a_json_round_trip(self):
+        world = self.build_piecewise_constant_curvature_world()
+        segment = world.get_connections_by_type(PiecewiseConstantCurvatureConnection)[0]
+        tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+
+        restored = Connection.from_json(segment.to_json(), **tracker.create_kwargs())
+
+        assert type(restored) is type(segment)
+        assert restored.kappa_dof_id == segment.kappa_dof_id
+        assert restored.phi_dof_id == segment.phi_dof_id
+        assert restored.segment_length == segment.segment_length
+
+    def test_a_cosserat_rod_segment_survives_a_json_round_trip(self):
+        world = self.build_cosserat_world()
+        segment = world.get_connections_by_type(CosseratRodConnection)[0]
+        tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+
+        restored = Connection.from_json(segment.to_json(), **tracker.create_kwargs())
+
+        assert type(restored) is type(segment)
+        assert restored.bending_x_dof_id == segment.bending_x_dof_id
+        assert restored.bending_y_dof_id == segment.bending_y_dof_id
+        assert restored.torsion_dof_id == segment.torsion_dof_id
+        assert restored.extension_dof_id == segment.extension_dof_id
+        assert restored.segment_length == segment.segment_length
+
+    def test_a_trunks_arm_is_registered_in_the_world(self):
+        """
+        The trunk refers to its arm by id, so an arm the world does not hold cannot be
+        resolved when the world is rebuilt.
+        """
+        world = self.build_piecewise_constant_curvature_world()
+        trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
+
+        assert world.get_semantic_annotations_by_type(SoftArm) == trunk.arms

--- a/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
+++ b/test/semantic_digital_twin_test/test_connections/test_soft_connections.py
@@ -43,10 +43,7 @@ class TestSoftTrunk:
         assert len(trunk.arms) == 1
         assert trunk.arms[0].end_effector is not None
 
-        # Verify property-based DOF access
-        assert len(trunk.kappa_dofs) == 3
-        assert len(trunk.phi_dofs) == 3
-        # Check the helper property
+        # Verify one section per requested section, each carrying its own DOFs
         assert len(trunk.piecewise_constant_curvature_sections) == 3
 
     def test_cosserat_rod_construction(self):
@@ -58,14 +55,11 @@ class TestSoftTrunk:
 
         trunk = SoftTrunk.build_cosserat(world, sections)
 
-        # Verify 4 DOFs per section
-        assert len(trunk.extension_dofs) == 2
-        assert len(trunk.torsion_dofs) == 2
-        assert len(trunk.bending_x_dofs) == 2
-        assert len(trunk.bending_y_dofs) == 2
+        # Verify one section per requested section, each carrying its 4 strain DOFs
+        assert len(trunk.cosserat_sections) == 2
 
         # Verify extension is initialized to 1.0
-        assert world.state[trunk.extension_dofs[0].id].position == 1.0
+        assert world.state[trunk.cosserat_sections[0].extension.id].position == 1.0
 
     def test_piecewise_constant_curvature_kinematics(self):
         """
@@ -76,8 +70,9 @@ class TestSoftTrunk:
         sections = [SoftTrunkSection(length=1.0, radius=0.02, resolution=10)]
         trunk = SoftTrunk.build_piecewise_constant_curvature(world, sections)
 
-        # Set kappa for a 90 degree bend (r = 2/pi)
-        world.state[trunk.kappa_dofs[0].id].position = np.pi / 2
+        # Set curvature for a 90 degree bend (r = 2/pi)
+        curvature = trunk.piecewise_constant_curvature_sections[0].curvature
+        world.state[curvature.id].position = np.pi / 2
         world.notify_state_change()
 
         # Get FK from root to tip of the arm
@@ -97,7 +92,7 @@ class TestSoftTrunk:
         trunk = SoftTrunk.build_cosserat(world, sections)
 
         # Stretch to 1.5m
-        world.state[trunk.extension_dofs[0].id].position = 1.5
+        world.state[trunk.cosserat_sections[0].extension.id].position = 1.5
         world.notify_state_change()
 
         fk = world.compute_forward_kinematics_np(world.root, trunk.arms[0].tip)
@@ -269,8 +264,8 @@ class TestSoftConnectionRebuilding:
     def test_a_copied_piecewise_constant_curvature_world_bends_the_same_way(self):
         world = self.build_piecewise_constant_curvature_world()
         trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
-        for dof in trunk.kappa_dofs:
-            world.state[dof.id].position = 0.8
+        for section in trunk.piecewise_constant_curvature_sections:
+            world.state[section.curvature.id].position = 0.8
         world.notify_state_change()
         expected = world.compute_forward_kinematics_np(world.root, trunk.arms[0].tip)
 
@@ -288,8 +283,8 @@ class TestSoftConnectionRebuilding:
     def test_a_copied_cosserat_world_deforms_the_same_way(self):
         world = self.build_cosserat_world()
         trunk = world.get_semantic_annotations_by_type(SoftTrunk)[0]
-        for dof in trunk.bending_x_dofs:
-            world.state[dof.id].position = 0.5
+        for section in trunk.cosserat_sections:
+            world.state[section.bending_x.id].position = 0.5
         world.notify_state_change()
         expected = world.compute_forward_kinematics_np(world.root, trunk.arms[0].tip)
 


### PR DESCRIPTION
  PiecewiseConstantCurvatureConnection and CosseratRodConnection did not survive serialization. Therefore I added:

  - New SoftConnection(Connection, ABC) owns segment_length and implements copy_for_world,
    copy_with_new_parent, to_json and _from_json, all driven by a deformation property each
    model extends with its own degrees of freedom.
  - SoftTrunk now ends both builders with world.add_semantic_annotation_recursively(trunk), as
    AbstractRobot does, registering the arm and end effector in dependency order. The arm was
    previously referenced but never registered, so that reference could not be resolved on
    the way back in.
