### PR TITLE
Smaller statechart jsons

### DIFF
--- a/coraplex/src/coraplex/perception.py
+++ b/coraplex/src/coraplex/perception.py
@@ -110,11 +110,11 @@ class PerceptionQuery(SubclassJSONSerializer):
         robot_camera = self.robot.get_default_camera()
         return [body for body in region_bodies if visible(robot_camera, body)]
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
-        result["semantic_annotation"] = to_json(self.semantic_annotation)
-        result["region"] = to_json(self.region)
-        result["robot_id"] = to_json(self.robot.id)
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
+        result["semantic_annotation"] = to_json(self.semantic_annotation, **kwargs)
+        result["region"] = to_json(self.region, **kwargs)
+        result["robot_id"] = to_json(self.robot.id, **kwargs)
         result["trust_detected_orientation"] = self.trust_detected_orientation
         return result
 

--- a/giskardpy/src/giskardpy/middleware/ros2/motion_goal.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/motion_goal.py
@@ -52,14 +52,14 @@ class MotionGoal(SubclassJSONSerializer):
             required_position=required_position,
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "motion_statechart": self.motion_statechart_json_data,
             "required_position": (
                 None
                 if self.required_position is None
-                else to_json(self.required_position)
+                else to_json(self.required_position, **kwargs)
             ),
         }
 

--- a/giskardpy/src/giskardpy/motion_statechart/graph_node.py
+++ b/giskardpy/src/giskardpy/motion_statechart/graph_node.py
@@ -272,8 +272,8 @@ class TrinaryCondition(SubclassJSONSerializer):
     def __repr__(self):
         return str(self)
 
-    def to_json(self) -> Dict[str, Any]:
-        json_data = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        json_data = super().to_json(**kwargs)
         json_data["kind"] = self.kind.name
         json_data["expression"] = str(self)
         json_data["owner"] = self.owner.index if self.owner else None
@@ -839,9 +839,9 @@ class MotionStatechartNode(SubclassJSONSerializer):
         else:
             self.parent_node_index = parent_node.index
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **DataclassJSONSerializer.to_json(self),
+            **DataclassJSONSerializer.to_json(self, **kwargs),
             NodeJSONKey.NODE_ID: self._node_id,
         }
 

--- a/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
+++ b/giskardpy/src/giskardpy/motion_statechart/motion_statechart.py
@@ -44,6 +44,9 @@ from giskardpy.motion_statechart.graph_node import (
 from giskardpy.motion_statechart.graph_node import Task
 from giskardpy.motion_statechart.plotters.graphviz import MotionStatechartGraphviz
 from giskardpy.qp.constraint_collection import ConstraintCollection
+from semantic_digital_twin.world_description.world_entity import (
+    WorldEntityReferenceWriter,
+)
 
 
 @dataclass(repr=False, eq=False)
@@ -155,11 +158,11 @@ class State(MutableMapping[MotionStatechartNode, float], SubclassJSONSerializer)
             data=self.data.copy(),
         )
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self, **kwargs) -> dict[str, Any]:
         """
         :return: The JSON representation of the base class, extended with the raw :attr:`data` array.
         """
-        return {**super().to_json(), "data": self.data.tolist()}
+        return {**super().to_json(**kwargs), "data": self.data.tolist()}
 
     @classmethod
     def _from_json(cls, data: dict[str, Any], **kwargs) -> Self:
@@ -1180,17 +1183,22 @@ class MotionStatechart(SubclassJSONSerializer):
             self, second_width_in_cm=second_length_in_cm, context=context
         ).plot_gantt_chart(path)
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self, **kwargs) -> dict[str, Any]:
         """
+        World entities are written as references, because whoever reads a motion
+        statechart resolves them against its own world, which has the same entities.
+
         :return: The JSON representation of this motion statechart, including all nodes and their unique edges.
         .. warning:: This rebuilds the graph's edges from the nodes' current conditions as a side effect, see :meth:`_add_transitions`.
         """
+        kwargs = {**kwargs, **WorldEntityReferenceWriter().create_kwargs()}
         self._add_transitions()
-        result = super().to_json()
+        result = super().to_json(**kwargs)
         result["nodes"] = [
-            to_json(node) for node in sorted(self.nodes, key=lambda n: n.index)
+            to_json(node, **kwargs)
+            for node in sorted(self.nodes, key=lambda n: n.index)
         ]
-        result["unique_edges"] = [edge.to_json() for edge in self.unique_edges]
+        result["unique_edges"] = [edge.to_json(**kwargs) for edge in self.unique_edges]
         return result
 
     @classmethod

--- a/krrood/src/krrood/adapters/deserialized_object_tracker.py
+++ b/krrood/src/krrood/adapters/deserialized_object_tracker.py
@@ -5,15 +5,17 @@ from dataclasses import dataclass, field
 from typing_extensions import Any, Dict, Generic, Self, TypeVar
 
 from krrood.adapters.exceptions import UntrackedObjectError
+from krrood.adapters.keyword_argument import SerializationKeywordArgument
 from krrood.patterns.subclass_safe_generic import SubClassSafeGeneric
-from krrood.utils import get_full_class_name
 
 KeyType = TypeVar("KeyType")
 TrackedType = TypeVar("TrackedType")
 
 
 @dataclass
-class DeserializedObjectTracker(Generic[KeyType, TrackedType], SubClassSafeGeneric):
+class DeserializedObjectTracker(
+    Generic[KeyType, TrackedType], SubClassSafeGeneric, SerializationKeywordArgument
+):
     """
     The objects created while deserializing one JSON document, by the key the document
     refers to them with.
@@ -43,21 +45,6 @@ class DeserializedObjectTracker(Generic[KeyType, TrackedType], SubClassSafeGener
         if keyword not in from_json_kwargs:
             from_json_kwargs[keyword] = cls()
         return from_json_kwargs[keyword]
-
-    @classmethod
-    def _keyword(cls) -> str:
-        """
-        :return: The keyword argument this type of tracker is passed as, distinct for every
-            tracker type.
-        """
-        return get_full_class_name(cls)
-
-    def create_kwargs(self) -> Dict[str, Self]:
-        """
-        :return: Keyword arguments carrying this tracker, to pass to the top-level
-            ``from_json`` call.
-        """
-        return {self._keyword(): self}
 
     def add(self, key: KeyType, tracked_object: TrackedType) -> None:
         """

--- a/krrood/src/krrood/adapters/json_serializer.py
+++ b/krrood/src/krrood/adapters/json_serializer.py
@@ -5,7 +5,7 @@ import importlib
 import inspect
 import uuid
 from datetime import timedelta
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields, is_dataclass
 from dataclasses import field
 from types import NoneType
@@ -22,6 +22,7 @@ from krrood.adapters.exceptions import (
     ClassNotSerializableError,
     JSON_TYPE_NAME,
 )
+from krrood.adapters.keyword_argument import SerializationKeywordArgument
 from krrood.class_diagrams.attribute_introspector import DataclassOnlyIntrospector
 from krrood.ormatic.data_access_objects.base import HasGeneric
 from krrood.singleton import SingletonMeta
@@ -116,7 +117,12 @@ class SubclassJSONSerializer:
     that class during deserialization.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        """
+        :param kwargs: Keyword arguments to hand on to the ``to_json`` calls for the
+            values this object holds.
+        :return: The JSON dict
+        """
         return {JSON_TYPE_NAME: get_full_class_name(self.__class__)}
 
     @classmethod
