### PR TITLE
Fixed a naming clash issue in ormatic interfaces

### DIFF
--- a/coraplex/src/coraplex/datastructures/grasp_scoring.py
+++ b/coraplex/src/coraplex/datastructures/grasp_scoring.py
@@ -271,7 +271,7 @@ def load_successful_grasps_from_dataset(
     with Session(engine) as session:
         query = (
             select(GrasPoseMappingDAO)
-            .join(BodyDAO, GrasPoseMappingDAO.reference_frame_id == BodyDAO.database_id)
+            .join(BodyDAO, GrasPoseMappingDAO._reference_frame_id == BodyDAO.database_id)
             .where(BodyDAO.id == object_uuid)
         )
 

--- a/krrood/src/krrood/ormatic/ormatic.py
+++ b/krrood/src/krrood/ormatic/ormatic.py
@@ -346,7 +346,7 @@ class ORMatic:
         """
         :return: A foreign key name for the given field.
         """
-        return f"{wrapped_field.clazz.clazz.__name__.lower()}_{wrapped_field.field.name}{self.foreign_key_postfix}"
+        return f"_{wrapped_field.clazz.clazz.__name__.lower()}_{wrapped_field.field.name}{self.foreign_key_postfix}"
 
     def to_sqlalchemy_file(self, file: TextIO):
         """

--- a/krrood/src/krrood/ormatic/wrapped_table.py
+++ b/krrood/src/krrood/ormatic/wrapped_table.py
@@ -783,7 +783,7 @@ class WrappedTable(TableLike):
         :param wrapped_field: The field to get the information from.
         """
         # create foreign key
-        fk_name = f"{wrapped_field.field.name}{self.ormatic.foreign_key_postfix}"
+        fk_name = f"_{wrapped_field.field.name}{self.ormatic.foreign_key_postfix}"
         fk_type = (
             f"Mapped[{module_and_class_name(Optional)}[{module_and_class_name(int)}]]"
             if wrapped_field.is_optional
@@ -831,9 +831,9 @@ class WrappedTable(TableLike):
         # Always disambiguate sides using source_/target_ prefixes to avoid
         # duplicated column names in self-referential relationships
         left_fk_name = (
-            f"source_{self.tablename.lower()}{self.ormatic.foreign_key_postfix}"
+            f"_source_{self.tablename.lower()}{self.ormatic.foreign_key_postfix}"
         )
-        right_fk_name = f"target_{target_wrapped_table.tablename.lower()}{self.ormatic.foreign_key_postfix}"
+        right_fk_name = f"_target_{target_wrapped_table.tablename.lower()}{self.ormatic.foreign_key_postfix}"
 
         # create association table metadata
         association_table = AssociationObject(

--- a/test/coraplex_test/test_training_environments.py
+++ b/test/coraplex_test/test_training_environments.py
@@ -20,7 +20,7 @@ def test_move_to_reach(coraplex_testing_session):
     coraplex_testing_session.commit()
 
     query = select(DesignatorNodeDAO.status).join(
-        MoveToReachDAO, DesignatorNodeDAO.designator_id == MoveToReachDAO.database_id
+        MoveToReachDAO, DesignatorNodeDAO._designator_id == MoveToReachDAO.database_id
     )
     results = coraplex_testing_session.execute(query).all()
 

--- a/test/krrood_test/conftest.py
+++ b/test/krrood_test/conftest.py
@@ -30,6 +30,7 @@ from .dataset import (
     example_classes,
     semantic_world_like_classes,
     alternative_mappings_construction_order,
+    clashing_field_names,
 )
 from .dataset.example_classes import (
     KRROODPhysicalObject,
@@ -77,6 +78,7 @@ def generate_sqlalchemy_interface():
     all_classes |= set(classes_of_module(role_takers_in_another_module))
     all_classes |= set(classes_of_module(classes_for_testing_role_recursion_error))
     all_classes |= set(classes_of_module(alternative_mappings_construction_order))
+    all_classes |= set(classes_of_module(clashing_field_names))
     all_classes |= {Symbol, Role}
 
     # remove classes that don't need persistence

--- a/test/krrood_test/dataset/clashing_field_names.py
+++ b/test/krrood_test/dataset/clashing_field_names.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional
+from uuid import UUID
+
+@dataclass
+class ClashingTarget:
+    id: UUID
+
+@dataclass
+class ClashingEntity:
+    clashing_target_id: UUID
+    clashing_target: Optional[ClashingTarget] = field(default=None, repr=False)

--- a/test/krrood_test/test_ormatic/test_eql.py
+++ b/test/krrood_test/test_ormatic/test_eql.py
@@ -233,7 +233,7 @@ def test_equal(session, database):
 
     query_by_hand = select(FixedConnectionDAO).join(
         PrismaticConnectionDAO,
-        onclause=PrismaticConnectionDAO.child_id == FixedConnectionDAO.parent_id,
+        onclause=PrismaticConnectionDAO._child_id == FixedConnectionDAO._parent_id,
     )
 
     assert len(session.scalars(query_by_hand).all()) == 1
@@ -297,13 +297,13 @@ def test_complicated_equal(session, database):
         select(ContainerDAO)
         .join(
             prismatic_alias,
-            onclause=prismatic_alias.parent_id == ContainerDAO.database_id,
+            onclause=prismatic_alias._parent_id == ContainerDAO.database_id,
         )
         .join(
-            drawer_alias, onclause=prismatic_alias.child_id == drawer_alias.database_id
+            drawer_alias, onclause=prismatic_alias._child_id == drawer_alias.database_id
         )
-        .join(fixed_alias, onclause=fixed_alias.parent_id == drawer_alias.database_id)
-        .join(handle_alias, onclause=fixed_alias.child_id == handle_alias.database_id)
+        .join(fixed_alias, onclause=fixed_alias._parent_id == drawer_alias.database_id)
+        .join(handle_alias, onclause=fixed_alias._child_id == handle_alias.database_id)
         .with_only_columns(drawer_alias)
     )
 
@@ -819,12 +819,12 @@ def test_set_of_multi_variable(session, database):
         select(ContainerDAO, HandleDAO, FixedConnectionDAO, PrismaticConnectionDAO)
         .join(
             FixedConnectionDAO,
-            onclause=FixedConnectionDAO.parent_id == ContainerDAO.database_id,
+            onclause=FixedConnectionDAO._parent_id == ContainerDAO.database_id,
         )
-        .join(HandleDAO, onclause=FixedConnectionDAO.child_id == HandleDAO.database_id)
+        .join(HandleDAO, onclause=FixedConnectionDAO._child_id == HandleDAO.database_id)
         .join(
             PrismaticConnectionDAO,
-            onclause=PrismaticConnectionDAO.child_id == ContainerDAO.database_id,
+            onclause=PrismaticConnectionDAO._child_id == ContainerDAO.database_id,
         )
     )
     assert str(translator.sql_query) == str(expected)
@@ -868,7 +868,7 @@ def test_set_of_move_action_transitive(session):
         grasp_alias.approach_direction,
         grasp_alias.manipulation_offset,
     ).join(
-        grasp_alias, onclause=grasp_alias.database_id == MoveActionDAO.grasp_config_id
+        grasp_alias, onclause=grasp_alias.database_id == MoveActionDAO._grasp_config_id
     )
 
     assert str(translator.sql_query) == str(expected)
@@ -897,7 +897,7 @@ def test_set_of_with_where(session):
         select(KRROODPoseDAO)
         .join(
             position_alias,
-            onclause=position_alias.database_id == KRROODPoseDAO.position_id,
+            onclause=position_alias.database_id == KRROODPoseDAO._position_id,
         )
         .with_only_columns(
             position_alias.x,
@@ -943,8 +943,8 @@ def test_set_of_same_table_twice(session):
     sql = str(translator.sql_query)
     assert "FixedConnectionDAO" in sql
     assert sql.count("JOIN") >= 2
-    assert "parent_id" in sql
-    assert "child_id" in sql
+    assert "_parent_id" in sql
+    assert "_child_id" in sql
     assert str(ContainerDAO.__tablename__) in sql
 
 
@@ -996,11 +996,11 @@ def test_plan_like_query(session):
         )
         .join(
             GraspConfigDAO,
-            onclause=GraspConfigDAO.database_id == MoveActionDAO.grasp_config_id,
+            onclause=GraspConfigDAO.database_id == MoveActionDAO._grasp_config_id,
         )
         .join(
             FixedConnectionDAO,
-            onclause=FixedConnectionDAO.parent_id == MoveActionDAO.grasp_config_id,
+            onclause=FixedConnectionDAO._parent_id == MoveActionDAO._grasp_config_id,
         )
         .where(MoveActionDAO.robot_x > 0.0)
     )
