### PR TITLE
[Giskard] Added client presence and watchdog

### DIFF
--- a/coraplex/demos/coraplex_real_tracy/demo.py
+++ b/coraplex/demos/coraplex_real_tracy/demo.py
@@ -48,7 +48,7 @@ execition_mode = ExecutionType.REAL
 
 print("Init ROS")
 rclpy.init()
-node = rclpy.create_node("stretch_demo_node")
+node = rclpy.create_node("tracy_demo_node")
 
 executor = MultiThreadedExecutor()
 executor.add_node(node)

--- a/giskardpy/src/giskardpy/data_types/exceptions.py
+++ b/giskardpy/src/giskardpy/data_types/exceptions.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from krrood.exceptions import DataclassException
 
 
-class DontPrintStackTrace:
+class DoesntPrintStackTrace:
     """
     Marker mixin for exceptions whose stack trace should not be printed.
     """

--- a/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
@@ -4,13 +4,15 @@ import json
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, ClassVar, Dict, List, Optional, Set
+from datetime import timedelta
+from typing import Callable, Dict, List, Optional
 
 import std_msgs.msg
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.subscription import Subscription
 from rclpy.timer import Timer
+from sortedcontainers import SortedSet
 
 from giskardpy.middleware.ros2.exceptions import NoWatchedClientError
 from krrood.adapters.json_serializer import from_json, to_json
@@ -41,14 +43,9 @@ class ClientHeartbeatPublisher:
     Node name of the Giskard the heartbeat is meant for.
     """
 
-    period: float = 0.1
+    period: timedelta = timedelta(milliseconds=100)
     """
-    Seconds between two heartbeats.
-    """
-
-    topic_suffix: ClassVar[str] = "client_heartbeat"
-    """
-    What the heartbeat topic of a Giskard is called, relative to its node name.
+    Time between two heartbeats.
     """
 
     publisher: Publisher = field(init=False)
@@ -73,14 +70,14 @@ class ClientHeartbeatPublisher:
             topic=self.topic_name(self.giskard_node_name),
             qos_profile=10,
         )
-        self.timer = self.node.create_timer(self.period, self.publish)
+        self.timer = self.node.create_timer(self.period.total_seconds(), self.publish)
 
-    @classmethod
-    def topic_name(cls, giskard_node_name: str) -> str:
+    @staticmethod
+    def topic_name(giskard_node_name: str) -> str:
         """
         The topic the clients of the given Giskard announce themselves on.
         """
-        return f"{giskard_node_name}/{cls.topic_suffix}"
+        return f"{giskard_node_name}/client_heartbeat"
 
     def publish(self) -> None:
         """
@@ -160,9 +157,9 @@ class HeartbeatPresence(ClientPresence):
     Node of Giskard, which the heartbeat topic is named after.
     """
 
-    timeout: float = 1.0
+    timeout: timedelta = timedelta(seconds=1)
     """
-    Seconds without a heartbeat after which a client counts as gone.
+    Time without a heartbeat after which a client counts as gone.
 
     Heartbeats are received on a ros executor thread while the control loop runs on its
     own, so this has to stay well above the heartbeat period: a value close to it would
@@ -206,7 +203,7 @@ class HeartbeatPresence(ClientPresence):
         last_heartbeat = self.last_heartbeat.get(client)
         if last_heartbeat is None:
             return False
-        return self.clock() - last_heartbeat <= self.timeout
+        return self.clock() - last_heartbeat <= self.timeout.total_seconds()
 
     def start_watching(self, client: MetaData) -> bool:
         if not self.has_recent_heartbeat(client):
@@ -239,7 +236,7 @@ class GraphPresence(ClientPresence):
     Name of the action whose clients are watched.
     """
 
-    watched_endpoints: Set[bytes] = field(init=False, default_factory=set)
+    watched_endpoints: SortedSet[bytes] = field(init=False, default_factory=SortedSet)
     """
     The subscriptions the watched client had when its goal started.
 
@@ -254,18 +251,18 @@ class GraphPresence(ClientPresence):
         """
         return f"{self.action_name}/_action/feedback"
 
-    def subscribed_endpoints_of(self, client: MetaData) -> Set[bytes]:
+    def subscribed_endpoints_of(self, client: MetaData) -> SortedSet[bytes]:
         """
         The subscriptions the given client currently keeps on the feedback of the
         action.
         """
-        return {
+        return SortedSet(
             bytes(endpoint.endpoint_gid)
             for endpoint in self.node.get_subscriptions_info_by_topic(
                 self.feedback_topic
             )
             if endpoint.node_name == client.node_name
-        }
+        )
 
     def start_watching(self, client: MetaData) -> bool:
         endpoints = self.subscribed_endpoints_of(client)
@@ -277,7 +274,7 @@ class GraphPresence(ClientPresence):
 
     def stop_watching(self) -> None:
         super().stop_watching()
-        self.watched_endpoints = set()
+        self.watched_endpoints = SortedSet()
 
     def is_client_present(self) -> bool:
         return bool(self.watched_endpoints & self.subscribed_endpoints_of(self.client))

--- a/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Callable, ClassVar, Dict, List, Optional, Set
+
+import std_msgs.msg
+from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.subscription import Subscription
+from rclpy.timer import Timer
+
+from giskardpy.middleware.ros2.exceptions import NoWatchedClientError
+from krrood.adapters.json_serializer import from_json, to_json
+from semantic_digital_twin.adapters.ros.messages import MetaData
+
+# %% the heartbeat a client sends
+
+
+@dataclass
+class ClientHeartbeatPublisher:
+    """
+    Announces that a client is still there, so that Giskard can stop a motion whose
+    client died instead of running it to its end.
+    """
+
+    node: Node
+    """
+    Node of the client that announces itself.
+    """
+
+    client: MetaData
+    """
+    Identity of that client, the same one its goals name.
+    """
+
+    giskard_node_name: str
+    """
+    Node name of the Giskard the heartbeat is meant for.
+    """
+
+    period: float = 0.1
+    """
+    Seconds between two heartbeats.
+    """
+
+    topic_suffix: ClassVar[str] = "client_heartbeat"
+    """
+    What the heartbeat topic of a Giskard is called, relative to its node name.
+    """
+
+    publisher: Publisher = field(init=False)
+    """
+    Publisher the heartbeats go out on.
+    """
+
+    timer: Timer = field(init=False)
+    """
+    Timer that sends the heartbeats.
+    """
+
+    message: std_msgs.msg.String = field(init=False)
+    """
+    The heartbeat that is sent, built once because the identity never changes.
+    """
+
+    def __post_init__(self):
+        self.message = std_msgs.msg.String(data=json.dumps(to_json(self.client)))
+        self.publisher = self.node.create_publisher(
+            std_msgs.msg.String,
+            topic=self.topic_name(self.giskard_node_name),
+            qos_profile=10,
+        )
+        self.timer = self.node.create_timer(self.period, self.publish)
+
+    @classmethod
+    def topic_name(cls, giskard_node_name: str) -> str:
+        """
+        The topic the clients of the given Giskard announce themselves on.
+        """
+        return f"{giskard_node_name}/{cls.topic_suffix}"
+
+    def publish(self) -> None:
+        """
+        Announce that this client is still there.
+        """
+        self.publisher.publish(self.message)
+
+    def stop(self) -> None:
+        """
+        Stop announcing this client.
+        """
+        self.timer.cancel()
+        self.node.destroy_timer(self.timer)
+        self.node.destroy_publisher(self.publisher)
+
+
+# %% whether a client is still there
+
+
+@dataclass
+class ClientPresence(ABC):
+    """
+    Tells whether the client that sent the running goal is still connected.
+    """
+
+    watched_client: Optional[MetaData] = field(init=False, default=None)
+    """
+    The client this check reports on, or ``None`` while no goal is running.
+    """
+
+    @property
+    def client(self) -> MetaData:
+        """
+        The client that is being watched.
+
+        :raises NoWatchedClientError: If nothing is being watched.
+        """
+        if self.watched_client is None:
+            raise NoWatchedClientError(check_type=type(self))
+        return self.watched_client
+
+    def stop_watching(self) -> None:
+        """
+        Stop reporting on the client of the goal that just ended.
+        """
+        self.watched_client = None
+
+    @abstractmethod
+    def start_watching(self, client: MetaData) -> bool:
+        """
+        Start reporting on the given client.
+
+        :return: whether this check sees that client and can tell when it leaves
+        """
+
+    @abstractmethod
+    def is_client_present(self) -> bool:
+        """
+        Whether the watched client is still connected.
+        """
+
+
+@dataclass
+class HeartbeatPresence(ClientPresence):
+    """
+    Reads the heartbeats of the clients and considers one gone once its heartbeats stop
+    arriving.
+
+    This is the fast check: it notices a client that was killed within ``timeout``,
+    while the ros graph needs the participant lease of the middleware for the same
+    observation. It also notices a client that is still running but no longer gets
+    around to announcing itself.
+    """
+
+    node: Node
+    """
+    Node of Giskard, which the heartbeat topic is named after.
+    """
+
+    timeout: float = 1.0
+    """
+    Seconds without a heartbeat after which a client counts as gone.
+
+    Heartbeats are received on a ros executor thread while the control loop runs on its
+    own, so this has to stay well above the heartbeat period: a value close to it would
+    turn a busy executor into a stopped robot.
+    """
+
+    clock: Callable[[], float] = time.monotonic
+    """
+    Reads the time the heartbeats are dated with.
+    """
+
+    last_heartbeat: Dict[MetaData, float] = field(init=False, default_factory=dict)
+    """
+    When each client announced itself last.
+    """
+
+    subscription: Subscription = field(init=False)
+    """
+    Subscription the heartbeats arrive on.
+    """
+
+    def __post_init__(self):
+        self.subscription = self.node.create_subscription(
+            std_msgs.msg.String,
+            topic=ClientHeartbeatPublisher.topic_name(self.node.get_name()),
+            callback=self.receive_heartbeat,
+            qos_profile=10,
+        )
+
+    def receive_heartbeat(self, message: std_msgs.msg.String) -> None:
+        """
+        Note that the client that sent this heartbeat is still there.
+        """
+        client = from_json(json.loads(message.data))
+        self.last_heartbeat[client] = self.clock()
+
+    def has_recent_heartbeat(self, client: MetaData) -> bool:
+        """
+        Whether the given client announced itself within ``timeout``.
+        """
+        last_heartbeat = self.last_heartbeat.get(client)
+        if last_heartbeat is None:
+            return False
+        return self.clock() - last_heartbeat <= self.timeout
+
+    def start_watching(self, client: MetaData) -> bool:
+        if not self.has_recent_heartbeat(client):
+            return False
+        self.watched_client = client
+        return True
+
+    def is_client_present(self) -> bool:
+        return self.has_recent_heartbeat(self.client)
+
+
+@dataclass
+class GraphPresence(ClientPresence):
+    """
+    Watches the ros graph for the subscriptions an action client keeps on the feedback
+    of the action, and considers the client gone once they are gone.
+
+    This is the check for clients that send no heartbeat. It sees a client leave as fast
+    as the middleware announces it, which is immediate for a client that shut down and
+    takes the participant lease for one that was killed.
+    """
+
+    node: Node
+    """
+    Node of Giskard, which sees the graph.
+    """
+
+    action_name: str
+    """
+    Name of the action whose clients are watched.
+    """
+
+    watched_endpoints: Set[bytes] = field(init=False, default_factory=set)
+    """
+    The subscriptions the watched client had when its goal started.
+
+    A restarted client subscribes anew, so comparing the endpoints rather than the node
+    name keeps a namesake of the dead client from passing as the client that is gone.
+    """
+
+    @property
+    def feedback_topic(self) -> str:
+        """
+        The topic the action publishes its feedback on.
+        """
+        return f"{self.action_name}/_action/feedback"
+
+    def subscribed_endpoints_of(self, client: MetaData) -> Set[bytes]:
+        """
+        The subscriptions the given client currently keeps on the feedback of the
+        action.
+        """
+        return {
+            bytes(endpoint.endpoint_gid)
+            for endpoint in self.node.get_subscriptions_info_by_topic(
+                self.feedback_topic
+            )
+            if endpoint.node_name == client.node_name
+        }
+
+    def start_watching(self, client: MetaData) -> bool:
+        endpoints = self.subscribed_endpoints_of(client)
+        if not endpoints:
+            return False
+        self.watched_client = client
+        self.watched_endpoints = endpoints
+        return True
+
+    def stop_watching(self) -> None:
+        super().stop_watching()
+        self.watched_endpoints = set()
+
+    def is_client_present(self) -> bool:
+        return bool(self.watched_endpoints & self.subscribed_endpoints_of(self.client))
+
+
+# %% watching the client of a goal
+
+
+@dataclass
+class ClientWatchdog:
+    """
+    Watches the client of the running goal and reports when it is gone.
+
+    A goal outlives its client for as long as nobody notices, which leaves the robot
+    executing a plan that nobody is waiting for anymore.
+    """
+
+    checks: List[ClientPresence] = field(default_factory=list)
+    """
+    The checks that can report on a client, most informative first.
+    """
+
+    watching: Optional[ClientPresence] = field(init=False, default=None)
+    """
+    The check that reports on the client of the running goal, or ``None`` if no check
+    recognized it.
+    """
+
+    @property
+    def client(self) -> MetaData:
+        """
+        The client of the running goal.
+
+        :raises NoWatchedClientError: If no goal is being watched.
+        """
+        if self.watching is None:
+            raise NoWatchedClientError(check_type=type(self))
+        return self.watching.client
+
+    def watch(self, client: MetaData) -> None:
+        """
+        Start watching the client of a goal with the first check that recognizes it.
+
+        A client no check recognizes is not watched, so an unknown client can never make
+        Giskard stop a goal it is still waiting for.
+        """
+        for check in self.checks:
+            if check.start_watching(client):
+                self.watching = check
+                return
+
+    def stop_watching(self) -> None:
+        """
+        Stop watching the client of the goal that just ended.
+        """
+        if self.watching is None:
+            return
+        self.watching.stop_watching()
+        self.watching = None
+
+    def is_client_gone(self) -> bool:
+        """
+        Whether the client of the running goal disconnected.
+        """
+        if self.watching is None:
+            return False
+        return not self.watching.is_client_present()

--- a/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 import json
 import time
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, Optional
 
 import std_msgs.msg
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.subscription import Subscription
 from rclpy.timer import Timer
-from sortedcontainers import SortedSet
 
 from giskardpy.middleware.ros2.exceptions import NoWatchedClientError
 from krrood.adapters.json_serializer import from_json, to_json
@@ -98,58 +96,13 @@ class ClientHeartbeatPublisher:
 
 
 @dataclass
-class ClientPresence(ABC):
-    """
-    Tells whether the client that sent the running goal is still connected.
-    """
-
-    watched_client: Optional[MetaData] = field(init=False, default=None)
-    """
-    The client this check reports on, or ``None`` while no goal is running.
-    """
-
-    @property
-    def client(self) -> MetaData:
-        """
-        The client that is being watched.
-
-        :raises NoWatchedClientError: If nothing is being watched.
-        """
-        if self.watched_client is None:
-            raise NoWatchedClientError(check_type=type(self))
-        return self.watched_client
-
-    def stop_watching(self) -> None:
-        """
-        Stop reporting on the client of the goal that just ended.
-        """
-        self.watched_client = None
-
-    @abstractmethod
-    def start_watching(self, client: MetaData) -> bool:
-        """
-        Start reporting on the given client.
-
-        :return: whether this check sees that client and can tell when it leaves
-        """
-
-    @abstractmethod
-    def is_client_present(self) -> bool:
-        """
-        Whether the watched client is still connected.
-        """
-
-
-@dataclass
-class HeartbeatPresence(ClientPresence):
+class HeartbeatPresence:
     """
     Reads the heartbeats of the clients and considers one gone once its heartbeats stop
     arriving.
 
