### PR TITLE
orm-build auto now detects a failed import instead of outdated

### DIFF
--- a/cognitive_robot_abstract_machine/exceptions.py
+++ b/cognitive_robot_abstract_machine/exceptions.py
@@ -67,6 +67,31 @@ class OrmGenerationFailedError(DataclassException, RuntimeError):
 
 
 @dataclass
+class OrmImportFailedError(DataclassException, RuntimeError):
+    """
+    Raised when importing the ORM interfaces of a checkout fails for a reason other than
+    an interface no longer matching the classes it maps.
+    """
+
+    output: str
+    """
+    What the attempt wrote before it gave up.
+    """
+
+    def error_message(self) -> str:
+        return (
+            "Importing the ORM interfaces of this checkout failed for a reason other "
+            f"than a stale interface. It wrote:\n{self.output}"
+        )
+
+    def suggest_correction(self) -> str:
+        return (
+            "Check that every package of the checkout is installed, and import the "
+            "interfaces by hand to follow what happens."
+        )
+
+
+@dataclass
 class MissingORMBuildChoiceError(DataclassException, ValueError):
     """
     Raised when a test run names the option that says when to build the ORM interfaces

--- a/cognitive_robot_abstract_machine/orm_import.py
+++ b/cognitive_robot_abstract_machine/orm_import.py
@@ -9,37 +9,77 @@ follow a failed import without leaving a stale interface behind in it.
 
 Started as ``python -P -m cognitive_robot_abstract_machine.orm_import <module>...`` by
 :mod:`cognitive_robot_abstract_machine.orm_interfaces`, which reads the report below back
-from this run's output.
+from this run's output. The report is part of that output rather than of this run's
+logging, which an interface can reconfigure while it is imported.
 """
 
 from __future__ import annotations
 
 import argparse
 import importlib
+import json
 import sys
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import Enum, IntEnum, StrEnum
 
 from typing_extensions import Optional, Sequence, Tuple, Type
 
-LINE_PREFIX = "cram-orm-interface-stale "
-"""
-What marks a line of output as this run's report rather than as something an interface
-wrote while it was imported.
-"""
 
-FIELD_SEPARATOR = " | "
-"""
-What separates the parts of the report on one line.
-"""
+class ReportMarker(StrEnum):
+    """
+    What marks a line of output as this run's report rather than as something an
+    interface wrote while it was imported.
+    """
 
-STALENESS_ERRORS: Tuple[Type[Exception], ...] = (ImportError, AttributeError)
-"""
-What an interface raises once it no longer matches the classes it maps: a module that has
-been renamed or removed raises :class:`ImportError`, and a class raises
-:class:`AttributeError`, because generated code reaches every class it maps as an
-attribute of the module holding it.
-"""
+    STALE_INTERFACE = "cram-orm-interface-stale "
+    """
+    Begins the line naming the interface that no longer matches the classes it maps.
+    """
+
+
+class StaleInterfaceField(StrEnum):
+    """
+    Names a report carries its parts under.
+    """
+
+    MODULE_NAME = "module_name"
+    """
+    The interface the report is about.
+    """
+
+    ERROR_TYPE = "error_type"
+    """
+    What importing it raised.
+    """
+
+    ERROR_DESCRIPTION = "error_description"
+    """
+    What that said.
+    """
+
+
+class StalenessError(Enum):
+    """
+    What an interface raises once it no longer matches the classes it maps.
+    """
+
+    RENAMED_OR_REMOVED_MODULE = ImportError
+    """
+    Raised by an interface reaching a module of its package that no longer exists.
+    """
+
+    REMOVED_CLASS = AttributeError
+    """
+    Raised by one reaching a class that no longer exists, because generated code reaches
+    every class it maps as an attribute of the module holding it.
+    """
+
+    @classmethod
+    def types(cls) -> Tuple[Type[Exception], ...]:
+        """
+        The exceptions these stand for, as an ``except`` clause takes them.
+        """
+        return tuple(member.value for member in cls)
 
 
 class InterfaceImportResult(IntEnum):
@@ -80,7 +120,7 @@ class StaleInterface:
 
     error_description: str
     """
-    What it said, on one line.
+    What it said.
     """
 
     @classmethod
@@ -91,7 +131,7 @@ class StaleInterface:
         :param module_name: The interface that was being imported.
         :param error: What it raised.
         """
-        return cls(module_name, type(error).__name__, " ".join(str(error).split()))
+        return cls(module_name, type(error).__name__, str(error))
 
     @classmethod
     def from_line(cls, line: str) -> Optional[StaleInterface]:
@@ -101,12 +141,14 @@ class StaleInterface:
         :param line: One line of output, of any kind.
         :return: The report the line carries, or nothing when it carries none.
         """
-        if not line.startswith(LINE_PREFIX):
+        if not line.startswith(ReportMarker.STALE_INTERFACE):
             return None
