### PR TITLE
Keep Motion server's goal out of rclpy thread, abort a superseded goal in rclpy's terms

### DIFF
--- a/giskardpy/src/giskardpy/middleware/ros2/action_server.py
+++ b/giskardpy/src/giskardpy/middleware/ros2/action_server.py
@@ -39,14 +39,43 @@ class GoalOutcome(Enum):
     def report_to(self, goal_handle: ServerGoalHandle) -> None:
         """
         Transition the goal handle into the state matching this outcome.
+
+        rclpy allows the canceled transition only for a goal whose client asked to
+        cancel it. A goal that was superseded by a newer one is therefore aborted in
+        rclpy's terms; its result still reports the cancellation.
         """
         match self:
             case GoalOutcome.SUCCEEDED:
                 goal_handle.succeed()
             case GoalOutcome.ABORTED:
                 goal_handle.abort()
-            case GoalOutcome.CANCELED:
+            case GoalOutcome.CANCELED if goal_handle.is_cancel_requested:
                 goal_handle.canceled()
+            case GoalOutcome.CANCELED:
+                goal_handle.abort()
+
+
+@dataclass
+class GoalAnswer:
+    """
+    The motion server's answer to one goal, handed back to the rclpy thread that waits
+    for it.
+    """
+
+    goal_id: int
+    """
+    Identifier of the answered goal in logs and feedback.
+    """
+
+    result_message: Any
+    """
+    Result of the answered goal.
+    """
+
+    outcome: GoalOutcome
+    """
+    How the answered goal ended.
+    """
 
 
 @dataclass
@@ -55,9 +84,12 @@ class ActionServerHandler:
     Hands goals from rclpy's executor threads over to the thread that runs the motion
     server.
 
-    ``execute_cb`` runs on an rclpy executor thread and blocks on a queue, while the
-    motion server polls :meth:`has_goal` and answers with :meth:`send_result`. Goal
-    execution therefore stays on the motion server's own thread.
+    :meth:`execute_callback` runs on an rclpy executor thread and blocks on a queue,
+    while the motion server polls :meth:`has_goal` and answers with :meth:`send_result`.
+    Goal execution therefore stays on the motion server's own thread, and so does every
+    change to the current goal: the motion server resets the handler before it releases
+    an answer, so the rclpy thread never writes to a goal the motion server may already
+    have moved on from.
     """
 
     action_name: str
@@ -125,12 +157,15 @@ class ActionServerHandler:
             cancel_callback=self.cancel_callback,
         )
 
-    def loginfo(self, message: str) -> None:
+    def loginfo(self, message: str, goal_id: int | None = None) -> None:
         """
-        Log a message tagged with the action name and the current goal id.
+        Log a message tagged with the action name and a goal id, the current goal's
+        unless another is given.
         """
+        if goal_id is None:
+            goal_id = self.goal_id
         rospy.get_node().get_logger().info(
-            f"{self.action_name}(Goal #{self.goal_id}): {message}"
+            f"{self.action_name}(Goal #{goal_id}): {message}"
         )
 
     def default_goal_callback(self, goal_request: Any) -> GoalResponse:
@@ -154,38 +189,16 @@ class ActionServerHandler:
 
     async def execute_callback(self, goal_handle: ServerGoalHandle) -> Any:
         """
-        Queue the goal for the motion server thread and wait for its result.
+        Queue the goal for the motion server thread, wait for its answer and tell rclpy
+        how it ended.
         """
         while self.goal_handle is not None:
             sleep(0.1)
         self.goal_queue.put(goal_handle)
-        result_msg = self.result_queue.get()
-        self.loginfo("Sending response.")
-        outcome = self.outcome
-        self.goal_msg = None
-        self.goal_handle = None
-        self.result_message = None
-        self.cancel_requested = False
-        self.outcome = None
-        self.report_outcome(goal_handle, outcome)
-        return result_msg
-
-    def report_outcome(
-        self, goal_handle: ServerGoalHandle, outcome: GoalOutcome | None
-    ) -> None:
-        """
-        Tell rclpy how the goal ended.
-
-        The handler releases the goal before this runs, so that the next goal waiting in
-        :meth:`execute_cb` is not blocked while rclpy transitions this one.
-
-        :raises MissingGoalOutcomeError: If the goal is answered without an outcome.
-        """
-        if outcome is None:
-            raise MissingGoalOutcomeError(
-                action_server_name=self.action_name, goal_id=self.goal_id
-            )
-        outcome.report_to(goal_handle)
+        answer: GoalAnswer = self.result_queue.get()
+        self.loginfo("Sending response.", goal_id=answer.goal_id)
+        answer.outcome.report_to(goal_handle)
+        return answer.result_message
 
     def accept_goal(self) -> None:
         """