@@ -222,11 +228,13 @@ def from_json(data: Dict[str, Any], **kwargs) -> Union[SubclassJSONSerializer, A
     return SubclassJSONSerializer.from_json(data, **kwargs)
 
 
-def to_json(obj: Union[SubclassJSONSerializer, Any]) -> JSON_RETURN_TYPE:
+def to_json(obj: Union[SubclassJSONSerializer, Any], **kwargs) -> JSON_RETURN_TYPE:
     """
     Serialize an object to a JSON dict.
 
     :param obj: The object to convert to json
+    :param kwargs: Keyword arguments handed on to every nested ``to_json`` call, for
+        example a :class:`ReferenceWriter`.
     :return: The JSON string
     """
     if isinstance(obj, dict):
@@ -238,19 +246,23 @@ def to_json(obj: Union[SubclassJSONSerializer, Any]) -> JSON_RETURN_TYPE:
         return obj
 
     if isinstance(obj, list_like_classes):
-        return [to_json(item) for item in obj]
+        return [to_json(item, **kwargs) for item in obj]
+
+    reference_writer = ReferenceWriter.find_for(obj, kwargs)
+    if reference_writer is not None:
+        return reference_writer.write_reference(obj)
 
     if isinstance(obj, SubclassJSONSerializer):
-        return obj.to_json()
+        return obj.to_json(**kwargs)
 
     if inspect.isclass(obj):
-        return ClassJSONSerializer.to_json(obj)
+        return ClassJSONSerializer.to_json(obj, **kwargs)
 
     registered_json_serializer = JSONSerializableTypeRegistry().get_external_serializer(
         type(obj)
     )
 
-    return registered_json_serializer.to_json(obj)
+    return registered_json_serializer.to_json(obj, **kwargs)
 
 
 @dataclass
@@ -274,8 +286,7 @@ class JSONAttributeDiff(SubclassJSONSerializer):
     The items that have been removed from the attribute.
     """
 
-    def to_json(self) -> Dict[str, Any]:
-        super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(self.__class__),
             "attribute_name": self.attribute_name,
@@ -365,11 +376,13 @@ class ExternalClassJSONSerializer(HasGeneric[T], ABC):
     """
 
     @classmethod
-    def to_json(cls, obj: Any) -> Dict[str, Any]:
+    def to_json(cls, obj: Any, **kwargs) -> Dict[str, Any]:
         """
         Convert an object to a JSON serializable dictionary.
 
         :param obj: The object to convert.
+        :param kwargs: Keyword arguments to hand on to the ``to_json`` calls for the
+            values the object holds.
         :return: The JSON serializable dictionary.
         """
 
@@ -396,11 +409,49 @@ class ExternalClassJSONSerializer(HasGeneric[T], ABC):
         return cls.original_class() == clazz
 
 
+ReferencedType = TypeVar("ReferencedType")
+
+
+@dataclass
+class ReferenceWriter(SerializationKeywordArgument, HasGeneric[ReferencedType], ABC):
+    """
+    Writes the objects of the type it is bound to as references, because whoever reads
+    the document already has them.
+
+    Passed through the keyword arguments of ``to_json``, it replaces such an object with
+    its reference wherever the object sits in the document.
+    """
+
+    @classmethod
+    def find_for(
+        cls, obj: Any, to_json_kwargs: Dict[str, Any]
+    ) -> Optional[ReferenceWriter]:
+        """
+        :param obj: The object about to be serialized.
+        :param to_json_kwargs: The keyword arguments of the ``to_json`` call.
+        :return: The reference writer among the keyword arguments that writes the object
+            as a reference, if there is one.
+        """
+        for value in to_json_kwargs.values():
+            if isinstance(value, ReferenceWriter) and isinstance(
+                obj, value.original_class()
+            ):
+                return value
+        return None
+
+    @abstractmethod
+    def write_reference(self, obj: ReferencedType) -> Dict[str, Any]:
+        """
+        :param obj: The object to refer to.
+        :return: The JSON the document holds in place of the object.
+        """
+
+
 @dataclass
 class UUIDJSONSerializer(ExternalClassJSONSerializer[uuid.UUID]):
 
     @classmethod
-    def to_json(cls, obj: uuid.UUID) -> Dict[str, Any]:
+    def to_json(cls, obj: uuid.UUID, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(type(obj)),
             "value": str(obj),
@@ -423,7 +474,7 @@ class TimedeltaJSONSerializer(ExternalClassJSONSerializer[timedelta]):
     """
 
     @classmethod
-    def to_json(cls, obj: timedelta) -> Dict[str, Any]:
+    def to_json(cls, obj: timedelta, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(type(obj)),
             "days": obj.days,
@@ -450,7 +501,7 @@ class ClassJSONSerializer(ExternalClassJSONSerializer[None]):
     """
 
     @classmethod
-    def to_json(cls, obj: Type) -> Dict[str, Any]:
+    def to_json(cls, obj: Type, **kwargs) -> Dict[str, Any]:
         """
         This is a special case because we need to remember that the type of the class is
         a class, not a type.
@@ -471,7 +522,7 @@ class ClassJSONSerializer(ExternalClassJSONSerializer[None]):
 class EnumJSONSerializer(ExternalClassJSONSerializer[enum.Enum]):
 
     @classmethod
-    def to_json(cls, obj: enum.Enum) -> Dict[str, Any]:
+    def to_json(cls, obj: enum.Enum, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(type(obj)),
             "name": obj.name,
@@ -487,7 +538,7 @@ class EnumJSONSerializer(ExternalClassJSONSerializer[enum.Enum]):
 @dataclass
 class ExceptionJSONSerializer(ExternalClassJSONSerializer[Exception]):
     @classmethod
-    def to_json(cls, obj: Exception) -> Dict[str, Any]:
+    def to_json(cls, obj: Exception, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(type(obj)),
             "value": str(obj),
@@ -507,7 +558,7 @@ class NumpyNDarrayJSONSerializer(ExternalClassJSONSerializer[np.ndarray]):
     """
 
     @classmethod
-    def to_json(cls, obj: np.ndarray) -> Dict[str, Any]:
+    def to_json(cls, obj: np.ndarray, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(type(obj)),
             "type": str(obj.dtype),
@@ -531,20 +582,20 @@ class DataclassJSONSerializer(ExternalClassJSONSerializer[None]):
     """
 
     @classmethod
-    def to_json(cls, obj) -> Dict[str, Any]:
+    def to_json(cls, obj, **kwargs) -> Dict[str, Any]:
         result = {JSON_TYPE_NAME: get_full_class_name(type(obj))}
         introspector = DataclassOnlyIntrospector()
         for field_ in introspector.discover(obj.__class__):
             value = getattr(obj, field_.public_name)
 
             if isinstance(value, (list, set)):
-                current_result = [to_json(item) for item in value]
+                current_result = [to_json(item, **kwargs) for item in value]
             elif isinstance(value, dict):
-                keys = [to_json(k) for k in value.keys()]
-                values = [to_json(v) for v in value.values()]
+                keys = [to_json(k, **kwargs) for k in value.keys()]
+                values = [to_json(v, **kwargs) for v in value.values()]
                 current_result = {"keys": keys, "values": values}
             else:
-                current_result = to_json(value)
+                current_result = to_json(value, **kwargs)
             result[field_.public_name] = current_result
         return result
 
@@ -599,7 +650,7 @@ class NumpyFloatJSONSerializer(ExternalClassJSONSerializer[np.float32]):
     """
 
     @classmethod
-    def to_json(cls, obj: np.float32) -> Dict[str, Any]:
+    def to_json(cls, obj: np.float32, **kwargs) -> Dict[str, Any]:
         return {JSON_TYPE_NAME: get_full_class_name(type(obj)), "value": float(obj)}
 
     @classmethod

--- a/krrood/src/krrood/adapters/keyword_argument.py
+++ b/krrood/src/krrood/adapters/keyword_argument.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Dict, Self
+
+from krrood.utils import get_full_class_name
+
+
+@dataclass
+class SerializationKeywordArgument:
+    """
+    An object that travels through nested ``to_json`` or ``from_json`` calls in their
+    keyword arguments.
+
+    The top-level caller passes :meth:`create_kwargs`, and every call hands its keyword
+    arguments on to the calls it makes.
+    """
+
+    @classmethod
+    def _keyword(cls) -> str:
+        """
+        :return: The keyword argument this type of object is passed as, distinct for
+            every type.
+        """
+        return get_full_class_name(cls)
+
+    def create_kwargs(self) -> Dict[str, Self]:
+        """
+        :return: Keyword arguments carrying this object, to pass to the top-level call.
+        """
+        return {self._keyword(): self}

--- a/krrood/src/krrood/symbolic_math/symbolic_math.py
+++ b/krrood/src/krrood/symbolic_math/symbolic_math.py
@@ -941,14 +941,14 @@ class SerializableSymbolicMathType(SymbolicMathType, SubclassJSONSerializer):
     A symbolic math value that can be serialized to JSON while it is constant.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         """
         :raises SymbolicMathNotJsonSerializableError: If the value depends on variables,
             since an expression means nothing to whoever reads the JSON.
         """
         if not self.is_constant():
             raise SymbolicMathNotJsonSerializableError(expression=self)
-        result = super().to_json()
+        result = super().to_json(**kwargs)
         result[SymbolicMathJSONKey.VALUES] = ca.DM(self.casadi_sx).full().tolist()
         return result
 

--- a/robokudo/src/robokudo/io/cas_annotation_codecs.py
+++ b/robokudo/src/robokudo/io/cas_annotation_codecs.py
@@ -38,7 +38,7 @@ class Open3DPointCloudJSONSerializer(
     """
 
     @classmethod
-    def to_json(cls, obj: o3d.geometry.PointCloud) -> Dict[str, Any]:
+    def to_json(cls, obj: o3d.geometry.PointCloud, **kwargs) -> Dict[str, Any]:
         """
         Convert an Open3D point cloud into a JSON-compatible payload.
         """
@@ -66,7 +66,7 @@ class NumpyScalarJSONSerializer(ExternalClassJSONSerializer[np.generic]):
     """
 
     @classmethod
-    def to_json(cls, obj: np.generic) -> Dict[str, Any]:
+    def to_json(cls, obj: np.generic, **kwargs) -> Dict[str, Any]:
         """
         Convert a NumPy scalar value to JSON-compatible data.
         """

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/messages.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/messages.py
@@ -31,12 +31,12 @@ class MetaData(SubclassJSONSerializer):
     """The id of the origin world. This is used to identify messages that were published by the same publisher."""
 
     @memoize
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "node_name": self.node_name,
             "process_id": self.process_id,
-            "world_id": to_json(self.world_id),
+            "world_id": to_json(self.world_id, **kwargs),
         }
 
     @classmethod
@@ -190,12 +190,12 @@ class WorldModelSnapshot(SubclassJSONSerializer):
     states: List[float]
     """The values of the free variables contained in the state snapshot."""
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            SnapshotField.MODIFICATIONS: to_json(self.modifications),
+            **super().to_json(**kwargs),
+            SnapshotField.MODIFICATIONS: to_json(self.modifications, **kwargs),
             SnapshotField.STATE: {
-                SnapshotField.IDS: to_json(self.ids),
+                SnapshotField.IDS: to_json(self.ids, **kwargs),
                 SnapshotField.STATES: list(self.states),
             },
         }

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/ros_msg_serializer.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/ros/ros_msg_serializer.py
@@ -43,7 +43,7 @@ class Ros2MessageJSONSerializer(ExternalClassJSONSerializer[None]):
         )
 
     @classmethod
-    def to_json(cls, obj: Any) -> Dict[str, Any]:
+    def to_json(cls, obj: Any, **kwargs) -> Dict[str, Any]:
         """
         Serialize a ROS 2 message into a JSON-compatible dictionary.
         """
@@ -85,14 +85,14 @@ class QoSProfileJSONSerializer(ExternalClassJSONSerializer[QoSProfile]):
     """
 
     @classmethod
-    def to_json(cls, obj: QoSProfile) -> Dict[str, Any]:
+    def to_json(cls, obj: QoSProfile, **kwargs) -> Dict[str, Any]:
         """
         Serialize a QoSProfile into a JSON-compatible dictionary.
         """
         return {
             JSON_TYPE_NAME: get_full_class_name(obj.__class__),
             **{
-                field_name: to_json(getattr(obj, field_name))
+                field_name: to_json(getattr(obj, field_name), **kwargs)
                 for field_name in obj.__slots__
             },
         }
@@ -120,7 +120,7 @@ class DurationJSONSerializer(ExternalClassJSONSerializer[Duration]):
     """
 
     @classmethod
-    def to_json(cls, obj: Duration) -> Dict[str, Any]:
+    def to_json(cls, obj: Duration, **kwargs) -> Dict[str, Any]:
         """
         Serialize a Duration into a JSON-compatible dictionary.
         """

--- a/semantic_digital_twin/src/semantic_digital_twin/adapters/sage_10k_dataset/schema.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/adapters/sage_10k_dataset/schema.py
@@ -101,9 +101,9 @@ class HasXYZ(Sage10kBase):
     y: float
     z: float
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "x": self.x,
             "y": self.y,
             "z": self.z,
@@ -173,9 +173,9 @@ class Sage10kSize(Sage10kBase):
     def z(self) -> float:
         return self.height
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "height": self.height,
             "length": self.length,
             "width": self.width,
@@ -199,9 +199,9 @@ class Sage10kPhysicallyBasedRendering(SubclassJSONSerializer):
     metallic: float
     roughness: float
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "metallic": self.metallic,
             "roughness": self.roughness,
         }