-        module_name, error_type, error_description = line[len(LINE_PREFIX) :].split(
-            FIELD_SEPARATOR, maxsplit=2
+        payload = json.loads(line[len(ReportMarker.STALE_INTERFACE) :])
+        return cls(
+            payload[StaleInterfaceField.MODULE_NAME],
+            payload[StaleInterfaceField.ERROR_TYPE],
+            payload[StaleInterfaceField.ERROR_DESCRIPTION],
         )
-        return cls(module_name, error_type, error_description.strip())
 
     @classmethod
     def from_output(cls, output: str) -> Optional[StaleInterface]:
@@ -128,9 +170,12 @@ class StaleInterface:
 
         :return: The line, without its terminating line break.
         """
-        return LINE_PREFIX + FIELD_SEPARATOR.join(
-            (self.module_name, self.error_type, self.error_description)
-        )
+        payload = {
+            StaleInterfaceField.MODULE_NAME.value: self.module_name,
+            StaleInterfaceField.ERROR_TYPE.value: self.error_type,
+            StaleInterfaceField.ERROR_DESCRIPTION.value: self.error_description,
+        }
+        return ReportMarker.STALE_INTERFACE + json.dumps(payload)
 
     def report(self) -> str:
         """
@@ -157,7 +202,7 @@ def import_interfaces(module_names: Sequence[str]) -> Optional[StaleInterface]:
     for module_name in module_names:
         try:
             importlib.import_module(module_name)
-        except STALENESS_ERRORS as error:
+        except StalenessError.types() as error:
             return StaleInterface.from_error(module_name, error)
     return None
 

--- a/cognitive_robot_abstract_machine/orm_import.py
+++ b/cognitive_robot_abstract_machine/orm_import.py
@@ -1,0 +1,184 @@
+"""
+Importing the generated ORM interfaces of a checkout, one after another in one
+interpreter.
+
+An interface that no longer matches the classes it maps is the one thing a checkout has
+to rebuild for, and the only way to find out is to import it. Doing so here keeps what
+the interfaces pull in out of the interpreter that asked, which is what lets a build
+follow a failed import without leaving a stale interface behind in it.
+
+Started as ``python -P -m cognitive_robot_abstract_machine.orm_import <module>...`` by
+:mod:`cognitive_robot_abstract_machine.orm_interfaces`, which reads the report below back
+from this run's output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from dataclasses import dataclass
+from enum import IntEnum
+
+from typing_extensions import Optional, Sequence, Tuple, Type
+
+LINE_PREFIX = "cram-orm-interface-stale "
+"""
+What marks a line of output as this run's report rather than as something an interface
+wrote while it was imported.
+"""
+
+FIELD_SEPARATOR = " | "
+"""
+What separates the parts of the report on one line.
+"""
+
+STALENESS_ERRORS: Tuple[Type[Exception], ...] = (ImportError, AttributeError)
+"""
+What an interface raises once it no longer matches the classes it maps: a module that has
+been renamed or removed raises :class:`ImportError`, and a class raises
+:class:`AttributeError`, because generated code reaches every class it maps as an
+attribute of the module holding it.
+"""
+
+
+class InterfaceImportResult(IntEnum):
+    """
+    What importing the interfaces of a checkout ended in, as the exit code of a run.
+    """
+
+    IMPORTED = 0
+    """
+    Every interface imported.
+    """
+
+    STALE = 3
+    """
+    One of them no longer matches the classes it maps, held apart from the ``1`` an
+    interface failing for any other reason exits with.
+    """
+
+
+# %% what a run reports about itself
+
+
+@dataclass
+class StaleInterface:
+    """
+    An interface that no longer matches the classes it maps.
+    """
+
+    module_name: str
+    """
+    The interface, as it is imported.
+    """
+
+    error_type: str
+    """
+    Name of what it raised.
+    """
+
+    error_description: str
+    """
+    What it said, on one line.
+    """
+
+    @classmethod
+    def from_error(cls, module_name: str, error: Exception) -> StaleInterface:
+        """
+        Report an interface by what importing it raised.
+
+        :param module_name: The interface that was being imported.
+        :param error: What it raised.
+        """
+        return cls(module_name, type(error).__name__, " ".join(str(error).split()))
+
+    @classmethod
+    def from_line(cls, line: str) -> Optional[StaleInterface]:
+        """
+        Read a report back from a line of this run's output.
+
+        :param line: One line of output, of any kind.
+        :return: The report the line carries, or nothing when it carries none.
+        """
+        if not line.startswith(LINE_PREFIX):
+            return None
+        module_name, error_type, error_description = line[len(LINE_PREFIX) :].split(
+            FIELD_SEPARATOR, maxsplit=2
+        )
+        return cls(module_name, error_type, error_description.strip())
+
+    @classmethod
+    def from_output(cls, output: str) -> Optional[StaleInterface]:
+        """
+        Read the report back from everything this run wrote.
+
+        :param output: The output of the run, reports and interface writing alike.
+        :return: The report it carries, or nothing when it carries none.
+        """
+        for line in output.splitlines():
+            reported = cls.from_line(line)
+            if reported is not None:
+                return reported
+        return None
+
+    def to_line(self) -> str:
+        """
+        Render this report as one line of output.
+
+        :return: The line, without its terminating line break.
+        """
+        return LINE_PREFIX + FIELD_SEPARATOR.join(
+            (self.module_name, self.error_type, self.error_description)
+        )
+
+    def report(self) -> str:
+        """
+        Say which interface has to be built again, and what it raised.
+        """
+        return (
+            f"{self.module_name} no longer matches the classes it maps: "
+            f"{self.error_type}: {self.error_description}"
+        )
+
+
+# %% importing the interfaces
+
+
+def import_interfaces(module_names: Sequence[str]) -> Optional[StaleInterface]:
+    """
+    Import interfaces in the order given, stopping at the first that no longer matches
+    the classes it maps.
+
+    :param module_names: The interfaces to import, in dependency order.
+    :return: The first interface that no longer matches, or nothing when every one of
+        them imported.
+    """
+    for module_name in module_names:
+        try:
+            importlib.import_module(module_name)
+        except STALENESS_ERRORS as error:
+            return StaleInterface.from_error(module_name, error)
+    return None
+
+
+def main() -> None:
+    """
+    Import every interface named on the command line, and report the first that no
+    longer matches the classes it maps.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "interfaces",
+        nargs="+",
+        help="The interface modules to import, in dependency order.",
+    )
+    stale = import_interfaces(parser.parse_args().interfaces)
+    if stale is None:
+        return
+    print(stale.to_line(), flush=True)
+    sys.exit(InterfaceImportResult.STALE)
+
+
+if __name__ == "__main__":
+    main()