@@ -239,9 +252,29 @@ class ActionServerHandler:
 
     def send_result(self) -> None:
         """
-        Hand the result back to the waiting rclpy executor thread.
+        Hand the result back to the waiting rclpy executor thread and forget the goal.
+
+        The handler is reset before the answer is released, so that the next goal can be
+        accepted the moment this one is answered.
+
+        :raises MissingGoalOutcomeError: If the goal is answered without an outcome.
+        :raises MissingActionResultError: If the goal is answered without a result.
         """
-        self.result_queue.put(self.result_message)
+        if self.outcome is None:
+            raise MissingGoalOutcomeError(
+                action_server_name=self.action_name, goal_id=self.goal_id
+            )
+        answer = GoalAnswer(
+            goal_id=self.goal_id,
+            result_message=self.result_message,
+            outcome=self.outcome,
+        )
+        self.goal_msg = None
+        self.goal_handle = None
+        self.result_message = None
+        self.cancel_requested = False
+        self.outcome = None
+        self.result_queue.put(answer)
 
     def is_cancel_requested(self) -> bool:
         """

--- a/test/giskardpy_test/test_ros2_stuff/test_action_server.py
+++ b/test/giskardpy_test/test_ros2_stuff/test_action_server.py
@@ -1,5 +1,8 @@
+import asyncio
 from dataclasses import dataclass, field
-from typing import List
+from threading import Thread
+from time import sleep
+from typing import Any, List
 
 import pytest
 
@@ -18,8 +21,16 @@ class HandlerWithoutRosAdvertisement(ActionServerHandler):
     Exercises the handler's goal bookkeeping without advertising a ROS action.
     """
 
+    messages: List[str] = field(default_factory=list)
+    """
+    Everything the handler logged, instead of writing it to a ROS logger.
+    """
+
     def __post_init__(self):
         pass
+
+    def loginfo(self, message: str, goal_id: int | None = None) -> None:
+        self.messages.append(message)
 
 
 @dataclass
@@ -31,6 +42,16 @@ class GoalStateRecorder:
     transitions: List[str] = field(default_factory=list)
     """
     The name of every transition that was requested, in order.
+    """
+
+    request: Any = None
+    """
+    The goal message this handle carries.
+    """
+
+    is_cancel_requested: bool = False
+    """
+    Whether the client asked rclpy to cancel this goal.
     """
 
     def succeed(self) -> None:
@@ -62,12 +83,20 @@ def test_aborted_is_reported_as_abort():
     assert goal_handle.transitions == ["abort"]
 
 
-def test_canceled_is_reported_as_cancellation():
-    goal_handle = GoalStateRecorder()
+def test_a_goal_its_client_asked_to_cancel_is_reported_as_canceled():
+    goal_handle = GoalStateRecorder(is_cancel_requested=True)
 
     GoalOutcome.CANCELED.report_to(goal_handle)
 
     assert goal_handle.transitions == ["canceled"]
+
+
+def test_a_goal_superseded_by_a_newer_one_is_reported_as_aborted():
+    goal_handle = GoalStateRecorder(is_cancel_requested=False)
+
+    GoalOutcome.CANCELED.report_to(goal_handle)
+
+    assert goal_handle.transitions == ["abort"]
 
 
 def test_every_outcome_reports_exactly_one_transition():
@@ -87,9 +116,10 @@ def test_answering_a_goal_without_an_outcome_reports_which_goal_it_was():
         action_name="giskard/command", action_type=None
     )
     handler.goal_id = 3
+    handler.result_message = "result"
 
     with pytest.raises(MissingGoalOutcomeError) as error:
