### PR TITLE
Fix MujocoVideoRecorder.advance_simulation ignoring frames_per_second under many short calls

### DIFF
--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/mujoco_video_recording.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/mujoco_video_recording.py
@@ -261,10 +261,6 @@ class MujocoVideoRecorder:
         steps_per_frame = max(1, round((1.0 / self.frames_per_second) / step_size))
         previous_decimation = self.capture_every_n_state_changes
         self.capture_every_n_state_changes = steps_per_frame
-        # Restart the decimation period cleanly so the first frame of this call lands
-        # exactly steps_per_frame steps in, rather than wherever the previous decimation
-        # period's phase happened to leave off.
-        self._state_change_count = 0
         try:
             for _ in range(max(1, round(duration / step_size))):
                 self._multi_sim.simulator.step()

--- a/test/semantic_digital_twin_test/test_adapters/test_mujoco_video_recording.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_mujoco_video_recording.py
@@ -205,6 +205,39 @@ def test_captured_frame_count_tracks_frames_kept_so_far(ray_test_world):
 
 
 @requires_mujoco_ci
+def test_many_short_advances_still_respect_the_configured_frame_rate(ray_test_world):
+    """
+    A caller that drives the recorder through many short calls -- exactly how
+    :class:`~experiments.montessori.scenarios.SimulatedScene`'s own ``advance()`` is
+    used by settling and by trajectory-following, each call far shorter than one frame
+    period -- must still get roughly ``frames_per_second`` frames per simulated second
+    overall, not one guaranteed frame per call. A decimation counter reset at the start
+    of every call always satisfies its own "already at the boundary" check, so many short
+    calls would otherwise capture close to one frame each regardless of how low
+    ``frames_per_second`` is asked to be -- defeating the whole point of asking for a
+    lower one.
+    """
+    world, *_ = ray_test_world
+    recorder = MujocoVideoRecorder(world=world, frames_per_second=1)
+
+    recorder.start()
+    try:
+        step_size = recorder.multi_sim.simulator.step_size
+        short_call_duration = step_size * 5
+        number_of_calls = 200
+        for _ in range(number_of_calls):
+            recorder.advance_simulation(duration=short_call_duration)
+        frame_count = recorder.captured_frame_count
+    finally:
+        recorder.stop()
+
+    total_simulated_time = number_of_calls * short_call_duration
+    expected_frames = total_simulated_time * recorder.frames_per_second
+    assert frame_count < number_of_calls
+    assert frame_count <= expected_frames + 2
+
+
+@requires_mujoco_ci
 def test_start_twice_raises(ray_test_world):
     world, *_ = ray_test_world
     recorder = MujocoVideoRecorder(world=world)

--- a/test/semantic_digital_twin_test/test_adapters/test_mujoco_video_recording.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_mujoco_video_recording.py
@@ -222,7 +222,7 @@ def test_many_short_advances_still_respect_the_configured_frame_rate(ray_test_wo
 
     recorder.start()
     try:
-        step_size = recorder.multi_sim.simulator.step_size
+        step_size = recorder._multi_sim.simulator.step_size
         short_call_duration = step_size * 5
         number_of_calls = 200
         for _ in range(number_of_calls):


### PR DESCRIPTION
## Summary

`MujocoVideoRecorder.advance_simulation` resets its own frame-decimation counter
(`_state_change_count`) to zero at the start of every call, before stepping. A caller
that drives it through many short calls — each far shorter than one frame period, e.g.
once per settling window or once per trajectory-following tick — always lands on the
counter's own zero-phase on entry, so every such call captures a frame regardless of
how low `frames_per_second` is asked to be.

In practice this makes `frames_per_second` toothless for exactly the calling pattern
the method's own docstring names as its intended use ("use this when nothing else is
already driving the world"), and can make filming dominate a run's wall-clock cost by
an order of magnitude when the run itself needs many short physics advances (e.g. a
trajectory that repeatedly retries to settle).

## Fix

Let the counter run continuously across calls instead of restarting it:
`steps_per_frame` is recomputed identically call to call from the same
`frames_per_second` and `step_size`, so the decimation phase stays valid without a
reset.

## Test plan

- [x] New regression test `test_many_short_advances_still_respect_the_configured_frame_rate`
  drives a recorder through 200 short `advance_simulation` calls at
  `frames_per_second=1` and asserts the frame count reflects the requested rate rather
  than one frame per call.
- [x] Fails against the old code: `assert 201 < 200` (200 calls, 201 frames — one per
  call plus the initial frame from `start()`).
- [x] Passes against the fix.
- [x] Full `test_mujoco_video_recording.py` suite (17 tests) still passes.

Found and isolated while generating a corpus of filmed simulation episodes, where this
was making one filmed episode take roughly 20 minutes of wall clock almost entirely on
redundant frame renders (dropping to about 2 minutes once fixed and asked for a lower
frame rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)