--- a/cognitive_robot_abstract_machine/orm_interfaces.py
+++ b/cognitive_robot_abstract_machine/orm_interfaces.py
@@ -8,6 +8,7 @@ be persisted or turned into a data access object until they have been generated 
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -33,35 +34,49 @@ from krrood.class_diagrams.progress_report import (
     ProgressEnvironmentVariable,
 )
 
+logger = logging.getLogger(__name__)
+
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 """
 Root of the checkout this package is installed from.
 """
 
-INTERFACE_MODULE_NAME = "ormatic_interface"
-"""
-Name every package's generator writes its interface to, as it is imported.
-"""
 
-INTERFACE_FILE_NAME = f"{INTERFACE_MODULE_NAME}.py"
-"""
-Name of the file holding it.
-"""
+class InterfaceLocation(StrEnum):
+    """
+    Where a package's generator writes its ORM interface, and how it is imported.
+    """
 
-INTERFACE_FOLDER_NAME = "orm"
-"""
-Folder of a package's sources that holds its interface.
-"""
+    MODULE_NAME = "ormatic_interface"
+    """
+    Name every package's generator writes its interface to, as it is imported.
+    """
 
-PROGRESS_DESCRIPTION = "Building ORM interfaces"
-"""
-What the progress bar of a build calls itself.
-"""
+    FILE_NAME = f"{MODULE_NAME}.py"
+    """
+    Name of the file holding it.
+    """
 
-PROGRESS_REQUESTED = "1"
-"""
-What a generator is told to report the classes it finishes.
-"""
+    FOLDER_NAME = "orm"
+    """
+    Folder of a package's sources that holds it.
+    """
+
+
+class GeneratorProgress(StrEnum):
+    """
+    What a build asks its generators for, and what it calls the reports they send back.
+    """
+
+    REQUESTED = "1"
+    """
+    What a generator is told to report the classes it finishes.
+    """
+
+    BAR_DESCRIPTION = "Building ORM interfaces"
+    """
+    What the bar counting those reports calls itself.
+    """
 
 
 class ImportEnvironmentVariable(StrEnum):
@@ -126,7 +141,8 @@ class BuildProgress:
         Put how far along the interfaces are beside the bar.
         """
         self.bar.set_description_str(
-            f"{PROGRESS_DESCRIPTION} {self.completed_interfaces}/{self.total_interfaces}"
+            f"{GeneratorProgress.BAR_DESCRIPTION} "
+            f"{self.completed_interfaces}/{self.total_interfaces}"
         )
 
     def start(self, package_name: str) -> None:
@@ -200,14 +216,22 @@ class OrmInterface:
         """
         The generated interface file.
         """
-        return self.sources / INTERFACE_FOLDER_NAME / INTERFACE_FILE_NAME
+        return (
+            self.sources / InterfaceLocation.FOLDER_NAME / InterfaceLocation.FILE_NAME
+        )
 
     @property
     def module_name(self) -> str:
         """
         The generated interface, as it is imported.
         """
-        return f"{self.package_name}.{INTERFACE_FOLDER_NAME}.{INTERFACE_MODULE_NAME}"
+        return ".".join(
+            (
+                self.package_name,
+                InterfaceLocation.FOLDER_NAME,
+                InterfaceLocation.MODULE_NAME,
+            )
+        )
 
     @property
     def sources(self) -> Path:
@@ -373,10 +397,7 @@ class WorkspaceOrmInterfaces:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            env={
-                **os.environ,
-                ProgressEnvironmentVariable.REPORT_PROGRESS: PROGRESS_REQUESTED,
-            },
+            env=self.generation_environment,
         )
         output = GenerationOutput(progress)
         for line in generation.stdout:
@@ -386,6 +407,17 @@ class WorkspaceOrmInterfaces:
                 self.unbuilt_package_name, "".join(output.written)
             )
         output.finish()
+
+    @property
+    def generation_environment(self) -> Dict[str, str]:
+        """
+        The environment the generators run in, asking them to report the classes they
+        finish so the build can count them.
+        """
+        return {
+            **os.environ,
+            ProgressEnvironmentVariable.REPORT_PROGRESS: GeneratorProgress.REQUESTED,
+        }
 
     @property
     def import_command(self) -> List[str]:
@@ -438,7 +470,7 @@ class WorkspaceOrmInterfaces:
         stale = StaleInterface.from_output(attempt.stdout)
         if attempt.returncode != InterfaceImportResult.STALE or stale is None:
             raise OrmImportFailedError(attempt.stdout)
-        print(stale.report())
+        logger.warning(stale.report())
         return stale
 
     @property

--- a/cognitive_robot_abstract_machine/orm_interfaces.py
+++ b/cognitive_robot_abstract_machine/orm_interfaces.py
@@ -12,15 +12,21 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 
 from tqdm import tqdm
-from typing_extensions import List, Optional, Sequence, Tuple
+from typing_extensions import Dict, List, Optional, Sequence, Tuple
 
-from cognitive_robot_abstract_machine import orm_generation
+from cognitive_robot_abstract_machine import orm_generation, orm_import
 from cognitive_robot_abstract_machine.exceptions import (
     OrmGenerationFailedError,
     MissingORMGeneratorError,
+    OrmImportFailedError,
+)
+from cognitive_robot_abstract_machine.orm_import import (
+    InterfaceImportResult,
+    StaleInterface,
 )
 from krrood.class_diagrams.progress_report import (
     ClassDiagramProgress,
@@ -32,24 +38,19 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 Root of the checkout this package is installed from.
 """
 