@@ -248,12 +248,12 @@ class Sage10kWall(Sage10kWithID):
     The thickness of the wall.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "id": self.id,
-            "start_point": to_json(self.start_point),
-            "end_point": to_json(self.end_point),
+            "start_point": to_json(self.start_point, **kwargs),
+            "end_point": to_json(self.end_point, **kwargs),
             "material": self.material,
             "height": self.height,
             "thickness": self.thickness,
@@ -473,9 +473,9 @@ class Sage10kObject(Sage10kWithID):
 
         return body
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "id": self.id,
             "room_id": self.room_id,
             "type": self.type,
@@ -485,10 +485,10 @@ class Sage10kObject(Sage10kWithID):
             "place_id": self.place_id,
             "place_guidance": self.place_guidance,
             "mass": self.mass,
-            "position": to_json(self.position),
-            "rotation": to_json(self.rotation),
-            "dimensions": to_json(self.dimensions),
-            "pbr_parameters": to_json(self.pbr_parameters),
+            "position": to_json(self.position, **kwargs),
+            "rotation": to_json(self.rotation, **kwargs),
+            "dimensions": to_json(self.dimensions, **kwargs),
+            "pbr_parameters": to_json(self.pbr_parameters, **kwargs),
         }
 
     @classmethod
@@ -566,9 +566,9 @@ class Sage10kDoor(Sage10kWithID):
     The door materials filename found in the `materials` folder.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "id": self.id,
             "wall_id": self.wall_id,
             "position_on_wall": self.position_on_wall,
@@ -908,17 +908,17 @@ class Sage10kRoom(Sage10kWithID):
 
         return world.root
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
             JSON_TYPE_NAME: get_full_class_name(self.__class__),
             "id": self.id,
             "room_type": self.room_type,
-            "dimensions": to_json(self.dimensions),
-            "position": to_json(self.position),
+            "dimensions": to_json(self.dimensions, **kwargs),
+            "position": to_json(self.position, **kwargs),
             "floor_material": self.floor_material,
-            "objects": to_json(self.objects),
-            "walls": to_json(self.walls),
-            "doors": to_json(self.doors),
+            "objects": to_json(self.objects, **kwargs),
+            "walls": to_json(self.walls, **kwargs),
+            "doors": to_json(self.doors, **kwargs),
         }
 
     @classmethod
@@ -975,15 +975,15 @@ class Sage10kScene(Sage10kWithID):
     The layout files are named like `layout*.json`.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "id": self.id,
             "building_style": self.building_style,
             "description": self.description,
             "created_from_text": self.created_from_text,
             "total_area": self.total_area,
