### PR TITLE
Fix duplicated goal children on motion statechart JSON round trip

### DIFF
--- a/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
+++ b/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
@@ -1199,6 +1199,12 @@ class MotionStatechart(SubclassJSONSerializer):
         :meth:`to_json`: first all nodes, then their transition conditions, then
         goal/child parent links.
 
+        A registered goal serializes each child both in the flat node list and inline
+        (Sequence, Parallel), so its inline copies are dropped the first time a flat
+        child is re-nested; keeping them would list each child twice. A goal whose
+        children only live inline (an unexpanded nested motion chart named by no flat
+        node) is untouched.
+
         :param data: The JSON dict.
         :param kwargs: Forwarded to :func:`~krrood.adapters.json_serializer.from_json`
             for every node.
@@ -1213,12 +1219,15 @@ class MotionStatechart(SubclassJSONSerializer):
                 json_data, motion_statechart=motion_statechart, **kwargs
             )
             transition.owner._set_transition(transition)
+        reparented: set[int] = set()
         for node in motion_statechart.nodes:
-            if node.parent_node_index is not None:
-                parent_node = motion_statechart.get_node_by_index(
-                    node.parent_node_index
-                )
-                parent_node.nodes.append(node)
+            if node.parent_node_index is None:
+                continue
+            parent_node = motion_statechart.get_node_by_index(node.parent_node_index)
+            if node.parent_node_index not in reparented:
+                parent_node.nodes.clear()
+                reparented.add(node.parent_node_index)
+            parent_node.nodes.append(node)
         return motion_statechart
 
     def sanity_check(self):

--- a/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
+++ b/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
@@ -366,6 +366,22 @@ def test_collapsed_goal_survives_json_round_trip():
     assert msc_copy.get_node_by_index(goal.index).plot_specifications.collapse_children
 
 
+def test_goal_children_survive_json_round_trip_exactly_once():
+    msc = MotionStatechart()
+    registered = Sequence(name="registered")
+    msc.add_node(registered)
+    registered.add_node(ConstTrueNode())
+    registered.add_node(ConstTrueNode())
+    inline_only = Sequence([ConstTrueNode(), ConstTrueNode()], name="inline_only")
+    msc.add_node(inline_only)
+    msc.add_node(EndMotion.when_true(registered))
+
+    msc_copy = MotionStatechart.from_json(json.loads(json.dumps(msc.to_json())))
+
+    assert len(msc_copy.get_node_by_index(registered.index).nodes) == 2
+    assert len(msc_copy.get_node_by_index(inline_only.index).nodes) == 2
+
+
 def test_cancel_motion():
     msc = MotionStatechart()
     msc.add_node(node := ConstTrueNode())


### PR DESCRIPTION
  `MotionStatechart._from_json` could return a chart where a goal's children
  appear more than once, multiplying by nesting depth. On deserialization the
  motions then run several times.

  The cause: `Sequence` and `Parallel` declare their `nodes` field `init=True`,
  so they serialize their children inline, while the base `Goal` keeps `nodes`
  `init=False` and builds its children in `expand()`. A registered goal therefore
  carries each child both inline and in the flat node list, and `_from_json`
  re-nested from the flat list on top of the inline copies.

  `_from_json` now drops a goal's inline children the first time one of its flat
  children is re-nested, so each child is attached once. A goal whose children
  only live inline, an unexpanded nested motion chart that no flat node names as
  its parent, is left untouched and keeps them.

  ### Tests

  Added `test_goal_children_survive_json_round_trip_exactly_once`, covering both a
  registered goal (children in the flat list and inline) and an inline-only goal
  built through the constructor. It fails without the fix.