-    This is the fast check: it notices a client that was killed within ``timeout``,
-    while the ros graph needs the participant lease of the middleware for the same
-    observation. It also notices a client that is still running but no longer gets
-    around to announcing itself.
+    This is the fast check: it notices a client that was killed within ``timeout``, and a
+    client that is still running but no longer gets around to announcing itself.
     """
 
     node: Node
@@ -174,6 +127,11 @@ class HeartbeatPresence(ClientPresence):
     deterministically instead of sleeping in real time.
     """
 
+    watched_client: Optional[MetaData] = field(init=False, default=None)
+    """
+    The client this check reports on, or ``None`` while no goal is running.
+    """
+
     last_heartbeat: Dict[MetaData, float] = field(init=False, default_factory=dict)
     """
     When each client announced itself last.
@@ -183,6 +141,23 @@ class HeartbeatPresence(ClientPresence):
     """
     Subscription the heartbeats arrive on.
     """
+
+    @property
+    def client(self) -> MetaData:
+        """
+        The client that is being watched.
+
+        :raises NoWatchedClientError: If nothing is being watched.
+        """
+        if self.watched_client is None:
+            raise NoWatchedClientError(check_type=type(self))
+        return self.watched_client
+
+    def stop_watching(self) -> None:
+        """
+        Stop reporting on the client of the goal that just ended.
+        """
+        self.watched_client = None
 
     def __post_init__(self):
         self.subscription = self.node.create_subscription(
@@ -218,75 +193,6 @@ class HeartbeatPresence(ClientPresence):
         return self.has_recent_heartbeat(self.client)
 
 
-@dataclass
-class GraphPresence(ClientPresence):
-    """
-    Watches the ros graph for the subscriptions an action client keeps on the feedback
-    of the action, and considers the client gone once they are gone.
-
-    This is the check for clients that send no heartbeat. It sees a client leave as fast
-    as the middleware announces it, which is immediate for a client that shut down and
-    takes the participant lease for one that was killed.
-    """
-
-    node: Node
-    """
-    Node of Giskard, which sees the graph.
-    """
-
-    action_name: str
-    """
-    Name of the action whose clients are watched.
-    """
-
-    watched_endpoints: SortedSet[bytes] = field(init=False, default_factory=SortedSet)
-    """
-    The subscriptions the watched client had when its goal started.
-
-    A restarted client subscribes anew, so comparing the endpoints rather than the node
-    name keeps a namesake of the dead client from passing as the client that is gone.
-
-    ``rclpy`` reports each endpoint's id as a raw ``list[int]``, which cannot be a set
-    member; it is converted to ``bytes`` here, the immutable and hashable form of the
-    same raw identifier.
-    """
-
-    @property
-    def feedback_topic(self) -> str:
-        """
-        The topic the action publishes its feedback on.
-        """
-        return f"{self.action_name}/_action/feedback"
-
-    def subscribed_endpoints_of(self, client: MetaData) -> SortedSet[bytes]:
-        """
-        The subscriptions the given client currently keeps on the feedback of the
-        action.
-        """
-        return SortedSet(
-            bytes(endpoint.endpoint_gid)
-            for endpoint in self.node.get_subscriptions_info_by_topic(
-                self.feedback_topic
-            )
-            if endpoint.node_name == client.node_name
-        )
-
-    def start_watching(self, client: MetaData) -> bool:
-        endpoints = self.subscribed_endpoints_of(client)
-        if not endpoints:
-            return False
-        self.watched_client = client
-        self.watched_endpoints = endpoints
-        return True
-
-    def stop_watching(self) -> None:
-        super().stop_watching()
-        self.watched_endpoints = SortedSet()
-
-    def is_client_present(self) -> bool:
-        return bool(self.watched_endpoints & self.subscribed_endpoints_of(self.client))
-
-
 # %% watching the client of a goal
 
 
@@ -299,15 +205,9 @@ class ClientWatchdog:
     executing a plan that nobody is waiting for anymore.
     """
 
-    checks: List[ClientPresence] = field(default_factory=list)
+    presence: HeartbeatPresence
     """
-    The checks that can report on a client, most informative first.
-    """
-
-    watching: Optional[ClientPresence] = field(init=False, default=None)
-    """
-    The check that reports on the client of the running goal, or ``None`` if no check
-    recognized it.
+    The check that reports on the client's continued presence.
     """
 
     @property
@@ -317,35 +217,31 @@ class ClientWatchdog:
 
         :raises NoWatchedClientError: If no goal is being watched.
         """
-        if self.watching is None:
+        if self.presence.watched_client is None:
             raise NoWatchedClientError(check_type=type(self))
-        return self.watching.client
+        return self.presence.client
 
     def watch(self, client: MetaData) -> None:
         """
-        Start watching the client of a goal with the first check that recognizes it.
+        Start watching the client of a goal, if the presence check recognizes it.
 