-            "rooms": to_json(self.rooms),
+            "rooms": to_json(self.rooms, **kwargs),
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/callbacks/callback.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/callbacks/callback.py
@@ -93,8 +93,8 @@ class Callback(WorldEntityWithClassBasedID, SubclassJSONSerializer, ABC):
         """
         self._is_paused = False
 
-    def to_json(self) -> Dict[str, Any]:
-        return {**super().to_json(), "is_paused": self._is_paused}
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return {**super().to_json(**kwargs), "is_paused": self._is_paused}
 
     @classmethod
     def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_manager.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_manager.py
@@ -315,14 +315,16 @@ class CollisionManager(ModelChangeCallback):
         """
         return self.default_rules + self.temporary_rules + self.ignore_collision_rules
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "id": to_json(self.id),
-            "default_rules": to_json(self.default_rules),
-            "temporary_rules": to_json(self.temporary_rules),
-            "ignore_collision_rules": to_json(self.ignore_collision_rules),
-            "max_avoided_bodies_rules": to_json(self.max_avoided_bodies_rules),
+            **super().to_json(**kwargs),
+            "id": to_json(self.id, **kwargs),
+            "default_rules": to_json(self.default_rules, **kwargs),
+            "temporary_rules": to_json(self.temporary_rules, **kwargs),
+            "ignore_collision_rules": to_json(self.ignore_collision_rules, **kwargs),
+            "max_avoided_bodies_rules": to_json(
+                self.max_avoided_bodies_rules, **kwargs
+            ),
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_matrix.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_matrix.py
@@ -122,12 +122,12 @@ class CollisionCheck(SubclassJSONSerializer):
         if self.body_a.id > self.body_b.id:
             self.body_a, self.body_b = self.body_b, self.body_a
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "body_a": to_json(self.body_a.id),
-            "body_b": to_json(self.body_b.id),
-            "distance": to_json(self.distance),
+            **super().to_json(**kwargs),
+            "body_a": to_json(self.body_a.id, **kwargs),
+            "body_b": to_json(self.body_b.id, **kwargs),
+            "distance": to_json(self.distance, **kwargs),
         }
 
     @classmethod
@@ -301,11 +301,13 @@ class MaxAvoidedCollisionsOverride(MaxAvoidedCollisionsRule, SubclassJSONSeriali
             return None
         return self.value
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "value": self.value,
-            "bodies": to_json({b.id for b in self.bodies} if self.bodies else None),
+            "bodies": to_json(
+                {b.id for b in self.bodies} if self.bodies else None, **kwargs
+            ),
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_rules.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/collision_checking/collision_rules.py
@@ -195,12 +195,12 @@ class AvoidExternalCollisions(AvoidCollisionRule, SubclassJSONSerializer):
             for body_a, body_b in product(body_subset, external_bodies)
         }
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "robot": to_json(self.robot.id),
+            **super().to_json(**kwargs),
+            "robot": to_json(self.robot.id, **kwargs),
             "body_subset": to_json(
-                {b.id for b in self.body_subset} if self.body_subset else None
+                {b.id for b in self.body_subset} if self.body_subset else None, **kwargs
             ),
         }
 
@@ -716,13 +716,13 @@ class SelfCollisionMatrixRule(AllowCollisionRule, SubclassJSONSerializer):
             )
         return self
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "allowed_body_ids": to_json(
-                {body.id for body in self.allowed_collision_bodies}
+                {body.id for body in self.allowed_collision_bodies}, **kwargs
             ),
-            "allowed_collision_pairs": to_json(self.allowed_collision_pairs),
+            "allowed_collision_pairs": to_json(self.allowed_collision_pairs, **kwargs),
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/datastructures/joint_state.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/datastructures/joint_state.py
@@ -131,18 +131,20 @@ class JointState(SubclassJSONSerializer):
     def from_lists(cls, connections: List[ActiveConnection1DOF], targets: List[float]):
         return cls(connections, targets)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "child_ids": [
-                to_json(connection.child.id) for connection in self.connections
+                to_json(connection.child.id, **kwargs)
+                for connection in self.connections
             ],
             "child_names": [
-                to_json(connection.child.name) for connection in self.connections
+                to_json(connection.child.name, **kwargs)
+                for connection in self.connections
             ],
             "target_values": self.target_values,
-            "joint_state_type": to_json(self.state_type),
-            "name": to_json(self.name),
+            "joint_state_type": to_json(self.state_type, **kwargs),
+            "name": to_json(self.name, **kwargs),
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/pipeline/pipeline.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/pipeline/pipeline.py
@@ -178,7 +178,8 @@ class BodyFactoryReplace(Step):
 
             world.remove_kinematic_structure_entity(body)
 
-            parent_connection.child = new_world.root
-            world.merge_world(new_world, parent_connection)
+            world.merge_world(
+                new_world, parent_connection.copy_with_new_child(new_world.root)
+            )
 
         return world

--- a/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/spatial_types/spatial_types.py
@@ -104,7 +104,7 @@ class SpatialType:
     Can be None if no reference frame is required or applicable.
     """
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         """
         The json of a spatial type, carrying the frame it is expressed in.
 
@@ -116,7 +116,7 @@ class SpatialType:
         """
         if not self.is_constant():
             raise SpatialTypeNotJsonSerializable(self)
-        result = super().to_json()
+        result = super().to_json(**kwargs)
         if self.reference_frame is not None:
             WorldEntityReference(SpatialFrameKey.REFERENCE).write(
                 result, self.reference_frame
@@ -298,8 +298,8 @@ class HomogeneousTransformationMatrix(
         transformation_matrix.append([0, 0, 0, 1])
         return cls(transformation_matrix)
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         if self.child_frame is not None:
             WorldEntityReference(SpatialFrameKey.CHILD).write(result, self.child_frame)
         result["position"] = self.to_position().to_np().tolist()
@@ -617,8 +617,8 @@ class RotationMatrix(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
             reference_frame=reference_frame,
         ).to_rotation_matrix()
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["quaternion"] = self.to_quaternion().to_np().tolist()
         return result
 
@@ -1088,8 +1088,8 @@ class Point3(Point):
             z.resolve = lambda: resolver()[2]
         return result
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["data"] = self.to_np().tolist()
         return result
 
@@ -1266,8 +1266,8 @@ class Point2(Point):
         x, y = data["data"][:2]
         return cls(x=x, y=y, reference_frame=reference_frame)
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["data"] = self.to_np().tolist()
         return result
 
@@ -1346,8 +1346,8 @@ class Vector3(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
             reference_frame=reference_frame,
         )
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["data"] = self.to_np().tolist()
         return result
 
@@ -1705,8 +1705,8 @@ class Quaternion(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
             reference_frame=reference_frame,
         )
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["data"] = self.to_np().tolist()
         return result
 
@@ -2058,8 +2058,8 @@ class Pose(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
             reference_frame=reference_frame,
         )
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["position"] = self.to_position().to_np().tolist()
         result["rotation"] = self.to_quaternion().to_np().tolist()
         return result
@@ -2402,8 +2402,8 @@ class Pose2D(sm.SymbolicMathType, SpatialType, SubclassJSONSerializer):
             reference_frame=reference_frame,
         )
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         result["data"] = self.to_np().tolist()
         return result
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world.py
@@ -1151,15 +1151,10 @@ class World(HasSimulatorProperties):
 
         :param connection: The connection to be removed
 
-        .. warning::
+        .. note::
 
-            The reason self.is_connection_in_world is not checked before removing the connection, is because it is using
-            the self.connections internally, which accesses the live rustworkx kinematic_structure. The problem arises
-            if we want to remove the parent or child from the world, before removing the connection from the world.
-            In that case, rustworkx automatically removes the edge representing the connection, which results in
-            self.is_connection_in_world returning False, even though we have not cleaned up the connection properly on
-            our side. The ownership the connection itself records survives that,
-            which is what makes it usable as the check here.
+            A connection whose parent or child was removed first has already left the
+            world with it, so removing it afterwards does nothing.
         """
         if connection._world is not self:
             return
@@ -1202,9 +1197,19 @@ class World(HasSimulatorProperties):
         Do not call this function directly, use `remove_kinematic_structure_entity`
         instead.
 