-INTERFACE_FILE_NAME = "ormatic_interface.py"
+INTERFACE_MODULE_NAME = "ormatic_interface"
 """
-Name every package's generator writes its interface to.
-"""
-
-SOURCE_FILE_PATTERN = "*.py"
-"""
-What a module of a package is named like.
+Name every package's generator writes its interface to, as it is imported.
 """
 
-MAPPING_ENGINE_SOURCE_FOLDERS: Tuple[Path, ...] = (
-    Path("krrood") / "src" / "krrood",
-    Path("cognitive_robot_abstract_machine"),
-)
+INTERFACE_FILE_NAME = f"{INTERFACE_MODULE_NAME}.py"
 """
-Folders of a checkout that every generator reads whichever package it is building for,
-relative to the root: the library that maps the classes, and the module that runs the
-generators.
+Name of the file holding it.
+"""
+
+INTERFACE_FOLDER_NAME = "orm"
+"""
+Folder of a package's sources that holds its interface.
 """
 
 PROGRESS_DESCRIPTION = "Building ORM interfaces"
@@ -61,6 +62,19 @@ PROGRESS_REQUESTED = "1"
 """
 What a generator is told to report the classes it finishes.
 """
+
+
+class ImportEnvironmentVariable(StrEnum):
+    """
+    Environment variables an import of the interfaces is run with.
+    """
+
+    MODULE_SEARCH_PATH = "PYTHONPATH"
+    """
+    Where the interpreter looks for the packages of the checkout, ahead of what is
+    installed.
+    """
+
 
 # %% what a build shows while it runs
 
@@ -186,14 +200,14 @@ class OrmInterface:
         """
         The generated interface file.
         """
-        return (
-            self.repository_root
-            / self.package_name
-            / "src"
-            / self.package_name
-            / "orm"
-            / INTERFACE_FILE_NAME
-        )
+        return self.sources / INTERFACE_FOLDER_NAME / INTERFACE_FILE_NAME
+
+    @property
+    def module_name(self) -> str:
+        """
+        The generated interface, as it is imported.
+        """
+        return f"{self.package_name}.{INTERFACE_FOLDER_NAME}.{INTERFACE_MODULE_NAME}"
 
     @property
     def sources(self) -> Path:
@@ -201,47 +215,6 @@ class OrmInterface:
         The source folder holding the modules this interface maps.
         """
         return self.repository_root / self.package_name / "src" / self.package_name
-
-    @property
-    def mapping_engine_sources(self) -> List[Path]:
-        """
-        The folders of the library that maps this package's classes and of the module
-        that runs its generator.
-        """
-        return [
-            self.repository_root / folder for folder in MAPPING_ENGINE_SOURCE_FOLDERS
-        ]
-
-    @property
-    def inputs(self) -> List[Path]:
-        """
-        The files this package contributes to a build: its generator, the modules of its
-        source folder, and those of the mapping engine.
-
-        The interface itself is written by a build rather than read by one, so it is not
-        among them.
-        """
-        modules = [
-            module
-            for source_folder in (self.sources, *self.mapping_engine_sources)
-            for module in source_folder.rglob(SOURCE_FILE_PATTERN)
-            if module != self.path
-        ]
-        return [self.generator, *modules]
-
-    @property
-    def is_outdated(self) -> bool:
-        """
-        Whether this interface is missing, or older than a file this package contributes
-        to a build.
-
-        ..note:: A checkout that cannot build the interface counts as outdated, so the
-            build runs and reports what it is missing rather than being skipped.
-        """
-        if not self.path.exists() or not self.generator.exists():
-            return True
-        generated_at = self.path.stat().st_mtime
-        return any(source.stat().st_mtime > generated_at for source in self.inputs)
 
     def remove(self) -> None:
         """
@@ -334,18 +307,6 @@ class WorkspaceOrmInterfaces:
     The interfaces in the order they are built, which follows their dependencies.
     """
 
-    @property
-    def is_outdated(self) -> bool:
-        """
-        Whether any interface is missing, or older than a file of the checkout a build
-        reads.
-
-        ..note:: A build covers every interface at once, so a package whose ORM model
-            another builds on outdates the whole workspace through its own interface,
-            and no interface has to look past its own package.
-        """
-        return any(interface.is_outdated for interface in self.interfaces)
-
     def regenerate(self, show_generator_output: bool = False) -> None:
         """
         Build every interface anew, from an empty state and in dependency order.
@@ -425,6 +386,60 @@ class WorkspaceOrmInterfaces:
                 self.unbuilt_package_name, "".join(output.written)
             )
         output.finish()
+
+    @property
+    def import_command(self) -> List[str]:
+        """
+        The command that imports every interface in one interpreter, in dependency
+        order.
+        """
+        return [
+            sys.executable,
+            "-P",
+            "-m",
+            orm_import.__name__,
+            *(interface.module_name for interface in self.interfaces),
+        ]
+
+    @property
+    def import_environment(self) -> Dict[str, str]:
+        """
+        The environment that import runs in, with the source folders of this checkout
+        ahead of the packages that are installed.
+        """
+        search_path = [str(interface.sources.parent) for interface in self.interfaces]
+        installed = os.environ.get(ImportEnvironmentVariable.MODULE_SEARCH_PATH)
+        if installed:
+            search_path.append(installed)
+        return {
+            **os.environ,
+            ImportEnvironmentVariable.MODULE_SEARCH_PATH: os.pathsep.join(search_path),
+        }
+
+    def stale_interface(self) -> Optional[StaleInterface]:
+        """
+        Import every interface of this checkout in an interpreter of its own, and say
+        which one no longer matches the classes it maps.
+
+        :return: The first interface that no longer matches, or nothing when every one
+            of them imported.
+        :raises OrmImportFailedError: If the import failed for a reason other than an
+            interface no longer matching the classes it maps.
+        """
+        attempt = subprocess.run(
+            self.import_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=self.import_environment,
+        )
+        if attempt.returncode == InterfaceImportResult.IMPORTED:
+            return None
+        stale = StaleInterface.from_output(attempt.stdout)
+        if attempt.returncode != InterfaceImportResult.STALE or stale is None:
+            raise OrmImportFailedError(attempt.stdout)
+        print(stale.report())
+        return stale
 
     @property
     def unbuilt_package_name(self) -> str:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -19,12 +19,13 @@ clone needs before it can persist anything and a changed mapped datastructure ne
 again; CI generates them the same way for its tests.
 
 A test run builds them for itself, and a build takes about a minute, so by default it