@@ -1140,7 +1140,7 @@ def test_big_query_select_part(session):
         )
         .join(
             grasp_alias,
-            onclause=grasp_alias.database_id == MoveActionDAO.grasp_config_id,
+            onclause=grasp_alias.database_id == MoveActionDAO._grasp_config_id,
         )
         .where(grasp_alias.rotate_gripper < 0.9)
         .order_by(MoveActionDAO.robot_x)
@@ -1421,7 +1421,7 @@ def test_exists_in_where_clause(session, database):
     FROM MoveActionDAO
     WHERE EXISTS (
         SELECT 1 FROM GraspConfigDAO
-        WHERE MoveActionDAO.grasp_config_id = GraspConfigDAO.database_id
+        WHERE MoveActionDAO._grasp_config_id = GraspConfigDAO.database_id
     )
 
     so only MoveActions that have an associated GraspConfig are returned.

--- a/test/krrood_test/test_ormatic/test_field_name_clash.py
+++ b/test/krrood_test/test_ormatic/test_field_name_clash.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import sqlalchemy
+from ..dataset.ormatic_interface import ClashingEntityDAO, ClashingTargetDAO
+
+def test_duplicate_column():
+    """Test that clashing field names do not cause duplicate columns or shadowing."""
+    expected_columns = {"database_id", "clashing_target_id", "polymorphic_type", "_clashing_target_id"}
+    actual_columns = set(ClashingEntityDAO.__table__.columns.keys())
+    assert expected_columns.issubset(actual_columns), (
+        f"Missing columns in ClashingEntityDAO. Expected at least {expected_columns}, found {actual_columns}"
+    )
+
+    expected_target_columns = {"database_id", "id", "polymorphic_type"}
+    actual_target_columns = set(ClashingTargetDAO.__table__.columns.keys())
+    assert expected_target_columns.issubset(actual_target_columns), (
+        f"Missing columns in ClashingTargetDAO. Expected at least {expected_target_columns}, found {actual_target_columns}"
+    )
+
+    column = ClashingEntityDAO.__table__.columns["clashing_target_id"]
+    assert not isinstance(column.type, sqlalchemy.Integer), (
+        f"Column 'clashing_target_id' in ClashingEntityDAO has type {column.type}, "
+        "which suggests it was shadowed by the automatically generated foreign key."
+    )

--- a/test/krrood_test/test_ormatic/test_typevar_field.py
+++ b/test/krrood_test/test_ormatic/test_typevar_field.py
@@ -12,7 +12,7 @@ def test_typevar_field_dao_generation():
     """
     mapper = inspect(TypeVarFieldHolderDAO)
     assert hasattr(
-        TypeVarFieldHolderDAO, "typed_field_id"
+        TypeVarFieldHolderDAO, "_typed_field_id"
     ), "TypeVarFieldHolderDAO should have a typed_field_id column"
     assert (
         "typed_field" in mapper.relationships


### PR DESCRIPTION
No name clashes anymore between dataclasses that define _id fields and ormatics generated fields