+        Connections still attached to it leave the world with it, as removing its node
+        removes their edges from the kinematic structure.
+
         :param kinematic_structure_entity: The kinematic_structure_entity to remove.
         """
-        self.kinematic_structure.remove_node(kinematic_structure_entity.index)
+        index = kinematic_structure_entity.index
+        attached_edges = chain(
+            self.kinematic_structure.in_edges(index),
+            self.kinematic_structure.out_edges(index),
+        )
+        for _, _, connection in attached_edges:
+            connection.remove_from_world()
+        self.kinematic_structure.remove_node(index)
         kinematic_structure_entity.remove_from_world()
 
     def remove_degree_of_freedom(self, dof: DegreeOfFreedom) -> None:
@@ -1648,10 +1653,8 @@ class World(HasSimulatorProperties):
 
         Walks `obj` recursively through dataclass fields, list like classes and dict values.
         A :class:`~semantic_digital_twin.world_description.world_entity.WorldEntityWithID`
-        is looked up here by its id and a
-        :class:`~semantic_digital_twin.world_description.world_entity.Connection`, which
-        has no id, by its rebound parent and child. Anything else is deep-copied, so
-        `obj` and the result never share mutable state.
+        is looked up here by its id. Anything else is deep-copied, so `obj` and the
+        result never share mutable state.
 
         An entity this world does not contain is left as it is: it is not this world's
         state to rebind, and leaving it behaves exactly as not rebinding at all.
@@ -1676,13 +1679,6 @@ class World(HasSimulatorProperties):
                     world=self, world_entity=found
                 )
             return found
-        if isinstance(obj, Connection):
-            parent, child = self.rebind_world_entities(
-                obj.parent
-            ), self.rebind_world_entities(obj.child)
-            if parent is obj.parent or child is obj.child:
-                return obj
-            return self.get_connection(parent, child)
         if isinstance(obj, list_like_classes):
             return type(obj)(self.rebind_world_entities(item) for item in obj)
         if isinstance(obj, dict):

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/geometry.py
@@ -468,11 +468,11 @@ class Shape(ABC, SubclassJSONSerializer, HasSimulatorProperties):
         """
         return [field_ for field_ in fields(cls) if field_.init]
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             **{
-                field_.name: to_json(getattr(self, field_.name))
+                field_.name: to_json(getattr(self, field_.name), **kwargs)
                 for field_ in self._serialized_fields()
             },
         }
@@ -624,7 +624,7 @@ class Mesh(Shape):
             if field_.name != "filename"
         ]
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         # Serialize the unscaled geometry and the scale separately. This is the same
         # mesh :attr:`mesh` exposes, so a deserialized mesh reproduces the original
         # rather than a differently tessellated version of the same file.
@@ -640,9 +640,9 @@ class Mesh(Shape):
             ).tolist()
         file_type = self.filename.split(".")[-1]
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "mesh": mesh_dict,
-            "scale": to_json(self.scale),
+            "scale": to_json(self.scale, **kwargs),
             "file_type": file_type,
         }
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/inertial_properties.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/inertial_properties.py
@@ -21,8 +21,8 @@ class NPMatrix3x3(SubclassJSONSerializer):
     def __matmul__(self, other: GenericMatrix3x3Type) -> GenericMatrix3x3Type:
         return NPMatrix3x3(data=self.data @ other.data)
 
-    def to_json(self) -> Dict[str, Any]:
-        return {**super().to_json(), "data": self.data.tolist()}
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return {**super().to_json(**kwargs), "data": self.data.tolist()}
 
     @classmethod
     def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
@@ -59,8 +59,8 @@ class NPVector3(SubclassJSONSerializer):
         """
         return NPMatrix3x3(data=np.diag(self.data))
 
-    def to_json(self) -> Dict[str, Any]:
-        return {**super().to_json(), "data": self.data.tolist()}
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return {**super().to_json(**kwargs), "data": self.data.tolist()}
 
     @classmethod
     def _from_json(cls, data: Dict[str, Any]) -> Self:

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/shape_collection.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/shape_collection.py
@@ -205,10 +205,10 @@ class ShapeCollection(SubclassJSONSerializer):
             HomogeneousTransformationMatrix(reference_frame=reference_frame)
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "shapes": [to_json(shape) for shape in self.shapes],
+            **super().to_json(**kwargs),
+            "shapes": [to_json(shape, **kwargs) for shape in self.shapes],
         }
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/soft_connections.py
@@ -44,10 +44,10 @@ class PiecewiseConstantCurvatureConnection(Connection):
     The physical arc length of this specific segment.
     """
 
-    def to_json(self) -> dict[str, Any]:
-        result = super().to_json()
-        result["kappa_dof_id"] = to_json(self.kappa_dof_id)
-        result["phi_dof_id"] = to_json(self.phi_dof_id)
+    def to_json(self, **kwargs) -> dict[str, Any]:
+        result = super().to_json(**kwargs)
+        result["kappa_dof_id"] = to_json(self.kappa_dof_id, **kwargs)
+        result["phi_dof_id"] = to_json(self.phi_dof_id, **kwargs)
         result["segment_length"] = self.segment_length
         return result
 
@@ -249,12 +249,12 @@ class CosseratRodConnection(Connection):
     The intrinsic rest length of the rod segment.
     """
 
-    def to_json(self) -> dict[str, Any]:
-        result = super().to_json()
-        result["bending_x_dof_id"] = to_json(self.bending_x_dof_id)
-        result["bending_y_dof_id"] = to_json(self.bending_y_dof_id)
-        result["torsion_dof_id"] = to_json(self.torsion_dof_id)
-        result["extension_dof_id"] = to_json(self.extension_dof_id)
+    def to_json(self, **kwargs) -> dict[str, Any]:
+        result = super().to_json(**kwargs)
+        result["bending_x_dof_id"] = to_json(self.bending_x_dof_id, **kwargs)
+        result["bending_y_dof_id"] = to_json(self.bending_y_dof_id, **kwargs)
+        result["torsion_dof_id"] = to_json(self.torsion_dof_id, **kwargs)
+        result["extension_dof_id"] = to_json(self.extension_dof_id, **kwargs)
         result["segment_length"] = self.segment_length
         return result
 

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
@@ -6,9 +6,8 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from copy import deepcopy
-from dataclasses import dataclass, field, Field
+from dataclasses import dataclass, field, Field, replace
 from dataclasses import fields
-from functools import cached_property
 from functools import cached_property
 from uuid import UUID, uuid4
 
@@ -36,9 +35,9 @@ from krrood.adapters.json_serializer import (
 )
 from krrood.class_diagrams.attribute_introspector import DataclassOnlyIntrospector
 from krrood.entity_query_language.predicate import Symbol
+from krrood.patterns.caching import memoize
 from krrood.symbolic_math.symbolic_math import Matrix
 from krrood.utils import get_full_class_name
-from krrood.patterns.caching import memoize
 from semantic_digital_twin.adapters.world_entity_kwargs_tracker import (
     WorldEntityReference,
     WorldEntityWithIDKwargsTracker,
@@ -874,9 +873,16 @@ class SemanticAnnotation(WorldEntityWithSimulatorProperties):
 
 
 @dataclass(eq=False)
-class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, ABC):
+class Connection(WorldEntityWithSimulatorProperties, ABC):
     """
     Represents a connection between two entities in the world.
+    """
+
+    id: UUID = field(init=False)
+    """
+    The identifier of this connection, derived from the ids of its parent and child.
+
+    Every copy of a connection, in any world, therefore carries the same id.
     """
 
     _world: Optional[World] = field(default=None, repr=False, hash=False, init=False)
@@ -916,6 +922,7 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
     """
 
     def __post_init__(self):
+        self.id = uuid.uuid5(self.parent.id, str(self.child.id))
         self.name = self.name or self._generate_default_name(
             parent=self.parent, child=self.child
         )
@@ -969,7 +976,9 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
         return [field_ for field_ in fields(cls) if field_.init]
 
     def to_json(self, **kwargs) -> Dict[str, Any]:
-        result = super().to_json(**kwargs)
+        # A connection writes its own fields, so it skips the field dump of
+        # WorldEntityWithID.to_json
+        result = SubclassJSONSerializer.to_json(self, **kwargs)
         for field_ in self._serialized_fields():
             value = getattr(self, field_.name)
             if isinstance(value, WorldEntityWithID):
@@ -1031,9 +1040,6 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
     @property
     def has_hardware_interface(self) -> bool:
         return False