-only pays for one when the checkout has not built its interfaces since the sources they
-are generated from changed. ``--orm-build`` overrides that:
+only pays for one when an interface of the checkout can no longer be imported -- because
+it is missing, or because the classes it maps have been renamed or removed since it was
+generated. ``--orm-build`` overrides that:
 
 .. code:: bash
 
-  pytest --orm-build=auto     # the default: build only what the sources have outrun
+  pytest --orm-build=auto     # the default: build only what no longer imports
   pytest --orm-build=always   # build every run, whatever the checkout holds
   pytest --orm-build=never    # build nothing, and read whatever the checkout holds
 

--- a/test/cognitive_robot_abstract_machine_test/dataset/failing_interface.py
+++ b/test/cognitive_robot_abstract_machine_test/dataset/failing_interface.py
@@ -1,0 +1,16 @@
+"""
+Stand-in for an ORM interface that fails to import for a reason other than no longer
+matching the classes it maps.
+
+Raises the way a mapping the installed packages cannot support would, rather than the
+:class:`ImportError` or :class:`AttributeError` a stale interface raises.
+"""
+
+from __future__ import annotations
+
+DIAGNOSTIC = "the mapped columns of this interface do not fit their table"
+"""
+What this interface raises with.
+"""
+
+raise ValueError(DIAGNOSTIC)

--- a/test/cognitive_robot_abstract_machine_test/dataset/interface_of_a_removed_class.py
+++ b/test/cognitive_robot_abstract_machine_test/dataset/interface_of_a_removed_class.py
@@ -1,0 +1,31 @@
+"""
+Stand-in for an ORM interface generated from a class its package no longer holds.
+
+A generated interface reaches every class it maps as an attribute of the module holding
+it, so a class that was renamed or removed after the build leaves the interface raising
+:class:`AttributeError` on import.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+MAPPED_MODULE_NAME = "mapped_module"
+"""
+Module of this interface's package whose classes it maps.
+"""
+
+package_name = __name__.split(".")[0]
+"""
+Package this interface belongs to, which is the one it maps.
+"""
+
+mapped_module = importlib.import_module(f"{package_name}.{MAPPED_MODULE_NAME}")
+"""
+The module this interface maps.
+"""
+
+MAPPED_CLASS = mapped_module.Drawer
+"""
+The class this interface maps, which its package no longer holds.
+"""

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interface_build_hook.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interface_build_hook.py
@@ -92,50 +92,50 @@ class TestOrmInterfacesBuiltOnlyByTheXdistController:
 
 
 @pytest.fixture
-def current_interfaces(workspace: WorkspaceOrmInterfaces) -> WorkspaceOrmInterfaces:
+def importable_interfaces(workspace: WorkspaceOrmInterfaces) -> WorkspaceOrmInterfaces:
     """
-    The interfaces of a checkout that has been built since its sources last changed.
+    The interfaces of a checkout that still match the classes they map.
     """
     workspace.regenerate()
     return workspace
 
 
 @pytest.fixture
-def outdated_interfaces(
-    current_interfaces: WorkspaceOrmInterfaces,
+def stale_interfaces(
+    importable_interfaces: WorkspaceOrmInterfaces,
 ) -> WorkspaceOrmInterfaces:
     """
-    The interfaces of a checkout that has not been built since its sources changed.
+    The interfaces of a checkout that has lost one of them.
     """
-    current_interfaces.interfaces[0].remove()
-    return current_interfaces
+    importable_interfaces.interfaces[0].remove()
+    return importable_interfaces
 
 
 class TestWhenAChoiceBuilds:
     """
-    A run builds the interfaces every time, never, or only when the checkout has not
-    built them since its sources changed.
+    A run builds the interfaces every time, never, or only when the checkout holds one
+    that can no longer be imported.
     """
 
     def test_never_skips_a_checkout_that_has_none(
-        self, outdated_interfaces: WorkspaceOrmInterfaces
+        self, stale_interfaces: WorkspaceOrmInterfaces
     ):
-        assert OrmBuild.NEVER.builds(outdated_interfaces) is False
+        assert OrmBuild.NEVER.builds(stale_interfaces) is False
 
-    def test_always_builds_a_current_checkout(
-        self, current_interfaces: WorkspaceOrmInterfaces
+    def test_always_builds_a_checkout_whose_interfaces_import(
+        self, importable_interfaces: WorkspaceOrmInterfaces
     ):
-        assert OrmBuild.ALWAYS.builds(current_interfaces) is True
+        assert OrmBuild.ALWAYS.builds(importable_interfaces) is True
 
-    def test_auto_skips_a_current_checkout(
-        self, current_interfaces: WorkspaceOrmInterfaces
+    def test_auto_skips_a_checkout_whose_interfaces_import(
+        self, importable_interfaces: WorkspaceOrmInterfaces
     ):
-        assert OrmBuild.AUTO.builds(current_interfaces) is False
+        assert OrmBuild.AUTO.builds(importable_interfaces) is False
 
-    def test_auto_builds_an_outdated_checkout(
-        self, outdated_interfaces: WorkspaceOrmInterfaces
+    def test_auto_builds_a_checkout_with_a_stale_interface(
+        self, stale_interfaces: WorkspaceOrmInterfaces
     ):
-        assert OrmBuild.AUTO.builds(outdated_interfaces) is True
+        assert OrmBuild.AUTO.builds(stale_interfaces) is True
 
 
 class TestTheChoiceReachesTheProcessesOfARun:
@@ -144,7 +144,7 @@ class TestTheChoiceReachesTheProcessesOfARun:
     command line, so the choice is read off the arguments as they were given.
     """
 