-        A client no check recognizes is not watched, so an unknown client can never make
-        Giskard stop a goal it is still waiting for.
+        A client the check does not recognize is not watched, so an unknown client can
+        never make Giskard stop a goal it is still waiting for.
         """
-        for check in self.checks:
-            if check.start_watching(client):
-                self.watching = check
-                return
+        self.presence.start_watching(client)
 
     def stop_watching(self) -> None:
         """
         Stop watching the client of the goal that just ended.
         """
-        if self.watching is None:
+        if self.presence.watched_client is None:
             return
-        self.watching.stop_watching()
-        self.watching = None
+        self.presence.stop_watching()
 
     def is_client_gone(self) -> bool:
         """
         Whether the client of the running goal disconnected.
         """
-        if self.watching is None:
+        if self.presence.watched_client is None:
             return False
-        return not self.watching.is_client_present()
+        return not self.presence.is_client_present()

--- a/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
@@ -169,6 +169,9 @@ class HeartbeatPresence(ClientPresence):
     clock: Callable[[], float] = time.monotonic
     """
     Reads the time the heartbeats are dated with.
+
+    Tests substitute a controllable clock here to advance simulated time
+    deterministically instead of sleeping in real time.
     """
 
     last_heartbeat: Dict[MetaData, float] = field(init=False, default_factory=dict)
@@ -242,6 +245,10 @@ class GraphPresence(ClientPresence):
 
     A restarted client subscribes anew, so comparing the endpoints rather than the node
     name keeps a namesake of the dead client from passing as the client that is gone.
+
+    ``rclpy`` reports each endpoint's id as a raw ``list[int]``, which cannot be a set
+    member; it is converted to ``bytes`` here, the immutable and hashable form of the
+    same raw identifier.
     """
 
     @property

--- a/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/client_presence.py
@@ -41,7 +41,7 @@ class ClientHeartbeatPublisher:
     Node name of the Giskard the heartbeat is meant for.
     """
 
-    period: timedelta = timedelta(milliseconds=100)
+    period: timedelta = timedelta(seconds=1)
     """
     Time between two heartbeats.
     """
@@ -110,7 +110,7 @@ class HeartbeatPresence:
     Node of Giskard, which the heartbeat topic is named after.
     """
 
-    timeout: timedelta = timedelta(seconds=1)
+    timeout: timedelta = timedelta(seconds=3)
     """
     Time without a heartbeat after which a client counts as gone.
 
@@ -119,7 +119,7 @@ class HeartbeatPresence:
     turn a busy executor into a stopped robot.
     """
 
-    clock: Callable[[], float] = time.monotonic
+    clock: Callable[[], float] = field(default=time.monotonic, kw_only=True, repr=False)
     """
     Reads the time the heartbeats are dated with.
 

--- a/giskardpy/src/giskardpy/middleware/ros2/control_loop.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/control_loop.py
@@ -5,8 +5,10 @@ from typing import List
 
 from giskardpy.executor import Executor
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog
 from giskardpy.middleware.ros2.command_publishing import CommandPublisher
 from giskardpy.middleware.ros2.exceptions import (
+    ClientDisconnectedError,
     ExecutionCanceledException,
     WorldModelModifiedDuringMotionError,
 )
@@ -51,6 +53,11 @@ class ControlLoop:
     Ticked at the end of every cycle, shared with the idle loop of the motion server.
     """
 
+    client_watchdog: ClientWatchdog
+    """
+    Watches the client of the running goal; polled for its disconnect.
+    """
+
     world_updates: IncomingWorldUpdates
     """
     Delivers the world updates of other processes at the start of every cycle.
@@ -74,6 +81,7 @@ class ControlLoop:
         Run cycles until the motion statechart reaches an end motion.
 
         :raises ExecutionCanceledException: If the goal was canceled.
+        :raises ClientDisconnectedError: If the client of the goal disconnected.
         """
         while True:
             self.run_cycle()
@@ -86,12 +94,14 @@ class ControlLoop:
         Synchronize the inputs, compute the next command and publish it.
 
         :raises ExecutionCanceledException: If the goal was canceled.
+        :raises ClientDisconnectedError: If the client of the goal disconnected.
         :raises WorldModelModifiedDuringMotionError: If another process modified the
             world model.
         """
         self.apply_world_updates()
         self.inputs.synchronize()
         self.raise_if_canceled()
+        self.raise_if_client_disconnected()
         self.executor.tick()
         self.publish_commands()
         self.feedback_publisher.publish_if_changed()
@@ -122,6 +132,15 @@ class ControlLoop:
             action_server_name=self.action_server.action_name,
             goal_id=self.action_server.goal_id,
         )
+
+    def raise_if_client_disconnected(self) -> None:
+        """
+        :raises ClientDisconnectedError: If the client that sent the goal is gone.
+        """
+        if not self.client_watchdog.is_client_gone():
+            return
+        self.action_server.loginfo("client disconnected")
+        raise ClientDisconnectedError(client=self.client_watchdog.client)
 
     def publish_commands(self) -> None:
         """

--- a/giskardpy/src/giskardpy/middleware/ros2/exceptions.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/exceptions.py
@@ -12,6 +12,7 @@ from giskardpy.data_types.exceptions import (
     GiskardException,
     SetupException,
 )
+from semantic_digital_twin.adapters.ros.messages import MetaData
 from semantic_digital_twin.world_description.world_entity import Connection
 
 
@@ -82,6 +83,48 @@ class ExecutionCanceledException(ExecutionException):
 
     def suggest_correction(self) -> str:
         return ""
+
+
+@dataclass
+class ClientDisconnectedError(ExecutionException, DontPrintStackTrace):
+    """
+    Raised when the client that sent the running goal disconnected.
+
+    Nobody is waiting for the motion any more, so it is stopped instead of being run to
+    its end.
+    """
+
+    client: MetaData
+    """
+    The client that sent the goal and is now gone.
+    """
+
+    def error_message(self) -> str:
+        return (
+            f"The client '{self.client.node_name}' (process {self.client.process_id}) "
+            f"that sent this goal is gone."
+        )
+
+    def suggest_correction(self) -> str:
+        return "Restart the client and send the goal again."
+
+
+@dataclass
+class NoWatchedClientError(GiskardException):
+    """
+    Raised when a presence check is asked about a client while it watches none.
+    """
+
+    check_type: Type
+    """
+    The check that was asked.
+    """
+
+    def error_message(self) -> str:
+        return f"'{self.check_type.__name__}' is not watching a client."
+
+    def suggest_correction(self) -> str:
+        return "Only ask a check about a client that it started watching."
 
 
 @dataclass

--- a/giskardpy/src/giskardpy/middleware/ros2/exceptions.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/exceptions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import List, Type
 
 from giskardpy.data_types.exceptions import (
-    DontPrintStackTrace,
+    DoesntPrintStackTrace,
     GiskardException,
     SetupException,
 )
@@ -86,7 +86,7 @@ class ExecutionCanceledException(ExecutionException):
 
 
 @dataclass
-class ClientDisconnectedError(ExecutionException, DontPrintStackTrace):
+class ClientDisconnectedError(ExecutionException, DoesntPrintStackTrace):
     """
     Raised when the client that sent the running goal disconnected.
 
@@ -128,7 +128,7 @@ class NoWatchedClientError(GiskardException):
 
 
 @dataclass
-class WorldModelModifiedDuringMotionError(ExecutionException, DontPrintStackTrace):
+class WorldModelModifiedDuringMotionError(ExecutionException, DoesntPrintStackTrace):
     """
     Raised when another process modified the world model while a motion was running.
 