-
-    def add_to_world(self, world: World):
-        self._world = world
 
     @classmethod
     def _generate_default_name(
@@ -1193,6 +1199,23 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
             child=self.child,
             parent_T_connection_expression=parent_T_connection_expression,
             connection_T_child_expression=self.connection_T_child_expression,
+        )
+
+    def copy_with_new_child(self, new_child: KinematicStructureEntity) -> Self:
+        """
+        Create a copy of this connection that connects its parent to ``new_child``,
+        keeping everything else the connection was built with.
+
+        :param new_child: The child of the copy.
+        :return: The copy, named after its parent and new child.
+        """
+        connection_T_child_expression = deepcopy(self.connection_T_child_expression)
+        connection_T_child_expression.child_frame = new_child
+        return replace(
+            self,
+            child=new_child,
+            connection_T_child_expression=connection_T_child_expression,
+            name=None,
         )
 
     def update_references_for_world(self, world: World):

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_entity.py
@@ -27,6 +27,8 @@ from typing_extensions import (
 )
 
 from krrood.adapters.json_serializer import (
+    DataclassJSONSerializer,
+    ReferenceWriter,
     SubclassJSONSerializer,
     to_json,
     from_json,
@@ -166,29 +168,29 @@ class WorldEntityWithID(WorldEntity, SubclassJSONSerializer):
     def add_to_world(self, world: World):
         super().add_to_world(world)
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         introspector = DataclassOnlyIntrospector()
         for field_ in introspector.discover(self.__class__):
             value = getattr(self, field_.public_name)
 
             if isinstance(value, (list, set)):
-                current_result = [self._item_to_json(item) for item in value]
+                current_result = [self._item_to_json(item, **kwargs) for item in value]
             else:
-                current_result = self._item_to_json(value)
+                current_result = self._item_to_json(value, **kwargs)
             result[field_.public_name] = current_result
         return result
 
     @classmethod
-    def _item_to_json(cls, item: Any):
+    def _item_to_json(cls, item: Any, **kwargs):
         """
         Convert an item to JSON format, handling WorldEntityWithID objects by
         serializing their ID.
         """
         if isinstance(item, WorldEntityWithID):
-            result = to_json(item.id)
+            result = to_json(item.id, **kwargs)
         else:
-            result = to_json(item)
+            result = to_json(item, **kwargs)
         return result
 
     def _track_object_in_from_json(
@@ -293,6 +295,54 @@ class WorldEntityWithID(WorldEntity, SubclassJSONSerializer):
                 current_result = _resolve_item(value, world)
             result[field_.public_name] = current_result
         return self.__class__(**result)
+
+
+@dataclass
+class ReferencedWorldEntity(SubclassJSONSerializer):
+    """
+    Stands in a JSON document for a world entity that whoever reads the document already
+    has.
+
+    Reading it yields the entity of the reader's world, see
+    :class:`WorldEntityWithIDKwargsTracker`.
+    """
+
+    id: UUID
+    """
+    The id of the entity referred to.
+    """
+
+    name: PrefixedName
+    """
+    The name of the entity referred to, which says which entity was meant where it
+    cannot be found.
+    """
+
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return DataclassJSONSerializer.to_json(self, **kwargs)
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> WorldEntityWithID:
+        """
+        :return: The entity of the reader's world that the reference refers to.
+        :raises MissingWorldError: If the keyword arguments carry no world to find the
+            entity in.
+        :raises WorldEntityWithIDNotInKwargs: If the world holds no entity with the id.
+        """
+        reference = DataclassJSONSerializer.from_json(data, clazz=cls, **kwargs)
+        tracker = WorldEntityWithIDKwargsTracker.from_kwargs(kwargs)
+        return tracker.get(reference.id, name=reference.name)
+
+
+@dataclass
+class WorldEntityReferenceWriter(ReferenceWriter[WorldEntityWithID]):
+    """
+    Writes world entities as :class:`ReferencedWorldEntity`, for documents whose reader
+    has the world the entities belong to.
+    """
+
+    def write_reference(self, entity: WorldEntityWithID) -> Dict[str, Any]:
+        return ReferencedWorldEntity(id=entity.id, name=entity.name).to_json()
 
 
 @dataclass(eq=False)
@@ -598,10 +648,10 @@ class Region(KinematicStructureEntity):
             return None
         return self.area.combined_mesh
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
-        result["name"] = to_json(self.name)
-        result["area"] = to_json(self.area)
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
+        result["name"] = to_json(self.name, **kwargs)
+        result["area"] = to_json(self.area, **kwargs)
         return result
 
     @classmethod
@@ -918,14 +968,14 @@ class Connection(WorldEntity, HasSimulatorProperties, SubclassJSONSerializer, AB
         """
         return [field_ for field_ in fields(cls) if field_.init]
 
-    def to_json(self) -> Dict[str, Any]:
-        result = super().to_json()
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        result = super().to_json(**kwargs)
         for field_ in self._serialized_fields():
             value = getattr(self, field_.name)
             if isinstance(value, WorldEntityWithID):
                 WorldEntityReference(field_.name).write(result, value)
             else:
-                result[field_.name] = to_json(value)
+                result[field_.name] = to_json(value, **kwargs)
         return result
 
     @classmethod

--- a/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
+++ b/semantic_digital_twin/src/semantic_digital_twin/world_description/world_modification.py
@@ -365,11 +365,11 @@ class AddSemanticAnnotationModification(WorldModification, SubclassJSONSerialize
     # Written by hand rather than from the fields: the annotation stays json until
     # :meth:`apply` builds it against the world it is applied to, which the generic
     # serialization would rob it of by building it while reading the modification.
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "semantic_annotation_json": self.semantic_annotation_json,
-            "semantic_annotation_id": to_json(self.semantic_annotation_id),
+            "semantic_annotation_id": to_json(self.semantic_annotation_id, **kwargs),
         }
 
     @classmethod
@@ -410,10 +410,10 @@ class RemoveSemanticAnnotationModification(WorldModification, SubclassJSONSerial
             from_json(self.semantic_annotation_json, **kwargs)
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "semantic_annotation_id": to_json(self.semantic_annotation_id),
+            **super().to_json(**kwargs),
+            "semantic_annotation_id": to_json(self.semantic_annotation_id, **kwargs),
             "semantic_annotation_json": self.semantic_annotation_json,
         }
 
@@ -601,14 +601,14 @@ class SetDofHasHardwareInterface(WorldModification):
             ],
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
+            **super().to_json(**kwargs),
             "degree_of_freedom_ids": [
-                to_json(dof_id) for dof_id in self.degree_of_freedom_ids
+                to_json(dof_id, **kwargs) for dof_id in self.degree_of_freedom_ids
             ],
             "value": self.value,
-            "previous_values": to_json(self.previous_values),
+            "previous_values": to_json(self.previous_values, **kwargs),
         }
 
     @classmethod
@@ -709,11 +709,13 @@ class AttributeUpdateModification(WorldModification, SubclassJSONSerializer):
     # Written by hand rather than from the fields: the values an attribute gained and
     # lost stay json until :meth:`apply` builds them against the world it is applied to,
     # which the generic serialization would rob them of.
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, **kwargs) -> Dict[str, Any]:
         return {
-            **super().to_json(),
-            "entity_id": to_json(self.entity_id),
-            "updated_kwargs_json_list": to_json(self.updated_kwargs_json_list),
+            **super().to_json(**kwargs),
+            "entity_id": to_json(self.entity_id, **kwargs),
+            "updated_kwargs_json_list": to_json(
+                self.updated_kwargs_json_list, **kwargs
+            ),
         }
 
     @classmethod

--- a/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
+++ b/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
@@ -20,6 +20,7 @@ from giskardpy.motion_statechart.graph_node import (
     EndMotion,
     CancelMotion,
 )
+from giskardpy.motion_statechart.monitors.joint_monitors import JointPositionReached
 from giskardpy.motion_statechart.monitors.monitors import LocalMinimumReached
 from giskardpy.motion_statechart.monitors.progress_monitors import StillProgressing
 from giskardpy.motion_statechart.motion_statechart import (
@@ -159,6 +160,26 @@ def test_a_motion_statechart_refers_to_world_entities_by_reference(mini_world):
     node_copy = msc_copy.get_node_by_index(node.index)
     assert node_copy.root_link is root
     assert node_copy.tip_link is tip
+
+
+def test_a_motion_statechart_refers_to_connections_by_reference(mini_world):
+    """
+    A connection is a world entity like any other, so a node holding one points at the
+    connection of the reader's world.
+    """
+    connection = mini_world.get_connection_by_name("root_T_tip")
+    msc = MotionStatechart()
+    msc.add_node(node := JointPositionReached(connection=connection, position=0.5))
+
+    json_data = json.loads(json.dumps(msc.to_json()))
+
+    assert json_data["nodes"][node.index][
+        "connection"
+    ] == WorldEntityReferenceWriter().write_reference(connection)
+
+    tracker = WorldEntityWithIDKwargsTracker.from_world(mini_world)
+    msc_copy = MotionStatechart.from_json(json_data, **tracker.create_kwargs())
+    assert msc_copy.get_node_by_index(node.index).connection is connection
 
 
 def test_start_condition(mini_world):

--- a/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
+++ b/test/giskardpy_test/test_motion_statechart/test_json_parsing.py
@@ -55,7 +55,10 @@ from semantic_digital_twin.world_description.degree_of_freedom import (
     DegreeOfFreedom,
     DegreeOfFreedomLimits,
 )
-from semantic_digital_twin.world_description.world_entity import Body
+from semantic_digital_twin.world_description.world_entity import (
+    Body,
+    WorldEntityReferenceWriter,
+)
 
 
 def test_TrueMonitor():
@@ -125,6 +128,37 @@ def test_to_json_joint_position_list(mini_world):
     assert node_copy.name == node.name
     assert node_copy.threshold == node.threshold
     assert node_copy.goal_state == node.goal_state
+
+
+def test_a_motion_statechart_refers_to_world_entities_by_reference(mini_world):
+    """
+    Whoever reads a motion statechart has the world it was built for, so its nodes point
+    at the entities of that world instead of carrying copies of them.
+    """
+    root = mini_world.get_kinematic_structure_entity_by_name("root")
+    tip = mini_world.get_kinematic_structure_entity_by_name("tip")
+    msc = MotionStatechart()
+    msc.add_node(
+        node := CartesianPose(
+            root_link=root,
+            tip_link=tip,
+            goal_pose=HomogeneousTransformationMatrix.from_xyz_rpy(
+                x=0.1, reference_frame=root
+            ),
+        )
+    )
+
+    json_data = json.loads(json.dumps(msc.to_json()))
+
+    assert json_data["nodes"][node.index][
+        "root_link"
+    ] == WorldEntityReferenceWriter().write_reference(root)
+
+    tracker = WorldEntityWithIDKwargsTracker.from_world(mini_world)
+    msc_copy = MotionStatechart.from_json(json_data, **tracker.create_kwargs())
+    node_copy = msc_copy.get_node_by_index(node.index)
+    assert node_copy.root_link is root
+    assert node_copy.tip_link is tip
 
 
 def test_start_condition(mini_world):

--- a/test/krrood_test/dataset/referenced_objects.py
+++ b/test/krrood_test/dataset/referenced_objects.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from typing_extensions import Any, Dict, List, Self
+
+from krrood.adapters.deserialized_object_tracker import DeserializedObjectTracker
+from krrood.adapters.json_serializer import (
+    DataclassJSONSerializer,
+    ReferenceWriter,
+    SubclassJSONSerializer,
+    from_json,
+    to_json,
+)
+
+# %% an element every reader already has
+
+
+@dataclass
+class ReaderOwnedElement(SubclassJSONSerializer):
+    """
+    An element that whoever reads a document already has, so the document may refer to
+    it instead of containing it.
+    """
+
+    key: str
+    """
+    Identifies the element.
+    """
+
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return DataclassJSONSerializer.to_json(self, **kwargs)
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
+        return DataclassJSONSerializer.from_json(data, clazz=cls, **kwargs)
+
+
+@dataclass
+class ReaderOwnedElementTracker(DeserializedObjectTracker[str, ReaderOwnedElement]):
+    """
+    The elements the reader of a document already has.
+    """
+
+
+@dataclass
+class ReaderOwnedElementReference(SubclassJSONSerializer):
+    """
+    Refers to an element by its key.
+    """
+
+    key: str
+    """
+    The key of the element referred to.
+    """
+
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return {**super().to_json(**kwargs), "key": self.key}
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> ReaderOwnedElement:
+        return ReaderOwnedElementTracker.from_kwargs(kwargs).get(data["key"])
+
+
+@dataclass
+class ReaderOwnedElementReferenceWriter(ReferenceWriter[ReaderOwnedElement]):
+    """
+    Writes elements as references to their key.
+    """
+
+    def write_reference(self, element: ReaderOwnedElement) -> Dict[str, Any]:
+        return ReaderOwnedElementReference(key=element.key).to_json()
+
+
+# %% the places an element can be held in
+
+
+@dataclass
+class ElementHolder:
+    """
+    Holds an element in a field of a dataclass without a serialization of its own.
+    """
+
+    element: ReaderOwnedElement
+    """
+    The element held.
+    """
+
+
+@dataclass
+class ElementHolderWithOwnSerialization(SubclassJSONSerializer):
+    """
+    Holds an element in a field it serializes itself.
+    """
+
+    element: ReaderOwnedElement
+    """
+    The element held.
+    """
+
+    def to_json(self, **kwargs) -> Dict[str, Any]:
+        return {
+            **super().to_json(**kwargs),
+            "element": to_json(self.element, **kwargs),
+        }
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
+        return cls(element=from_json(data["element"], **kwargs))
+
+
+@dataclass
+class ElementInEveryPosition:
+    """
+    Holds one element in every kind of position a serialized document can hold it in.
+    """
+
+    direct: ReaderOwnedElement
+    """
+    The element as the value of a field.
+    """
+
+    nested: ElementHolder
+    """
+    The element one dataclass further down.
+    """
+
+    in_own_serialization: ElementHolderWithOwnSerialization
+    """
+    The element below a class that serializes its fields itself.
+    """
+
+    in_list: List[ReaderOwnedElement] = field(default_factory=list)
+    """
+    The element as an item of a list.
+    """
+
+    in_dict: Dict[str, ReaderOwnedElement] = field(default_factory=dict)
+    """
+    The element as a value of a dict.
+    """

--- a/test/krrood_test/test_utils/test_reference_writer.py
+++ b/test/krrood_test/test_utils/test_reference_writer.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from krrood.adapters.json_serializer import ReferenceWriter, from_json, to_json
+
+from ..dataset.referenced_objects import (
+    ElementHolder,
+    ElementHolderWithOwnSerialization,
+    ElementInEveryPosition,
+    ReaderOwnedElement,
+    ReaderOwnedElementReferenceWriter,
+    ReaderOwnedElementTracker,
+)
+
+
+@pytest.fixture
+def element() -> ReaderOwnedElement:
+    return ReaderOwnedElement(key="landmark")
+
+
+def create_element_in_every_position(
+    element: ReaderOwnedElement,
+) -> ElementInEveryPosition:
+    return ElementInEveryPosition(
+        direct=element,
+        nested=ElementHolder(element=element),
+        in_own_serialization=ElementHolderWithOwnSerialization(element=element),
+        in_list=[element],
+        in_dict={"entry": element},
+    )
+
+
+def test_a_referenced_object_is_written_as_its_reference(element):
+    writer = ReaderOwnedElementReferenceWriter()
+
+    data = to_json(create_element_in_every_position(element), **writer.create_kwargs())
+
+    assert data["direct"] == writer.write_reference(element)
+
+
+def test_every_position_refers_to_the_object_the_reader_has(element):
+    """
+    Written in full, an element would be read back as a new instance; a reference is
+    read back as the reader's own element.
+    """
+    writer = ReaderOwnedElementReferenceWriter()
+    data = json.loads(
+        json.dumps(
+            to_json(create_element_in_every_position(element), **writer.create_kwargs())
+        )
+    )
+    tracker = ReaderOwnedElementTracker()
+    tracker.add(element.key, element)
+
+    result = from_json(data, **tracker.create_kwargs())
+
+    assert result.direct is element
+    assert result.nested.element is element
+    assert result.in_own_serialization.element is element
+    assert result.in_list[0] is element
+    assert result.in_dict["entry"] is element
+
+
+def test_without_a_reference_writer_an_object_is_written_in_full(element):
+    data = to_json(create_element_in_every_position(element))
+
+    assert data["direct"] == element.to_json()
+
+
+def test_a_reference_writer_is_found_only_for_its_referenced_type(element):
+    writer = ReaderOwnedElementReferenceWriter()
+    kwargs = writer.create_kwargs()
+
+    assert ReferenceWriter.find_for(element, kwargs) is writer
+    assert ReferenceWriter.find_for(ElementHolder(element=element), kwargs) is None

--- a/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
@@ -1,3 +1,4 @@
+import json
 import os
 from copy import deepcopy
 
@@ -45,7 +46,11 @@ from semantic_digital_twin.world_description.degree_of_freedom import (
 )
 from semantic_digital_twin.world_description.geometry import Box
 from semantic_digital_twin.world_description.shape_collection import ShapeCollection
-from semantic_digital_twin.world_description.world_entity import Body
+from semantic_digital_twin.world_description.world_entity import (
+    Body,
+    ReferencedWorldEntity,
+    WorldEntityReferenceWriter,
+)
 
 
 def test_body_json_serialization():
@@ -201,6 +206,48 @@ def test_a_reference_resolves_to_the_entity_it_names():
 
     assert parsed_connection.parent is parent
     assert parsed_connection.child is child
+
+
+def test_an_entity_written_as_a_reference_carries_only_its_id_and_name():
+    body = Body(name=PrefixedName("cable_post"))
+
+    json_data = to_json(body, **WorldEntityReferenceWriter().create_kwargs())
+
+    assert json_data == to_json(ReferencedWorldEntity(id=body.id, name=body.name))
+
+
+def test_an_entity_written_as_a_reference_is_read_as_the_entity_of_the_world():
+    world = World()
+    body = Body(name=PrefixedName("cable_post"))
+    with world.modify_world():
+        world.add_kinematic_structure_entity(body)
+    json_data = json.loads(
+        json.dumps(to_json(body, **WorldEntityReferenceWriter().create_kwargs()))
+    )
+
+    tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+
+    assert from_json(json_data, **tracker.create_kwargs()) is body
+
+
+def test_a_reference_to_an_entity_cannot_be_read_without_a_world():
+    body = Body(name=PrefixedName("cable_post"))
+    json_data = to_json(body, **WorldEntityReferenceWriter().create_kwargs())
+
+    with pytest.raises(MissingWorldError):
+        from_json(json_data)
+
+
+def test_a_reference_to_an_entity_the_world_lacks_names_the_entity():
+    body = Body(name=PrefixedName("cable_post"))
+    json_data = to_json(body, **WorldEntityReferenceWriter().create_kwargs())
+
+    tracker = WorldEntityWithIDKwargsTracker.from_world(World())
+    with pytest.raises(WorldEntityWithIDNotInKwargs) as raised:
+        from_json(json_data, **tracker.create_kwargs())
+
+    assert raised.value.key == body.id
+    assert raised.value.world_entity_name == body.name
 
 
 def test_world_entity_missing_from_the_world_is_an_untracked_object():

--- a/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
+++ b/test/semantic_digital_twin_test/test_adapters/test_json_parsing.py
@@ -250,6 +250,33 @@ def test_a_reference_to_an_entity_the_world_lacks_names_the_entity():
     assert raised.value.world_entity_name == body.name
 
 
+def test_a_connection_written_as_a_reference_carries_only_its_id_and_name():
+    world = World()
+    parent = Body(name=PrefixedName("cable_post"))
+    child = Body(name=PrefixedName("cable"))
+    with world.modify_world():
+        world.add_connection(connection := FixedConnection(parent=parent, child=child))
+
+    json_data = to_json(connection, **WorldEntityReferenceWriter().create_kwargs())
+
+    assert json_data == WorldEntityReferenceWriter().write_reference(connection)
+
+
+def test_a_connection_written_as_a_reference_is_read_as_the_connection_of_the_world():
+    world = World()
+    parent = Body(name=PrefixedName("cable_post"))
+    child = Body(name=PrefixedName("cable"))
+    with world.modify_world():
+        world.add_connection(connection := FixedConnection(parent=parent, child=child))
+    json_data = json.loads(
+        json.dumps(to_json(connection, **WorldEntityReferenceWriter().create_kwargs()))
+    )
+
+    tracker = WorldEntityWithIDKwargsTracker.from_world(world)
+
+    assert from_json(json_data, **tracker.create_kwargs()) is connection
+
+
 def test_world_entity_missing_from_the_world_is_an_untracked_object():
     body = Body(name=PrefixedName("body"))
     point = Point3(1, 2, 3, reference_frame=body)

--- a/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
+++ b/test/semantic_digital_twin_test/test_ros/test_world_modifications.py
@@ -382,10 +382,6 @@ def test_revert_remove_kinematic_structure_entity():
 
 
 def test_revert_add_connection():
-    # world.is_connection_in_world() is not used here: Connection.add_to_world()
-    # never registers connections in the world's entity-hash table, so that check is
-    # always False regardless of revert. Membership in world.connections is the
-    # meaningful check, matching how the rest of this file verifies connections.
     world = World()
     with world.modify_world():
         b1 = Body(name=PrefixedName("b1"))

--- a/test/semantic_digital_twin_test/test_worlds/test_world.py
+++ b/test/semantic_digital_twin_test/test_worlds/test_world.py
@@ -1267,7 +1267,8 @@ def test_rebind_body(world_setup):
 
 def test_rebind_connection(world_setup):
     """
-    A connection, which has no id of its own, is rebound through its parent and child.
+    A connection is rebound to the connection of the other world between the same parent
+    and child.
     """
     world, l1, l2, bf, r1, r2 = world_setup
     world_copy = deepcopy(world)
@@ -1713,6 +1714,83 @@ def test_add_body_hash():
     with world.modify_world():
         world.remove_kinematic_structure_entity(body)
     assert hash(body) not in world._world_entity_hash_table
+
+
+# %% connections are identified by the entities they connect
+
+
+def test_a_connection_and_its_copy_in_another_world_share_an_id(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+    connection = world.get_connection(r1, r2)
+
+    world_copy = deepcopy(world)
+    connection_copy = world_copy.get_connection(
+        world_copy.get_kinematic_structure_entity_by_id(r1.id),
+        world_copy.get_kinematic_structure_entity_by_id(r2.id),
+    )
+
+    assert connection_copy is not connection
+    assert connection_copy.id == connection.id
+
+
+def test_connections_between_different_entities_have_different_ids(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+
+    assert world.get_connection(bf, l1).id != world.get_connection(bf, r1).id
+
+
+def test_the_world_finds_a_connection_by_its_id(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+    connection = world.get_connection(r1, r2)
+
+    assert world.get_world_entity_with_id_by_id(connection.id) is connection
+
+
+def test_a_connection_leaves_the_world_with_its_child(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+    connection = world.get_connection(r1, r2)
+
+    with world.modify_world():
+        world.remove_kinematic_structure_entity(r2)
+
+    assert world.find_world_entity_with_id(connection.id) is None
+    assert connection._world is None
+
+
+def test_adding_a_second_connection_between_connected_entities_keeps_the_first(
+    world_setup,
+):
+    world, l1, l2, bf, r1, r2 = world_setup
+    connection = world.get_connection(bf, l1)
+    number_of_connections = len(world.connections)
+
+    with world.modify_world():
+        world.add_connection(FixedConnection(parent=bf, child=l1))
+
+    assert len(world.connections) == number_of_connections
+    assert world.get_connection(bf, l1) is connection
+
+
+def test_a_connection_copied_with_a_new_child_connects_the_new_child(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+    connection: RevoluteConnection = world.get_connection(r1, r2)
+    new_child = Body(name=PrefixedName("r3"))
+
+    connection_copy = connection.copy_with_new_child(new_child)
+
+    assert type(connection_copy) is RevoluteConnection
+    assert connection_copy.parent is r1
+    assert connection_copy.child is new_child
+    assert connection_copy.raw_dof is connection.raw_dof
+    assert (
+        connection_copy.id
+        == RevoluteConnection(
+            parent=r1,
+            child=new_child,
+            raw_dof=connection.raw_dof,
+            axis=connection.axis,
+        ).id
+    )
 
 
 def test_world_state_trajectory(world_setup, tmp_path):


### PR DESCRIPTION
- motion statechart jsons are now much smaller, because they only hold a body id instead of a json copy
- Connection is now a WorldEntityWithID, so that we can generalize this to connections
- replaces https://github.com/cram2/cognitive_robot_abstract_machine/pull/548