-        handler.report_outcome(GoalStateRecorder(), None)
+        handler.send_result()
 
     assert error.value.action_server_name == handler.action_name
     assert error.value.goal_id == handler.goal_id
@@ -130,3 +160,86 @@ def test_missing_result_message_names_the_action_server_and_the_goal():
 
     assert "'giskard/command'" in str(error)
     assert "#3" in str(error)
+
+
+# %% handing a goal over between the rclpy thread and the motion server thread
+
+
+def answer_the_next_goal(
+    handler: ActionServerHandler, outcome: GoalOutcome, result: Any
+) -> None:
+    """
+    Do what the motion server does for one goal: accept it and answer it.
+    """
+    while not handler.has_goal():
+        sleep(0.001)
+    handler.accept_goal()
+    handler.outcome = outcome
+    handler.result_message = result
+    handler.send_result()
+
+
+def test_answering_a_goal_resets_the_handler_before_the_answer_is_released():
+    handler = HandlerWithoutRosAdvertisement(
+        action_name="giskard/command", action_type=None
+    )
+    goal_handle = GoalStateRecorder(request="goal")
+    handler.goal_queue.put(goal_handle)
+    handler.accept_goal()
+    handler.cancel_requested = True
+    handler.set_canceled()
+    handler.result_message = "result"
+
+    handler.send_result()
+
+    assert handler.goal_handle is None
+    assert handler.goal_msg is None
+    assert handler.cancel_requested is False
+    assert handler.outcome is None
+    with pytest.raises(MissingActionResultError):
+        handler.result_message
+
+
+def test_the_callback_returns_the_result_and_reports_the_outcome_of_its_goal():
+    handler = HandlerWithoutRosAdvertisement(
+        action_name="giskard/command", action_type=None
+    )
+    goal_handle = GoalStateRecorder(request="goal")
+    returned: List[Any] = []
+    callback = Thread(
+        target=lambda: returned.append(
+            asyncio.run(handler.execute_callback(goal_handle))
+        ),
+        daemon=True,
+    )
+    callback.start()
+
+    answer_the_next_goal(handler, GoalOutcome.SUCCEEDED, "result")
+    callback.join(timeout=5)
+
+    assert returned == ["result"]
+    assert goal_handle.transitions == ["succeed"]
+
+
+def test_a_goal_accepted_while_the_previous_one_is_being_answered_is_kept():
+    """
+    The rclpy thread answering the previous goal must not touch the goal the motion
+    server has moved on to, however late it runs.
+    """
+    handler = HandlerWithoutRosAdvertisement(
+        action_name="giskard/command", action_type=None
+    )
+    previous = GoalStateRecorder(request="previous")
+    callback = Thread(
+        target=lambda: asyncio.run(handler.execute_callback(previous)), daemon=True
+    )
+    callback.start()
+    answer_the_next_goal(handler, GoalOutcome.CANCELED, "result")
+    following = GoalStateRecorder(request="following")
+    handler.goal_queue.put(following)
+    handler.accept_goal()
+
+    callback.join(timeout=5)
+
+    assert handler.goal_handle is following
+    assert handler.goal_msg == following.request


### PR DESCRIPTION
Keep the motion server's goal out of the rclpy thread's hands, and abort a superseded goal in rclpy's terms

Two defects in ActionServerHandler, both hit the moment a new goal arrives while another one runs, which is what dragging the interactive marker twice does.

The rclpy thread that answered the previous goal reset the handler's current goal after the motion server thread may already have accepted the next one, so the motion server read a None goal message, failed, then failed again publishing feedback for a goal handle that was gone, and giskard died. The motion server now resets the handler itself, before it releases a GoalAnswer carrying the result, the outcome and the goal id; the rclpy thread only reads that answer and reports it.

A goal canceled because a newer one superseded it was reported to rclpy as canceled, a transition rclpy allows only from CANCELING, which needs a client's cancel request, so every supersede raised an RCLError in the execute callback. Such a goal is now aborted in rclpy's terms; its result payload still carries the ExecutionCanceledException.

Made with the help of Claude.
Claude-Session: https://claude.ai/code/session_01GCgvcENQygfenibC73KQ1n