@@ -146,7 +146,7 @@ class WorldModelModifiedDuringMotionError(ExecutionException, DontPrintStackTrac
 
 
 @dataclass
-class RequiredWorldUpdateNotReceivedError(ExecutionException, DontPrintStackTrace):
+class RequiredWorldUpdateNotReceivedError(ExecutionException, DoesntPrintStackTrace):
     """
     Raised when a goal names a change of the client's world that never arrived.
 
@@ -188,7 +188,7 @@ class RequiredWorldUpdateNotReceivedError(ExecutionException, DontPrintStackTrac
 
 
 @dataclass
-class GiskardWorldUpdateNotReceivedError(ExecutionException, DontPrintStackTrace):
+class GiskardWorldUpdateNotReceivedError(ExecutionException, DoesntPrintStackTrace):
     """
     Raised when the changes Giskard made during a goal never reached the client.
 

--- a/giskardpy/src/giskardpy/middleware/ros2/giskard.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/giskard.py
@@ -14,11 +14,7 @@ from giskardpy.data_types.exceptions import NoControlledJointsError
 from giskardpy.executor import Executor
 from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
-from giskardpy.middleware.ros2.client_presence import (
-    ClientWatchdog,
-    GraphPresence,
-    HeartbeatPresence,
-)
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog, HeartbeatPresence
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.feedback_publisher import ActionFeedbackPublisher
 from giskardpy.middleware.ros2.graceful_shutdown import GracefulShutdownSignals
@@ -128,10 +124,7 @@ class Giskard:
             action_name=f"{rospy.node.get_name()}/command", action_type=JsonAction
         )
         client_watchdog = ClientWatchdog(
-            checks=[
-                HeartbeatPresence(node=rospy.get_node()),
-                GraphPresence(node=rospy.get_node(), action_name=action_server.action_name),
-            ]
+            presence=HeartbeatPresence(node=rospy.get_node()),
         )
         feedback_publisher = ActionFeedbackPublisher(
             executor=self.executor, action_server=action_server

--- a/giskardpy/src/giskardpy/middleware/ros2/giskard.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/giskard.py
@@ -14,6 +14,11 @@ from giskardpy.data_types.exceptions import NoControlledJointsError
 from giskardpy.executor import Executor
 from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
+from giskardpy.middleware.ros2.client_presence import (
+    ClientWatchdog,
+    GraphPresence,
+    HeartbeatPresence,
+)
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.feedback_publisher import ActionFeedbackPublisher
 from giskardpy.middleware.ros2.graceful_shutdown import GracefulShutdownSignals
@@ -122,6 +127,12 @@ class Giskard:
         action_server = ActionServerHandler(
             action_name=f"{rospy.node.get_name()}/command", action_type=JsonAction
         )
+        client_watchdog = ClientWatchdog(
+            checks=[
+                HeartbeatPresence(node=rospy.node),
+                GraphPresence(node=rospy.node, action_name=action_server.action_name),
+            ]
+        )
         feedback_publisher = ActionFeedbackPublisher(
             executor=self.executor, action_server=action_server
         )
@@ -133,6 +144,7 @@ class Giskard:
         control_loop = ControlLoop(
             executor=self.executor,
             action_server=action_server,
+            client_watchdog=client_watchdog,
             feedback_publisher=feedback_publisher,
             inputs=WorldStateInputs(world=world),
             cycle_counter=cycle_counter,
@@ -142,6 +154,7 @@ class Giskard:
             executor=self.executor,
             action_server=action_server,
             control_loop=control_loop,
+            client_watchdog=client_watchdog,
             world_updates=world_updates,
             world_synchronizer=self.world_synchronizer,
             feedback_publisher=feedback_publisher,

--- a/giskardpy/src/giskardpy/middleware/ros2/giskard.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/giskard.py
@@ -129,8 +129,8 @@ class Giskard:
         )
         client_watchdog = ClientWatchdog(
             checks=[
-                HeartbeatPresence(node=rospy.node),
-                GraphPresence(node=rospy.node, action_name=action_server.action_name),
+                HeartbeatPresence(node=rospy.get_node()),
+                GraphPresence(node=rospy.get_node(), action_name=action_server.action_name),
             ]
         )
         feedback_publisher = ActionFeedbackPublisher(

--- a/giskardpy/src/giskardpy/middleware/ros2/motion_goal.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/motion_goal.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 from typing_extensions import Self
 
 from krrood.adapters.json_serializer import SubclassJSONSerializer, from_json, to_json
-from semantic_digital_twin.adapters.ros.messages import StreamPosition
+from semantic_digital_twin.adapters.ros.messages import MetaData, StreamPosition
 
 from giskardpy.motion_statechart.motion_statechart import MotionStatechart
 
@@ -29,6 +29,16 @@ class MotionGoal(SubclassJSONSerializer):
     The motion statechart to execute, as json.
     """
 
+    client: MetaData = field(kw_only=True)
+    """
+    Who is waiting for this goal.
+
+    Giskard watches that client while the motion runs and stops the robot once it is
+    gone, so the goal has to say who it belongs to. The action itself cannot tell: rclpy
+    hands the server the sequence number of the request, not the participant that sent
+    it.
+    """
+
     required_position: Optional[StreamPosition] = field(default=None, kw_only=True)
     """
     The position in the client's stream that the world has to contain before the motion
@@ -42,6 +52,7 @@ class MotionGoal(SubclassJSONSerializer):
     def for_motion_statechart(
         cls,
         motion_statechart: MotionStatechart,
+        client: MetaData,
         required_position: Optional[StreamPosition] = None,
     ) -> MotionGoal:
         """
@@ -49,6 +60,7 @@ class MotionGoal(SubclassJSONSerializer):
         """
         return cls(
             motion_statechart_json_data=motion_statechart.to_json(),
+            client=client,
             required_position=required_position,
         )
 
@@ -56,6 +68,7 @@ class MotionGoal(SubclassJSONSerializer):
         return {
             **super().to_json(),
             "motion_statechart": self.motion_statechart_json_data,
+            "client": to_json(self.client),
             "required_position": (
                 None
                 if self.required_position is None
@@ -71,6 +84,7 @@ class MotionGoal(SubclassJSONSerializer):
         required_position = data.get("required_position")
         return cls(
             motion_statechart_json_data=data["motion_statechart"],
+            client=from_json(data["client"]),
             required_position=(
                 None if required_position is None else from_json(required_position)
             ),

--- a/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
@@ -13,8 +13,10 @@ from giskardpy.data_types.exceptions import DontPrintStackTrace
 from giskardpy.executor import Executor, RealTimePacer
 from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.exceptions import (
+    ClientDisconnectedError,
     ExecutionCanceledException,
     RequiredWorldUpdateNotReceivedError,
 )
@@ -56,6 +58,12 @@ class MotionServer:
     control_loop: ControlLoop
     """
     Executes a compiled motion statechart.
+    """
+
+    client_watchdog: ClientWatchdog
+    """
+    Watches the client of the running goal, so that a motion nobody waits for any more
+    is stopped instead of run to its end.
     """
 
     world_updates: IncomingWorldUpdates
@@ -164,6 +172,7 @@ class MotionServer:
         error: Exception | None = None
         try:
             goal = MotionGoal.from_json(json.loads(self.action_server.goal_msg.goal))
+            self.client_watchdog.watch(goal.client)
             self.wait_for_required_world_updates(goal.required_position)
             self.compile_goal(goal)
             self.control_loop.run()
@@ -182,8 +191,13 @@ class MotionServer:
         """
         Wait until the world contains the change the goal was built on.
 
+        The change is the one the client published, so a client that left is never going
+        to deliver it and waiting out the timeout would only delay the answer.
+
         :raises RequiredWorldUpdateNotReceivedError: If that change does not arrive
             within ``world_update_timeout``.
+        :raises ClientDisconnectedError: If the client of the goal disconnects while its
+            change is awaited.
         """
         if required_position is None:
             return
@@ -192,6 +206,8 @@ class MotionServer:
             self.world_updates.apply_all()
             if self.world_updates.has_applied(required_position):
                 return
+            if self.client_watchdog.is_client_gone():
+                raise ClientDisconnectedError(client=self.client_watchdog.client)
             if time.monotonic() >= deadline:
                 raise RequiredWorldUpdateNotReceivedError(
                     current_sequence_number=self.world_synchronizer.published_sequence_number,
@@ -224,6 +240,7 @@ class MotionServer:
         here cannot make it wait forever.
         """
         try:
+            self.client_watchdog.stop_watching()
             self.control_loop.stop()
             if self.executor.motion_statechart is not None:
                 self.executor.motion_statechart.cleanup_nodes(

--- a/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/motion_server.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 import rclpy
 from json_msgs.action import JsonAction
 
-from giskardpy.data_types.exceptions import DontPrintStackTrace
+from giskardpy.data_types.exceptions import DoesntPrintStackTrace
 from giskardpy.executor import Executor, RealTimePacer
 from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import ActionServerHandler
@@ -178,7 +178,7 @@ class MotionServer:
             self.control_loop.run()
         except Exception as exception:
             if not isinstance(
-                exception, (DontPrintStackTrace, ExecutionCanceledException)
+                exception, (DoesntPrintStackTrace, ExecutionCanceledException)
             ):
                 traceback.print_exc()
             error = exception

--- a/giskardpy/src/giskardpy/middleware/ros2/python_interface.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/python_interface.py
@@ -10,6 +10,7 @@ import rclpy
 from json_msgs.action import JsonAction
 from json_msgs.action._json_action import JsonAction_Result
 from giskardpy.middleware.ros2 import rospy
+from giskardpy.middleware.ros2.client_presence import ClientHeartbeatPublisher
 from giskardpy.middleware.ros2.exceptions import NoActiveGoalToCancelError
 from giskardpy.middleware.ros2.motion_goal import MotionGoal
 from giskardpy.middleware.ros2.ros2_interface import MyActionClient
@@ -23,6 +24,7 @@ from rclpy import Context, Parameter, Future
 from rclpy.action.client import ClientGoalHandle
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from semantic_digital_twin.adapters.ros.messages import MetaData
 from semantic_digital_twin.adapters.ros.world_fetcher import fetch_world_from_service
 from semantic_digital_twin.adapters.ros.world_synchronizer import WorldSynchronizer
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
@@ -54,6 +56,11 @@ class GiskardWrapper:
     Keeps this world in step with the world Giskard controls around a goal.
     """
 
+    heartbeat_publisher: ClientHeartbeatPublisher = field(init=False, default=None)
+    """
+    Announces to Giskard that this client is still waiting for its goal.
+    """
+
     _motion_statechart: MotionStatechart | None = field(
         init=False, default=None, repr=False
     )
@@ -69,9 +76,21 @@ class GiskardWrapper:
         self.world_updates = ClientWorldUpdates(
             world_synchronizer=WorldSynchronizer.of_world(self.world)
         )
+        self.heartbeat_publisher = ClientHeartbeatPublisher(
+            node=self.node_handle,
+            client=self.client,
+            giskard_node_name=self.giskard_node_name,
+        )
         giskard_topic = f"{self.giskard_node_name}/command"
         self._client = MyActionClient(self.node_handle, JsonAction, giskard_topic)
         sleep(0.3)
+
+    @property
+    def client(self) -> MetaData:
+        """
+        Who this client is, as it names itself in its goals and its heartbeats.
+        """
+        return self.world_updates.world_synchronizer.meta_data
 
     @property
     def robot_name(self) -> PrefixedName:
@@ -137,6 +156,7 @@ class GiskardWrapper:
         goal_msg = JsonAction.Goal()
         goal = MotionGoal.for_motion_statechart(
             motion_statechart,
+            client=self.client,
             required_position=self.world_updates.required_position(),
         )
         goal_msg.goal = json.dumps(goal.to_json())

--- a/giskardpy/src/giskardpy/qp/exceptions.py
+++ b/giskardpy/src/giskardpy/qp/exceptions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 from typing_extensions import TYPE_CHECKING, Type
 
-from giskardpy.data_types.exceptions import GiskardException, DontPrintStackTrace
+from giskardpy.data_types.exceptions import GiskardException, DoesntPrintStackTrace
 
 if TYPE_CHECKING:
     from giskardpy.qp.constraint import GiskardConstraint
@@ -128,7 +128,7 @@ class HardConstraintsViolatedException(InfeasibleException):
 
 
 @dataclass
-class EmptyProblemException(InfeasibleException, DontPrintStackTrace):
+class EmptyProblemException(InfeasibleException, DoesntPrintStackTrace):
     """
     Raised when the QP problem has no free variables.
     """

--- a/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
@@ -170,7 +170,7 @@ class TestHeartbeatPresence:
         presence.receive_heartbeat(heartbeat_of(client))
         presence.start_watching(client)
 
-        clock.advance(presence.timeout + 0.01)
+        clock.advance(presence.timeout.total_seconds() + 0.01)
 
         assert not presence.is_client_present()
 
@@ -184,7 +184,7 @@ class TestHeartbeatPresence:
         presence.start_watching(client)
 
         for _ in range(5):
-            clock.advance(presence.timeout)
+            clock.advance(presence.timeout.total_seconds())
             presence.receive_heartbeat(heartbeat_of(client))
 
         assert presence.is_client_present()

--- a/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+import pytest
+import rclpy
+import std_msgs.msg
+from rclpy.node import Node
+
+from giskardpy.middleware.ros2.client_presence import (
+    ClientHeartbeatPublisher,
+    ClientPresence,
+    ClientWatchdog,
+    GraphPresence,
+    HeartbeatPresence,
+)
+from giskardpy.middleware.ros2.exceptions import NoWatchedClientError
+from krrood.adapters.json_serializer import to_json
+from semantic_digital_twin.adapters.ros.messages import MetaData
+
+# %% helpers
+
+
+@dataclass
+class SteppingClock:
+    """
+    A clock that only moves when a test moves it.
+    """
+
+    now: float = 0.0
+    """
+    The time this clock currently reads.
+    """
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        """
+        Let the given number of seconds pass.
+        """
+        self.now += seconds
+
+
+def wait_until(condition: Callable[[], bool], timeout: float = 5.0) -> bool:
+    """
+    Give the ros graph time to catch up with what a test just did.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(0.01)
+    return condition()
+
+
+def create_client(node_name: str = "some_client") -> MetaData:
+    """
+    The identity a client names itself with.
+    """
+    return MetaData(node_name=node_name, process_id=1234)
+
+
+def heartbeat_of(client: MetaData) -> std_msgs.msg.String:
+    """
+    The message that client sends to announce itself.
+    """
+    return std_msgs.msg.String(data=json.dumps(to_json(client)))
+
+
+@dataclass
+class KnownClientPresence(ClientPresence):
+    """
+    Stands in for a check that recognizes one client and is told whether it is there.
+    """
+
+    known_client: Optional[MetaData] = None
+    """
+    The only client this check recognizes.
+    """
+
+    present: bool = True
+    """
+    What this check reports about the watched client.
+    """
+
+    def start_watching(self, client: MetaData) -> bool:
+        if client != self.known_client:
+            return False
+        self.watched_client = client
+        return True
+
+    def is_client_present(self) -> bool:
+        return self.present
+
+
+@dataclass
+class UnknownClientPresence(ClientPresence):
+    """
+    Stands in for a check that recognizes no client at all.
+    """
+
+    asked_about: List[MetaData] = field(default_factory=list)
+    """
+    Every client this check was offered.
+    """
+
+    def start_watching(self, client: MetaData) -> bool:
+        self.asked_about.append(client)
+        return False
+
+    def is_client_present(self) -> bool:
+        return False
+
+
+# %% the heartbeats a client sends
+
+
+class TestClientHeartbeat:
+    """
+    The heartbeat has to reach Giskard, which means both sides have to agree on where it
+    is sent and what it says.
+    """
+
+    def test_giskard_receives_the_heartbeat_of_a_client(self, rclpy_node: Node):
+        presence = HeartbeatPresence(node=rclpy_node)
+        client_node = rclpy.create_node("heartbeat_sender")
+        client = MetaData(node_name=client_node.get_name(), process_id=7)
+        publisher = ClientHeartbeatPublisher(
+            node=client_node,
+            client=client,
+            giskard_node_name=rclpy_node.get_name(),
+        )
+        try:
+            assert wait_until(
+                lambda: publisher.publish() or client in presence.last_heartbeat
+            )
+        finally:
+            publisher.stop()
+            client_node.destroy_node()
+
+        assert presence.start_watching(client)
+        assert presence.is_client_present()
+
+
+# %% reading the heartbeats
+
+
+class TestHeartbeatPresence:
+    """
+    A client counts as gone once its heartbeats stop arriving.
+    """
+
+    def test_a_client_that_just_announced_itself_is_present(self, rclpy_node: Node):
+        clock = SteppingClock()
+        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        client = create_client()
+        presence.receive_heartbeat(heartbeat_of(client))
+
+        assert presence.start_watching(client)
+        assert presence.is_client_present()
+
+    def test_a_client_that_stopped_announcing_itself_is_gone(self, rclpy_node: Node):
+        clock = SteppingClock()
+        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        client = create_client()
+        presence.receive_heartbeat(heartbeat_of(client))
+        presence.start_watching(client)
+
+        clock.advance(presence.timeout + 0.01)
+
+        assert not presence.is_client_present()
+
+    def test_a_client_stays_present_while_it_keeps_announcing_itself(
+        self, rclpy_node: Node
+    ):
+        clock = SteppingClock()
+        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        client = create_client()
+        presence.receive_heartbeat(heartbeat_of(client))
+        presence.start_watching(client)
+
+        for _ in range(5):
+            clock.advance(presence.timeout)
+            presence.receive_heartbeat(heartbeat_of(client))
+
+        assert presence.is_client_present()
+
+    def test_a_client_that_never_announced_itself_is_not_watched(
+        self, rclpy_node: Node
+    ):
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
+
+        assert not presence.start_watching(create_client())
+
+    def test_the_heartbeat_of_one_client_says_nothing_about_another(
+        self, rclpy_node: Node
+    ):
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
+        presence.receive_heartbeat(heartbeat_of(create_client("other_client")))
+
+        assert not presence.start_watching(create_client("some_client"))
+
+    def test_a_check_that_watches_nothing_cannot_be_asked(self, rclpy_node: Node):
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
+
+        with pytest.raises(NoWatchedClientError):
+            presence.is_client_present()
+
+
+# %% watching the ros graph
+
+
+class TestGraphPresence:
+    """
+    A client that sends no heartbeat is watched through the subscriptions its action
+    client keeps on the feedback of the action.
+    """
+
+    action_name = "mimic_giskard/command"
+    """
+    The action whose clients are watched.
+    """
+
+    def create_feedback_subscriber(self, node_name: str) -> Node:
+        """
+        A node that listens to the feedback of the action, the way an action client
+        does.
+        """
+        node = rclpy.create_node(node_name)
+        node.create_subscription(
+            std_msgs.msg.String,
+            topic=f"{self.action_name}/_action/feedback",
+            callback=lambda message: None,
+            qos_profile=10,
+        )
+        return node
+
+    def test_a_subscribed_client_is_present(self, rclpy_node: Node):
+        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
+        client_node = self.create_feedback_subscriber("graph_watched_client")
+        client = MetaData(node_name=client_node.get_name(), process_id=7)
+        try:
+            assert wait_until(lambda: presence.start_watching(client))
+
+            assert presence.is_client_present()
+        finally:
+            client_node.destroy_node()
+
+    def test_a_client_that_unsubscribed_is_gone(self, rclpy_node: Node):
+        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
+        client_node = self.create_feedback_subscriber("graph_leaving_client")
+        client = MetaData(node_name=client_node.get_name(), process_id=7)
+        assert wait_until(lambda: presence.start_watching(client))
+
+        client_node.destroy_node()
+
+        assert wait_until(lambda: not presence.is_client_present())
+
+    def test_a_client_that_is_not_subscribed_is_not_watched(self, rclpy_node: Node):
+        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
+
+        assert not presence.start_watching(create_client("never_subscribed_client"))
+
+    def test_a_namesake_of_the_dead_client_does_not_pass_as_the_dead_client(
+        self, rclpy_node: Node
+    ):
+        """
+        A client that is restarted under the same node name is a different client, and
+        the goal of the one that died is still nobody's.
+        """
+        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
+        client_node = self.create_feedback_subscriber("graph_restarted_client")
+        client = MetaData(node_name=client_node.get_name(), process_id=7)
+        assert wait_until(lambda: presence.start_watching(client))
+        client_node.destroy_node()
+        assert wait_until(lambda: not presence.is_client_present())
+
+        namesake = self.create_feedback_subscriber("graph_restarted_client")
+        try:
+            assert wait_until(
+                lambda: bool(presence.subscribed_endpoints_of(client)), timeout=2.0
+            )
+
+            assert not presence.is_client_present()
+        finally:
+            namesake.destroy_node()
+
+
+# %% watching the client of a goal
+
+
+class TestClientWatchdog:
+    """
+    The watchdog reports on the client of the running goal, using whichever check knows
+    that client.
+    """
+
+    def test_the_first_check_that_recognizes_the_client_is_used(self):
+        client = create_client()
+        heartbeat_like = KnownClientPresence(known_client=client)
+        graph_like = KnownClientPresence(known_client=client)
+        watchdog = ClientWatchdog(checks=[heartbeat_like, graph_like])
+
+        watchdog.watch(client)
+
+        assert watchdog.watching is heartbeat_like
+        assert graph_like.watched_client is None
+
+    def test_a_client_the_first_check_does_not_know_falls_through(self):
+        client = create_client()
+        unknown = UnknownClientPresence()
+        known = KnownClientPresence(known_client=client)
+        watchdog = ClientWatchdog(checks=[unknown, known])
+
+        watchdog.watch(client)
+
+        assert watchdog.watching is known
+        assert unknown.asked_about == [client]
+
+    def test_a_client_no_check_knows_is_never_reported_gone(self):
+        """
+        Stopping a goal because nothing recognized its client would break every client
+        that Giskard simply cannot see.
+        """
+        watchdog = ClientWatchdog(checks=[UnknownClientPresence()])
+
+        watchdog.watch(create_client())
+
+        assert watchdog.watching is None
+        assert not watchdog.is_client_gone()
+
+    def test_a_client_that_left_is_reported_gone(self):
+        client = create_client()
+        check = KnownClientPresence(known_client=client)
+        watchdog = ClientWatchdog(checks=[check])
+        watchdog.watch(client)
+
+        check.present = False
+
+        assert watchdog.is_client_gone()
+        assert watchdog.client == client
+
+    def test_a_finished_goal_releases_its_check(self):
+        client = create_client()
+        check = KnownClientPresence(known_client=client)
+        watchdog = ClientWatchdog(checks=[check])
+        watchdog.watch(client)
+
+        watchdog.stop_watching()
+
+        assert watchdog.watching is None
+        assert check.watched_client is None
+        assert not watchdog.is_client_gone()
+
+    def test_the_client_of_no_goal_cannot_be_asked_for(self):
+        watchdog = ClientWatchdog(checks=[])
+
+        with pytest.raises(NoWatchedClientError):
+            watchdog.client

--- a/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
@@ -116,8 +116,7 @@ class TestHeartbeatPresence:
     """
 
     def test_a_client_that_just_announced_itself_is_present(self, rclpy_node: Node):
-        clock = SteppingClock()
-        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
         client = create_client()
         presence.receive_heartbeat(heartbeat_of(client))
 
@@ -137,14 +136,13 @@ class TestHeartbeatPresence:
     def test_a_client_stays_present_while_it_keeps_announcing_itself(
         self, rclpy_node: Node
     ):
-        clock = SteppingClock()
-        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
         client = create_client()
         presence.receive_heartbeat(heartbeat_of(client))
         presence.start_watching(client)
 
         for _ in range(5):
-            clock.advance(presence.timeout.total_seconds())
+            presence.clock.advance(presence.timeout.total_seconds())
             presence.receive_heartbeat(heartbeat_of(client))
 
         assert presence.is_client_present()

--- a/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_client_presence.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from dataclasses import dataclass
+from typing import Callable
 
 import pytest
 import rclpy
@@ -12,9 +12,7 @@ from rclpy.node import Node
 
 from giskardpy.middleware.ros2.client_presence import (
     ClientHeartbeatPublisher,
-    ClientPresence,
     ClientWatchdog,
-    GraphPresence,
     HeartbeatPresence,
 )
 from giskardpy.middleware.ros2.exceptions import NoWatchedClientError
@@ -71,49 +69,12 @@ def heartbeat_of(client: MetaData) -> std_msgs.msg.String:
     return std_msgs.msg.String(data=json.dumps(to_json(client)))
 
 
-@dataclass
-class KnownClientPresence(ClientPresence):
+def let_heartbeats_stop(presence: HeartbeatPresence) -> None:
     """
-    Stands in for a check that recognizes one client and is told whether it is there.
+    Advance a presence check's clock past its timeout, as if its client's heartbeats had
+    stopped arriving.
     """
-
-    known_client: Optional[MetaData] = None
-    """
-    The only client this check recognizes.
-    """
-
-    present: bool = True
-    """
-    What this check reports about the watched client.
-    """
-
-    def start_watching(self, client: MetaData) -> bool:
-        if client != self.known_client:
-            return False
-        self.watched_client = client
-        return True
-
-    def is_client_present(self) -> bool:
-        return self.present
-
-
-@dataclass
-class UnknownClientPresence(ClientPresence):
-    """
-    Stands in for a check that recognizes no client at all.
-    """
-
-    asked_about: List[MetaData] = field(default_factory=list)
-    """
-    Every client this check was offered.
-    """
-
-    def start_watching(self, client: MetaData) -> bool:
-        self.asked_about.append(client)
-        return False
-
-    def is_client_present(self) -> bool:
-        return False
+    presence.clock.advance(presence.timeout.total_seconds() + 0.01)
 
 
 # %% the heartbeats a client sends
@@ -164,13 +125,12 @@ class TestHeartbeatPresence:
         assert presence.is_client_present()
 
     def test_a_client_that_stopped_announcing_itself_is_gone(self, rclpy_node: Node):
-        clock = SteppingClock()
-        presence = HeartbeatPresence(node=rclpy_node, clock=clock)
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
         client = create_client()
         presence.receive_heartbeat(heartbeat_of(client))
         presence.start_watching(client)
 
-        clock.advance(presence.timeout.total_seconds() + 0.01)
+        let_heartbeats_stop(presence)
 
         assert not presence.is_client_present()
 
@@ -211,153 +171,54 @@ class TestHeartbeatPresence:
             presence.is_client_present()
 
 
-# %% watching the ros graph
-
-
-class TestGraphPresence:
-    """
-    A client that sends no heartbeat is watched through the subscriptions its action
-    client keeps on the feedback of the action.
-    """
-
-    action_name = "mimic_giskard/command"
-    """
-    The action whose clients are watched.
-    """
-
-    def create_feedback_subscriber(self, node_name: str) -> Node:
-        """
-        A node that listens to the feedback of the action, the way an action client
-        does.
-        """
-        node = rclpy.create_node(node_name)
-        node.create_subscription(
-            std_msgs.msg.String,
-            topic=f"{self.action_name}/_action/feedback",
-            callback=lambda message: None,
-            qos_profile=10,
-        )
-        return node
-
-    def test_a_subscribed_client_is_present(self, rclpy_node: Node):
-        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
-        client_node = self.create_feedback_subscriber("graph_watched_client")
-        client = MetaData(node_name=client_node.get_name(), process_id=7)
-        try:
-            assert wait_until(lambda: presence.start_watching(client))
-
-            assert presence.is_client_present()
-        finally:
-            client_node.destroy_node()
-
-    def test_a_client_that_unsubscribed_is_gone(self, rclpy_node: Node):
-        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
-        client_node = self.create_feedback_subscriber("graph_leaving_client")
-        client = MetaData(node_name=client_node.get_name(), process_id=7)
-        assert wait_until(lambda: presence.start_watching(client))
-
-        client_node.destroy_node()
-
-        assert wait_until(lambda: not presence.is_client_present())
-
-    def test_a_client_that_is_not_subscribed_is_not_watched(self, rclpy_node: Node):
-        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
-
-        assert not presence.start_watching(create_client("never_subscribed_client"))
-
-    def test_a_namesake_of_the_dead_client_does_not_pass_as_the_dead_client(
-        self, rclpy_node: Node
-    ):
-        """
-        A client that is restarted under the same node name is a different client, and
-        the goal of the one that died is still nobody's.
-        """
-        presence = GraphPresence(node=rclpy_node, action_name=self.action_name)
-        client_node = self.create_feedback_subscriber("graph_restarted_client")
-        client = MetaData(node_name=client_node.get_name(), process_id=7)
-        assert wait_until(lambda: presence.start_watching(client))
-        client_node.destroy_node()
-        assert wait_until(lambda: not presence.is_client_present())
-
-        namesake = self.create_feedback_subscriber("graph_restarted_client")
-        try:
-            assert wait_until(
-                lambda: bool(presence.subscribed_endpoints_of(client)), timeout=2.0
-            )
-
-            assert not presence.is_client_present()
-        finally:
-            namesake.destroy_node()
-
-
 # %% watching the client of a goal
 
 
 class TestClientWatchdog:
     """
-    The watchdog reports on the client of the running goal, using whichever check knows
-    that client.
+    The watchdog reports on the client of the running goal, through its presence check.
     """
 
-    def test_the_first_check_that_recognizes_the_client_is_used(self):
-        client = create_client()
-        heartbeat_like = KnownClientPresence(known_client=client)
-        graph_like = KnownClientPresence(known_client=client)
-        watchdog = ClientWatchdog(checks=[heartbeat_like, graph_like])
-
-        watchdog.watch(client)
-
-        assert watchdog.watching is heartbeat_like
-        assert graph_like.watched_client is None
-
-    def test_a_client_the_first_check_does_not_know_falls_through(self):
-        client = create_client()
-        unknown = UnknownClientPresence()
-        known = KnownClientPresence(known_client=client)
-        watchdog = ClientWatchdog(checks=[unknown, known])
-
-        watchdog.watch(client)
-
-        assert watchdog.watching is known
-        assert unknown.asked_about == [client]
-
-    def test_a_client_no_check_knows_is_never_reported_gone(self):
+    def test_a_client_the_presence_check_does_not_recognize_is_never_reported_gone(
+        self, rclpy_node: Node
+    ):
         """
-        Stopping a goal because nothing recognized its client would break every client
-        that Giskard simply cannot see.
+        Stopping a goal because the presence check does not recognize its client would
+        break every client that Giskard simply cannot see.
         """
-        watchdog = ClientWatchdog(checks=[UnknownClientPresence()])
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
+        watchdog = ClientWatchdog(presence=presence)
 
         watchdog.watch(create_client())
 
-        assert watchdog.watching is None
         assert not watchdog.is_client_gone()
 
-    def test_a_client_that_left_is_reported_gone(self):
+    def test_a_client_that_left_is_reported_gone(self, rclpy_node: Node):
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
         client = create_client()
-        check = KnownClientPresence(known_client=client)
-        watchdog = ClientWatchdog(checks=[check])
+        presence.receive_heartbeat(heartbeat_of(client))
+        watchdog = ClientWatchdog(presence=presence)
         watchdog.watch(client)
 
-        check.present = False
+        let_heartbeats_stop(presence)
 
         assert watchdog.is_client_gone()
         assert watchdog.client == client
 
-    def test_a_finished_goal_releases_its_check(self):
+    def test_a_finished_goal_releases_its_check(self, rclpy_node: Node):
+        presence = HeartbeatPresence(node=rclpy_node, clock=SteppingClock())
         client = create_client()
-        check = KnownClientPresence(known_client=client)
-        watchdog = ClientWatchdog(checks=[check])
+        presence.receive_heartbeat(heartbeat_of(client))
+        watchdog = ClientWatchdog(presence=presence)
         watchdog.watch(client)
 
         watchdog.stop_watching()
 
-        assert watchdog.watching is None
-        assert check.watched_client is None
+        assert presence.watched_client is None
         assert not watchdog.is_client_gone()
 
-    def test_the_client_of_no_goal_cannot_be_asked_for(self):
-        watchdog = ClientWatchdog(checks=[])
+    def test_the_client_of_no_goal_cannot_be_asked_for(self, rclpy_node: Node):
+        watchdog = ClientWatchdog(presence=HeartbeatPresence(node=rclpy_node))
 
         with pytest.raises(NoWatchedClientError):
             watchdog.client

--- a/test/giskardpy_test/test_ros2_stuff/test_integration_pr2.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_integration_pr2.py
@@ -14,6 +14,7 @@ import semantic_digital_twin.spatial_types.spatial_types as cas
 from giskardpy.data_types.exceptions import (
     MaxTrajectoryLengthException,
 )
+from giskardpy.middleware.ros2.client_presence import GraphPresence
 from giskardpy.middleware.ros2.server_config import ExecutionMode, GiskardServerConfig
 from giskardpy.middleware.ros2.scripts.iai_robots.pr2.configs import (
     PR2StandaloneInterface,
@@ -63,6 +64,7 @@ from giskardpy.motion_statechart.tasks.joint_tasks import (
 from giskardpy.motion_statechart.tasks.pointing import Pointing
 from giskardpy.qp.qp_controller_config import QPControllerConfig
 from giskardpy.middleware.ros2.exceptions import (
+    ClientDisconnectedError,
     ExecutionCanceledException,
     ExecutionAbortedException,
     WorldModelModifiedDuringMotionError,
@@ -90,6 +92,8 @@ from semantic_digital_twin.world_description.world_entity import (
     Body,
     KinematicStructureEntity,
 )
+
+from .test_client_presence import wait_until
 
 
 @dataclass
@@ -1873,6 +1877,49 @@ class TestActionServerEvents:
 
         with pytest.raises(ExecutionCanceledException):
             await giskard.api.get_result()
+
+    @pytest.mark.asyncio
+    async def test_a_goal_whose_client_stops_announcing_itself_is_aborted(
+        self, giskard: PR2Tester
+    ):
+        """
+        Nobody is waiting for a motion whose client died, so it is stopped instead of
+        being driven to its end.
+        """
+        msc = MotionStatechart()
+        msc.add_node(
+            CartesianPose(
+                root_link=giskard.map,
+                tip_link=giskard.base_footprint,
+                goal_pose=HomogeneousTransformationMatrix.from_xyz_rpy(
+                    x=0.5, reference_frame=giskard.base_footprint
+                ),
+            )
+        )
+        goal_accepted_future = giskard.api.execute_async(msc)
+        wait_for_future_to_complete(goal_accepted_future)
+        await asyncio.sleep(2)
+
+        giskard.api.heartbeat_publisher.stop()
+
+        with pytest.raises(ClientDisconnectedError) as disconnect:
+            await giskard.api.get_result()
+        assert disconnect.value.client == giskard.api.client
+
+    def test_giskard_finds_the_action_client_of_a_client_in_the_ros_graph(
+        self, giskard: PR2Tester
+    ):
+        """
+        A client that sends no heartbeat is watched through the subscriptions its action
+        client keeps, so the check has to look at the topic of the real action.
+        """
+        graph_check = next(
+            check
+            for check in giskard.giskard.motion_server.client_watchdog.checks
+            if isinstance(check, GraphPresence)
+        )
+
+        assert wait_until(lambda: graph_check.start_watching(giskard.api.client))
 
     def test_empty_goal(self, giskard: PR2Tester):
         with pytest.raises(EmptyMotionStatechartError):

--- a/test/giskardpy_test/test_ros2_stuff/test_integration_pr2.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_integration_pr2.py
@@ -14,7 +14,6 @@ import semantic_digital_twin.spatial_types.spatial_types as cas
 from giskardpy.data_types.exceptions import (
     MaxTrajectoryLengthException,
 )
-from giskardpy.middleware.ros2.client_presence import GraphPresence
 from giskardpy.middleware.ros2.server_config import ExecutionMode, GiskardServerConfig
 from giskardpy.middleware.ros2.scripts.iai_robots.pr2.configs import (
     PR2StandaloneInterface,
@@ -92,8 +91,6 @@ from semantic_digital_twin.world_description.world_entity import (
     Body,
     KinematicStructureEntity,
 )
-
-from .test_client_presence import wait_until
 
 
 @dataclass
@@ -1905,21 +1902,6 @@ class TestActionServerEvents:
         with pytest.raises(ClientDisconnectedError) as disconnect:
             await giskard.api.get_result()
         assert disconnect.value.client == giskard.api.client
-
-    def test_giskard_finds_the_action_client_of_a_client_in_the_ros_graph(
-        self, giskard: PR2Tester
-    ):
-        """
-        A client that sends no heartbeat is watched through the subscriptions its action
-        client keeps, so the check has to look at the topic of the real action.
-        """
-        graph_check = next(
-            check
-            for check in giskard.giskard.motion_server.client_watchdog.checks
-            if isinstance(check, GraphPresence)
-        )
-
-        assert wait_until(lambda: graph_check.start_watching(giskard.api.client))
 
     def test_empty_goal(self, giskard: PR2Tester):
         with pytest.raises(EmptyMotionStatechartError):

--- a/test/giskardpy_test/test_ros2_stuff/test_motion_goal.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_motion_goal.py
@@ -11,6 +11,13 @@ from semantic_digital_twin.adapters.ros.messages import MetaData, StreamPosition
 # %% the payload a client sends
 
 
+def create_client() -> MetaData:
+    """
+    The identity a client names itself with.
+    """
+    return MetaData(node_name="client", process_id=3)
+
+
 def create_motion_statechart() -> MotionStatechart:
     """
     Build a motion statechart that ends after some simulated time.
@@ -29,18 +36,34 @@ class TestMotionGoalPayload:
 
     def test_the_motion_statechart_survives_the_round_trip(self):
         motion_statechart = create_motion_statechart()
-        goal = MotionGoal.for_motion_statechart(motion_statechart)
+        goal = MotionGoal.for_motion_statechart(
+            motion_statechart, client=create_client()
+        )
 
         restored = MotionGoal.from_json(json.loads(json.dumps(goal.to_json())))
 
         assert restored.motion_statechart_json_data == motion_statechart.to_json()
 
-    def test_a_goal_built_on_a_change_names_it(self):
-        position = StreamPosition(
-            origin=MetaData(node_name="client", process_id=3), sequence_number=11
-        )
+    def test_a_goal_names_the_client_that_waits_for_it(self):
+        """
+        Giskard stops a motion whose client is gone, which it can only do for a client
+        the goal names.
+        """
+        client = create_client()
         goal = MotionGoal.for_motion_statechart(
-            create_motion_statechart(), required_position=position
+            create_motion_statechart(), client=client
+        )
+
+        restored = MotionGoal.from_json(json.loads(json.dumps(goal.to_json())))
+
+        assert restored.client == client
+
+    def test_a_goal_built_on_a_change_names_it(self):
+        position = StreamPosition(origin=create_client(), sequence_number=11)
+        goal = MotionGoal.for_motion_statechart(
+            create_motion_statechart(),
+            client=create_client(),
+            required_position=position,
         )
 
         restored = MotionGoal.from_json(json.loads(json.dumps(goal.to_json())))
@@ -48,7 +71,9 @@ class TestMotionGoalPayload:
         assert restored.required_position == position
 
     def test_a_goal_built_on_nothing_requires_nothing(self):
-        goal = MotionGoal.for_motion_statechart(create_motion_statechart())
+        goal = MotionGoal.for_motion_statechart(
+            create_motion_statechart(), client=create_client()
+        )
 
         restored = MotionGoal.from_json(json.loads(json.dumps(goal.to_json())))
 

--- a/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
@@ -5,8 +5,9 @@ from typing import Any, List, Optional
 import pytest
 
 from giskardpy.executor import Executor, NoPacing
+from giskardpy.middleware.ros2 import rospy
 from giskardpy.middleware.ros2.action_server import GoalOutcome
-from giskardpy.middleware.ros2.client_presence import ClientWatchdog
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog, HeartbeatPresence
 from giskardpy.middleware.ros2.command_publishing import CommandPublisher
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.exceptions import (
@@ -36,7 +37,7 @@ from semantic_digital_twin.adapters.ros.messages import MetaData, StreamPosition
 from semantic_digital_twin.callbacks.callback import StateChangeCallback
 from semantic_digital_twin.world import World
 
-from .test_client_presence import KnownClientPresence
+from .test_client_presence import SteppingClock, heartbeat_of, let_heartbeats_stop
 
 # %% mimics of the ros facing collaborators
 
@@ -383,7 +384,7 @@ class CycleWatchingClientDisconnector(InputSynchronizer):
     The counter that is watched.
     """
 
-    client_presence: Optional[KnownClientPresence] = None
+    client_presence: Optional[HeartbeatPresence] = None
     """
     The check that stops reporting the client as present.
     """
@@ -393,9 +394,17 @@ class CycleWatchingClientDisconnector(InputSynchronizer):
     How many ticks to observe before the client leaves.
     """
 
+    disconnected: bool = field(init=False, default=False)
+    """
+    Whether the client's heartbeats have already been let to stop.
+    """
+
     def apply(self) -> bool:
-        if self.cycle_counter.completed_cycles >= self.ticks_until_disconnect:
-            self.client_presence.present = False
+        if not self.disconnected and (
+            self.cycle_counter.completed_cycles >= self.ticks_until_disconnect
+        ):
+            let_heartbeats_stop(self.client_presence)
+            self.disconnected = True
         return False
 
 
@@ -557,7 +566,7 @@ class MotionServerFixture:
     motion_server: MotionServer
     control_loop: ControlLoop
     client: MetaData
-    client_presence: KnownClientPresence
+    client_presence: HeartbeatPresence
     command_publisher: RecordingCommandPublisher
     idle_input: RecordingInputSynchronizer
     control_input: RecordingInputSynchronizer
@@ -578,8 +587,9 @@ def motion_server(init_rospy) -> MotionServerFixture:
     control_input = RecordingInputSynchronizer(world=world, executor=executor)
     cycle_counter = CycleCounter()
     client = MetaData(node_name="watched_client", process_id=1)
-    client_presence = KnownClientPresence(known_client=client)
-    client_watchdog = ClientWatchdog(checks=[client_presence])
+    client_presence = HeartbeatPresence(node=rospy.node, clock=SteppingClock())
+    client_presence.receive_heartbeat(heartbeat_of(client))
+    client_watchdog = ClientWatchdog(presence=client_presence)
     control_loop = ControlLoop(
         executor=executor,
         action_server=action_server,
@@ -1324,29 +1334,6 @@ class TestClientDisconnect:
 
         assert motion_server.command_publisher.stop_count == 1
 
-    def test_a_goal_whose_client_leaves_while_its_change_is_awaited_is_aborted(
-        self, motion_server: MotionServerFixture
-    ):
-        """
-        The change a goal waits for is the one its client published, so a client that
-        left is never going to deliver it.
-        """
-        motion_server.motion_server.world_update_timeout = 100.0
-        motion_server.world_updates.drains_until_caught_up = None
-        motion_server.action_server.goal_json = create_goal_json(
-            required_position=StreamPosition(
-                origin=motion_server.client, sequence_number=4
-            ),
-            client=motion_server.client,
-        )
-        motion_server.client_presence.present = False
-
-        motion_server.motion_server.run_idle_cycle()
-
-        assert motion_server.action_server.outcome == GoalOutcome.ABORTED
-        result = json.loads(motion_server.action_server.sent_results[0].result)
-        assert isinstance(from_json(result["error"]), ClientDisconnectedError)
-
     def test_a_goal_whose_client_stays_runs_to_its_end(
         self, motion_server: MotionServerFixture
     ):
@@ -1365,7 +1352,6 @@ class TestClientDisconnect:
         A client Giskard cannot see is not a client that left.
         """
         motion_server.action_server.goal_json = create_goal_json()
-        motion_server.client_presence.present = False
 
         motion_server.motion_server.run_idle_cycle()
 
@@ -1384,5 +1370,4 @@ class TestClientDisconnect:
 
         motion_server.motion_server.run_idle_cycle()
 
-        assert motion_server.motion_server.client_watchdog.watching is None
         assert motion_server.client_presence.watched_client is None

--- a/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
@@ -587,7 +587,7 @@ def motion_server(init_rospy) -> MotionServerFixture:
     control_input = RecordingInputSynchronizer(world=world, executor=executor)
     cycle_counter = CycleCounter()
     client = MetaData(node_name="watched_client", process_id=1)
-    client_presence = HeartbeatPresence(node=rospy.node, clock=SteppingClock())
+    client_presence = HeartbeatPresence(node=rospy.get_node(), clock=SteppingClock())
     client_presence.receive_heartbeat(heartbeat_of(client))
     client_watchdog = ClientWatchdog(presence=client_presence)
     control_loop = ControlLoop(

--- a/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_motion_server.py
@@ -6,9 +6,11 @@ import pytest
 
 from giskardpy.executor import Executor, NoPacing
 from giskardpy.middleware.ros2.action_server import GoalOutcome
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog
 from giskardpy.middleware.ros2.command_publishing import CommandPublisher
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.exceptions import (
+    ClientDisconnectedError,
     ExecutionCanceledException,
     RequiredWorldUpdateNotReceivedError,
     WorldModelModifiedDuringMotionError,
@@ -33,6 +35,8 @@ from krrood.adapters.json_serializer import from_json
 from semantic_digital_twin.adapters.ros.messages import MetaData, StreamPosition
 from semantic_digital_twin.callbacks.callback import StateChangeCallback
 from semantic_digital_twin.world import World
+
+from .test_client_presence import KnownClientPresence
 
 # %% mimics of the ros facing collaborators
 
@@ -367,6 +371,35 @@ class CycleWatchingGoalCanceler(InputSynchronizer):
 
 
 @dataclass
+class CycleWatchingClientDisconnector(InputSynchronizer):
+    """
+    Watches the completed cycles from inside the control loop and lets the client of the
+    goal disappear once enough of them passed, standing in for a client that dies in the
+    middle of a never-ending motion.
+    """
+
+    cycle_counter: CycleCounter = None
+    """
+    The counter that is watched.
+    """
+
+    client_presence: Optional[KnownClientPresence] = None
+    """
+    The check that stops reporting the client as present.
+    """
+
+    ticks_until_disconnect: int = 5
+    """
+    How many ticks to observe before the client leaves.
+    """
+
+    def apply(self) -> bool:
+        if self.cycle_counter.completed_cycles >= self.ticks_until_disconnect:
+            self.client_presence.present = False
+        return False
+
+
+@dataclass
 class FeedbackCountingSynchronizer(InputSynchronizer):
     """
     Records how much feedback was already published when a control cycle read its
@@ -490,16 +523,23 @@ def feedback_data(message: Any) -> dict:
 
 
 def create_goal_json(
-    seconds: float = 0.5, required_position: Optional[StreamPosition] = None
+    seconds: float = 0.5,
+    required_position: Optional[StreamPosition] = None,
+    client: Optional[MetaData] = None,
 ) -> str:
     """
     Build the json of a goal whose motion ends after the given simulated time.
+
+    A goal that names no client comes from one that no check recognizes, which is what
+    every test that is not about a client leaving wants.
     """
     motion_statechart = MotionStatechart()
     motion_statechart.add_node(counter := CountSimulationTimeSeconds(seconds=seconds))
     motion_statechart.add_node(EndMotion.when_true(counter))
+    if client is None:
+        client = MetaData(node_name="unwatched_client", process_id=0)
     goal = MotionGoal.for_motion_statechart(
-        motion_statechart, required_position=required_position
+        motion_statechart, client=client, required_position=required_position
     )
     return json.dumps(goal.to_json())
 
@@ -516,6 +556,8 @@ class MotionServerFixture:
     publication_progress: PublicationProgressMimic
     motion_server: MotionServer
     control_loop: ControlLoop
+    client: MetaData
+    client_presence: KnownClientPresence
     command_publisher: RecordingCommandPublisher
     idle_input: RecordingInputSynchronizer
     control_input: RecordingInputSynchronizer
@@ -535,9 +577,13 @@ def motion_server(init_rospy) -> MotionServerFixture:
     command_publisher = RecordingCommandPublisher(world=world)
     control_input = RecordingInputSynchronizer(world=world, executor=executor)
     cycle_counter = CycleCounter()
+    client = MetaData(node_name="watched_client", process_id=1)
+    client_presence = KnownClientPresence(known_client=client)
+    client_watchdog = ClientWatchdog(checks=[client_presence])
     control_loop = ControlLoop(
         executor=executor,
         action_server=action_server,
+        client_watchdog=client_watchdog,
         feedback_publisher=feedback_publisher,
         inputs=WorldStateInputs(world=world, synchronizers=[control_input]),
         cycle_counter=cycle_counter,
@@ -551,6 +597,7 @@ def motion_server(init_rospy) -> MotionServerFixture:
         executor=executor,
         action_server=action_server,
         control_loop=control_loop,
+        client_watchdog=client_watchdog,
         world_updates=world_updates,
         world_synchronizer=publication_progress,
         feedback_publisher=feedback_publisher,
@@ -565,6 +612,8 @@ def motion_server(init_rospy) -> MotionServerFixture:
         publication_progress=publication_progress,
         motion_server=server,
         control_loop=control_loop,
+        client=client,
+        client_presence=client_presence,
         command_publisher=command_publisher,
         idle_input=idle_input,
         control_input=control_input,
@@ -1224,3 +1273,116 @@ class TestWaitingForTheWorldOfTheClient:
         assert isinstance(error, RequiredWorldUpdateNotReceivedError)
         assert error.publisher_name == "client"
         assert error.awaited_sequence_number == 4
+
+
+# %% the client of the goal leaving
+
+
+class TestClientDisconnect:
+    """
+    A goal outlives its client for as long as nobody notices, which leaves the robot
+    executing a plan nobody waits for, so a goal whose client left is stopped.
+    """
+
+    def test_a_goal_whose_client_leaves_mid_motion_is_aborted(
+        self, motion_server: MotionServerFixture
+    ):
+        motion_server.action_server.goal_json = create_goal_json(
+            seconds=1000.0, client=motion_server.client
+        )
+        motion_server.control_loop.inputs.synchronizers = [
+            CycleWatchingClientDisconnector(
+                world=motion_server.executor.context.world,
+                cycle_counter=motion_server.cycle_counter,
+                client_presence=motion_server.client_presence,
+            )
+        ]
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.action_server.outcome == GoalOutcome.ABORTED
+        result = json.loads(motion_server.action_server.sent_results[0].result)
+        error = from_json(result["error"])
+        assert isinstance(error, ClientDisconnectedError)
+        assert error.client == motion_server.client
+
+    def test_the_robot_is_stopped_when_its_client_leaves(
+        self, motion_server: MotionServerFixture
+    ):
+        motion_server.action_server.goal_json = create_goal_json(
+            seconds=1000.0, client=motion_server.client
+        )
+        motion_server.control_loop.inputs.synchronizers = [
+            CycleWatchingClientDisconnector(
+                world=motion_server.executor.context.world,
+                cycle_counter=motion_server.cycle_counter,
+                client_presence=motion_server.client_presence,
+            )
+        ]
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.command_publisher.stop_count == 1
+
+    def test_a_goal_whose_client_leaves_while_its_change_is_awaited_is_aborted(
+        self, motion_server: MotionServerFixture
+    ):
+        """
+        The change a goal waits for is the one its client published, so a client that
+        left is never going to deliver it.
+        """
+        motion_server.motion_server.world_update_timeout = 100.0
+        motion_server.world_updates.drains_until_caught_up = None
+        motion_server.action_server.goal_json = create_goal_json(
+            required_position=StreamPosition(
+                origin=motion_server.client, sequence_number=4
+            ),
+            client=motion_server.client,
+        )
+        motion_server.client_presence.present = False
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.action_server.outcome == GoalOutcome.ABORTED
+        result = json.loads(motion_server.action_server.sent_results[0].result)
+        assert isinstance(from_json(result["error"]), ClientDisconnectedError)
+
+    def test_a_goal_whose_client_stays_runs_to_its_end(
+        self, motion_server: MotionServerFixture
+    ):
+        motion_server.action_server.goal_json = create_goal_json(
+            client=motion_server.client
+        )
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.action_server.outcome == GoalOutcome.SUCCEEDED
+
+    def test_a_goal_from_a_client_nothing_recognizes_runs_to_its_end(
+        self, motion_server: MotionServerFixture
+    ):
+        """
+        A client Giskard cannot see is not a client that left.
+        """
+        motion_server.action_server.goal_json = create_goal_json()
+        motion_server.client_presence.present = False
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.action_server.outcome == GoalOutcome.SUCCEEDED
+
+    def test_a_finished_goal_stops_being_watched(
+        self, motion_server: MotionServerFixture
+    ):
+        """
+        The client of a finished goal may leave whenever it wants, and the next goal
+        picks its own client.
+        """
+        motion_server.action_server.goal_json = create_goal_json(
+            client=motion_server.client
+        )
+
+        motion_server.motion_server.run_idle_cycle()
+
+        assert motion_server.motion_server.client_watchdog.watching is None
+        assert motion_server.client_presence.watched_client is None

--- a/test/giskardpy_test/test_ros2_stuff/test_world_updates.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_world_updates.py
@@ -7,7 +7,7 @@ import pytest
 
 from giskardpy.executor import Executor, NoPacing
 from giskardpy.middleware.ros2 import rospy
-from giskardpy.middleware.ros2.client_presence import ClientWatchdog
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog, HeartbeatPresence
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.exceptions import (
     GiskardWorldUpdateNotReceivedError,
@@ -451,7 +451,7 @@ def control_loop(init_rospy) -> ControlLoopFixture:
         control_loop=ControlLoop(
             executor=executor,
             action_server=action_server,
-            client_watchdog=ClientWatchdog(checks=[]),
+            client_watchdog=ClientWatchdog(presence=HeartbeatPresence(node=rospy.get_node())),
             feedback_publisher=ActionFeedbackPublisher(
                 executor=executor, action_server=action_server
             ),

--- a/test/giskardpy_test/test_ros2_stuff/test_world_updates.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_world_updates.py
@@ -7,6 +7,7 @@ import pytest
 
 from giskardpy.executor import Executor, NoPacing
 from giskardpy.middleware.ros2 import rospy
+from giskardpy.middleware.ros2.client_presence import ClientWatchdog
 from giskardpy.middleware.ros2.control_loop import ControlLoop
 from giskardpy.middleware.ros2.exceptions import (
     GiskardWorldUpdateNotReceivedError,
@@ -450,6 +451,7 @@ def control_loop(init_rospy) -> ControlLoopFixture:
         control_loop=ControlLoop(
             executor=executor,
             action_server=action_server,
+            client_watchdog=ClientWatchdog(checks=[]),
             feedback_publisher=ActionFeedbackPublisher(
                 executor=executor, action_server=action_server
             ),


### PR DESCRIPTION
- Adds `client_presence.py`: a heartbeat mechanism where a client periodically announces it is still alive, plus a `ClientWatchdog` that Giskard uses to notice when the client that sent the running goal has gone quiet
- `MotionServer` now starts watching the goal's client when a goal begins and stops watching when it ends; if that client disconnects while its required world update is still being awaited, execution is stopped early with a new `ClientDisconnectedError` instead of running to completion or timing out for no one
- Adds `NoWatchedClientError` (`exceptions.py`) for the case where a presence check is queried before it has started watching a client
- Wires the watchdog through `control_loop`, `motion_goal`, `giskard`, and `python_interface` so clients can send heartbeats and Giskard can react to their absence
- Adds `test_client_presence.py` and extends `test_motion_server.py`, `test_motion_goal.py`, `test_integration_pr2.py`, and `test_world_updates.py` to cover the new behaviour