-    def test_a_run_stating_no_choice_builds_what_is_outdated(self, monkeypatch):
+    def test_a_run_stating_no_choice_builds_what_no_longer_imports(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", [PYTEST_COMMAND])
         monkeypatch.delenv(PytestEnvironmentVariable.ORM_BUILD, raising=False)
 

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
@@ -4,6 +4,7 @@ Tests for building the ORM interfaces a checkout needs before it can persist obj
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -21,7 +22,7 @@ from cognitive_robot_abstract_machine.exceptions import (
     OrmImportFailedError,
 )
 from cognitive_robot_abstract_machine.orm_interfaces import (
-    INTERFACE_FILE_NAME,
+    InterfaceLocation,
     OrmInterface,
     REPOSITORY_ROOT,
     WORKSPACE_ORM_INTERFACES,
@@ -92,7 +93,7 @@ def tracked_interfaces(repository_root: Path) -> Set[str]:
     :return: The repository-relative paths of the tracked interfaces.
     """
     listing = subprocess.run(
-        ["git", "ls-files", "--", f"*/{INTERFACE_FILE_NAME}"],
+        ["git", "ls-files", "--", f"*/{InterfaceLocation.FILE_NAME}"],
         cwd=repository_root,
         check=True,
         capture_output=True,
@@ -234,7 +235,11 @@ def test_this_repository_ignores_every_generated_interface():
 
 def test_this_repository_ignores_a_generated_interface_outside_a_workspace_package():
     krrood_test_dataset_interface = (
-        REPOSITORY_ROOT / "test" / "krrood_test" / "dataset" / INTERFACE_FILE_NAME
+        REPOSITORY_ROOT
+        / "test"
+        / "krrood_test"
+        / "dataset"
+        / InterfaceLocation.FILE_NAME
     )
 
     assert git_ignores(REPOSITORY_ROOT, krrood_test_dataset_interface)
@@ -456,3 +461,46 @@ def test_the_import_attempt_stays_out_of_the_calling_interpreter(
         for interface in workspace.interfaces
         if interface.module_name in sys.modules
     ] == []
+
+
+@pytest.fixture
+def reported_staleness(caplog) -> logging.Handler:
+    """
+    What a build writes about the interfaces it found stale.
+
+    ..note:: The ROS overlay installs a logger class whose loggers do not propagate, so
+        the capturing handler has to be attached to the one under test rather than to
+        the root logger.
+
+    :return: The handler holding the records, empty until a build writes one.
+    """
+    orm_interfaces.logger.addHandler(caplog.handler)
+    yield caplog.handler
+    orm_interfaces.logger.removeHandler(caplog.handler)
+
+
+def test_the_stale_interface_is_reported_through_logging(
+    workspace: WorkspaceOrmInterfaces, reported_staleness: logging.Handler
+):
+    """
+    The report explains a build the run did not ask for, so it goes to logging rather
+    than to whatever the caller has its output pointed at.
+    """
+    workspace.regenerate()
+    leave_behind(REMOVED_CLASS_INTERFACE, workspace.interfaces[0])
+
+    stale = workspace.stale_interface()
+
+    assert [record.getMessage() for record in reported_staleness.records] == [
+        stale.report()
+    ]
+
+
+def test_a_checkout_that_imports_is_reported_on_at_all(
+    workspace: WorkspaceOrmInterfaces, reported_staleness: logging.Handler
+):
+    workspace.regenerate()
+
+    workspace.stale_interface()
+
+    assert reported_staleness.records == []

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -17,6 +18,7 @@ from cognitive_robot_abstract_machine import orm_interfaces
 from cognitive_robot_abstract_machine.exceptions import (
     MissingORMGeneratorError,
     OrmGenerationFailedError,
+    OrmImportFailedError,
 )
 from cognitive_robot_abstract_machine.orm_interfaces import (
     INTERFACE_FILE_NAME,
@@ -35,7 +37,7 @@ PACKAGE_NAMES: Tuple[str, ...] = ("upstream", "downstream")
 Packages of the checkout under test, in dependency order.
 """
 
-STALE_INTERFACE_CONTENT = "# interface of a previous run\n"
+PREVIOUS_INTERFACE_CONTENT = "# interface of a previous run\n"
 """
 Content the interfaces of the checkout hold before it is regenerated.
 """
@@ -49,8 +51,7 @@ Name of the module of a package whose classes its interface maps.
 @pytest.fixture
 def checkout(tmp_path: Path) -> Path:
     """
-    A git checkout of two packages whose interfaces hold content of a previous run,
-    beside the mapping engine every one of their generators reads.
+    A git checkout of two packages whose interfaces hold content of a previous run.
     """
     for package_name in PACKAGE_NAMES:
         package_root = tmp_path / package_name
@@ -61,15 +62,10 @@ def checkout(tmp_path: Path) -> Path:
         )
         interface = generate_orm.interface_of(package_root)
         interface.parent.mkdir(parents=True)
-        interface.write_text(STALE_INTERFACE_CONTENT, encoding="utf-8")
+        interface.write_text(PREVIOUS_INTERFACE_CONTENT, encoding="utf-8")
         shutil.copy(
             Path(mapped_module.__file__), interface.parent.parent / SOURCE_MODULE_NAME
         )
-
-    for source_folder in orm_interfaces.MAPPING_ENGINE_SOURCE_FOLDERS:
-        mapping_engine = tmp_path / source_folder
-        mapping_engine.mkdir(parents=True)
-        shutil.copy(Path(mapped_module.__file__), mapping_engine / SOURCE_MODULE_NAME)
 
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(
@@ -352,94 +348,111 @@ def test_a_build_showing_generator_output_keeps_no_bar(
         assert progress.bar is None
 
 
-# %% interfaces their sources have outrun
+# %% interfaces that no longer match their classes
+
+DATASET = Path(mapped_module.__file__).parent
+"""
+Folder holding the modules a checkout under test is built from.
+"""
+
+REMOVED_CLASS_INTERFACE = DATASET / "interface_of_a_removed_class.py"
+"""
+An interface of a package that no longer holds a class it maps.
+"""
+
+FAILING_INTERFACE = DATASET / "failing_interface.py"
+"""
+An interface that fails to import for a reason other than a stale mapping.
+"""
 
 
-def change_after_the_build(path: Path, interface: OrmInterface) -> None:
+def leave_behind(stand_in: Path, interface: OrmInterface) -> None:
     """
-    Give a file a modification time later than the interface's, as an edit made after
-    the build would.
+    Put an interface of a previous build in a package's place.
 
-    :param path: The file to mark as changed.
-    :param interface: The interface the change comes after.
+    :param stand_in: The module standing in for what a build wrote.
+    :param interface: The interface of the package it is left in.
     """
-    changed_at = interface.path.stat().st_mtime + 1
-    os.utime(path, (changed_at, changed_at))
+    shutil.copy(stand_in, interface.path)
 
 
-def test_a_freshly_built_checkout_is_current(workspace: WorkspaceOrmInterfaces):
+def test_a_freshly_built_checkout_imports(workspace: WorkspaceOrmInterfaces):
     workspace.regenerate()
 
-    assert workspace.is_outdated is False
+    assert workspace.stale_interface() is None
 
 
-def test_a_missing_interface_is_outdated(workspace: WorkspaceOrmInterfaces):
+def test_a_missing_interface_is_stale(workspace: WorkspaceOrmInterfaces):
     workspace.regenerate()
-    workspace.interfaces[-1].remove()
+    missing = workspace.interfaces[-1]
+    missing.remove()
 
-    assert workspace.interfaces[-1].is_outdated is True
-    assert workspace.is_outdated is True
+    stale = workspace.stale_interface()
+
+    assert stale.module_name == missing.module_name
+    assert stale.error_type == ModuleNotFoundError.__name__
 
 
-def test_a_changed_module_outdates_the_interface_of_its_package(
+def test_an_interface_of_a_removed_class_is_stale(workspace: WorkspaceOrmInterfaces):
+    """
+    A generated interface reaches every class it maps as an attribute of its module, so
+    one that has been renamed or removed since the build fails the import as a missing
+    attribute rather than as a missing module.
+    """
+    workspace.regenerate()
+    outrun = workspace.interfaces[0]
+    leave_behind(REMOVED_CLASS_INTERFACE, outrun)
+
+    stale = workspace.stale_interface()
+
+    assert stale.module_name == outrun.module_name
+    assert stale.error_type == AttributeError.__name__
+
+
+def test_the_first_interface_that_does_not_import_is_the_one_reported(
     workspace: WorkspaceOrmInterfaces,
 ):
     workspace.regenerate()
-    interface = workspace.interfaces[0]
+    for interface in workspace.interfaces:
+        leave_behind(REMOVED_CLASS_INTERFACE, interface)
 
-    change_after_the_build(interface.sources / SOURCE_MODULE_NAME, interface)
+    stale = workspace.stale_interface()
 
-    assert interface.is_outdated is True
-
-
-def test_a_changed_module_leaves_the_interface_of_another_package_alone(
-    workspace: WorkspaceOrmInterfaces,
-):
-    workspace.regenerate()
-    interface = workspace.interfaces[0]
-
-    change_after_the_build(interface.sources / SOURCE_MODULE_NAME, interface)
-
-    assert workspace.interfaces[-1].is_outdated is False
+    assert stale.module_name == workspace.interfaces[0].module_name
 
 
-def test_a_changed_mapping_engine_module_outdates_every_interface(
+def test_an_interface_failing_for_another_reason_reports_what_it_wrote(
     workspace: WorkspaceOrmInterfaces,
 ):
     """
-    Every generator reads the library that maps the classes, so a change to it leaves no
-    interface of the checkout current.
+    An interface failing for anything but a stale mapping is a broken checkout rather
+    than one to rebuild, so the attempt says what happened instead of answering with a
+    build.
     """
     workspace.regenerate()
-    interface = workspace.interfaces[0]
+    failing = workspace.interfaces[0]
+    leave_behind(FAILING_INTERFACE, failing)
 
-    for source_folder in interface.mapping_engine_sources:
-        change_after_the_build(source_folder / SOURCE_MODULE_NAME, interface)
+    with pytest.raises(OrmImportFailedError) as failure:
+        workspace.stale_interface()
 
-    assert all(member.is_outdated for member in workspace.interfaces)
-    assert workspace.is_outdated is True
-
-
-def test_a_changed_generator_outdates_the_interface_it_writes(
-    workspace: WorkspaceOrmInterfaces,
-):
-    workspace.regenerate()
-    interface = workspace.interfaces[0]
-
-    change_after_the_build(interface.generator, interface)
-
-    assert interface.is_outdated is True
+    assert ValueError.__name__ in failure.value.output
+    assert str(failing.path) in failure.value.output
 
 
-def test_a_missing_generator_leaves_its_interface_outdated(
+def test_the_import_attempt_stays_out_of_the_calling_interpreter(
     workspace: WorkspaceOrmInterfaces,
 ):
     """
-    A checkout that cannot build an interface is never current, so the build runs and
-    reports the missing generator rather than being skipped.
+    The interfaces are imported in an interpreter of their own, so a build following a
+    failed attempt cannot leave a stale interface behind in the one that asked for it.
     """
     workspace.regenerate()
-    interface = workspace.interfaces[0]
-    interface.generator.unlink()
 
-    assert interface.is_outdated is True
+    workspace.stale_interface()
+
+    assert [
+        interface.module_name
+        for interface in workspace.interfaces
+        if interface.module_name in sys.modules
+    ] == []

--- a/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
+++ b/test/cognitive_robot_abstract_machine_test/test_orm_interfaces.py
@@ -464,16 +464,18 @@ def test_the_import_attempt_stays_out_of_the_calling_interpreter(
 
 
 @pytest.fixture
-def reported_staleness(caplog) -> logging.Handler:
+def reported_staleness(caplog, monkeypatch) -> logging.Handler:
     """
     What a build writes about the interfaces it found stale.
 
-    ..note:: The ROS overlay installs a logger class whose loggers do not propagate, so
-        the capturing handler has to be attached to the one under test rather than to
-        the root logger.
+    ..note:: Whether the logger under test propagates to the root logger depends on the
+        logger class the ROS overlay installs, and the capturing handler sits on the root
+        logger already. Attaching it to the logger under test and turning propagation off
+        records every report exactly once, with or without the overlay.
 
     :return: The handler holding the records, empty until a build writes one.
     """
+    monkeypatch.setattr(orm_interfaces.logger, "propagate", False)
     orm_interfaces.logger.addHandler(caplog.handler)
     yield caplog.handler
     orm_interfaces.logger.removeHandler(caplog.handler)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -186,8 +186,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help=(
             "when to build the generated ORM interfaces; "
-            f"'{OrmBuild.AUTO}' builds only what the checkout has not built since its "
-            f"sources changed, '{OrmBuild.ALWAYS}' builds every run, whatever the "
+            f"'{OrmBuild.AUTO}' builds only when an interface of the checkout can no "
+            f"longer be imported, '{OrmBuild.ALWAYS}' builds every run, whatever the "
             f"checkout holds, '{OrmBuild.NEVER}' builds nothing, and reads whatever the "
             "checkout holds"
         ),

--- a/test/krrood_test/test_eql/test_verbalization/verbalization_results.py
+++ b/test/krrood_test/test_eql/test_verbalization/verbalization_results.py
@@ -9,6 +9,7 @@ before committing an intentional wording change.
 
 from __future__ import annotations
 
+from krrood.entity_query_language.testing.result_verification import VerbalizationResult
 from krrood.entity_query_language.factories import (
     AttributeOwnerClass,
     IsClass,
@@ -21,7 +22,6 @@ from krrood.entity_query_language.factories import (
     RuntimeType,
 )
 from krrood.entity_query_language.predicate import HasType, HasTypes, Is, Length
-from krrood.entity_query_language.testing.result_verification import VerbalizationResult
 from krrood.entity_query_language.verbalization._example_domain import (
     IsReachable,
     WorksIn,

--- a/test/orm_interface_build.py
+++ b/test/orm_interface_build.py
@@ -5,8 +5,8 @@ Every package's ``ormatic_interface.py`` is generated rather than tracked, so a 
 holds none until something builds them. Only the packages whose tests read a mapped
 datastructure call this; the rest never pay for a build they would not read.
 
-A build takes about a minute, so a run only pays for it when the checkout has not built
-its interfaces since the sources changed. ``--orm-build`` overrides that.
+A build takes about a minute, so a run only pays for it when an interface of the
+checkout can no longer be imported. ``--orm-build`` overrides that.
 """
 
 from __future__ import annotations
@@ -64,7 +64,7 @@ class OrmBuild(StrEnum):
 
     AUTO = "auto"
     """
-    Builds only what the checkout has not built since its sources changed.
+    Builds when an interface of the checkout can no longer be imported.
     """
 
     ALWAYS = "always"
@@ -147,12 +147,14 @@ class OrmBuild(StrEnum):
         Whether this choice has the given interfaces built.
 
         :param interfaces: The interfaces of the checkout under test.
+        :raises OrmImportFailedError: If :attr:`AUTO` cannot import them for a reason
+            other than one of them being stale.
         """
         if self is OrmBuild.NEVER:
             return False
         if self is OrmBuild.ALWAYS:
             return True
-        return interfaces.is_outdated
+        return interfaces.stale_interface() is not None
 
 
 @cache

--- a/test/pytest_environment.py
+++ b/test/pytest_environment.py
@@ -20,5 +20,5 @@ class PytestEnvironmentVariable(StrEnum):
     ORM_BUILD = "CRAM_ORM_BUILD"
     """
     Names when the run builds the ORM interfaces, for runs that state no ``--orm-build``
-    on their command line; absent, a run builds what is outdated.
+    on their command line; absent, a run builds what it can no longer import.
     """


### PR DESCRIPTION
# Describe 
Quick 5 min adventure that changes the auto behaviour of --orm-build to try to import the interfaces and only if they fail they are re-generated