### PR TITLE
Store a field whose generic type is left unparameterized as the value it is

### DIFF
--- a/krrood/src/krrood/ormatic/wrapped_table.py
+++ b/krrood/src/krrood/ormatic/wrapped_table.py
@@ -633,6 +633,24 @@ class WrappedTable(TableLike):
 
         self.create_mapper_args()
 
+    def is_stored_as_a_value(self, type_endpoint: Type) -> bool:
+        """
+        Whether a custom type keeps this type in its owner's own row, rather than a table
+        of its own holding it.
+
+        A value is written whole - a :class:`SubclassJSONSerializer
+        <krrood.adapters.json_serializer.SubclassJSONSerializer>` names its own subclass
+        in the JSON it writes - so a free type parameter leaves nothing undecided about
+        how to store it.
+
+        :param type_endpoint: The type a field resolves to.
+        :return: True if a custom type stores it and no table maps it.
+        """
+        return (
+            type_endpoint not in self.ormatic.mapped_classes
+            and type_endpoint in self.ormatic.type_mappings
+        )
+
     def parse_field(self, wrapped_field: WrappedField):
         """
         Parses a given `WrappedField` and determines its type or relationship to create
@@ -654,6 +672,7 @@ class WrappedTable(TableLike):
         if (
             wrapped_field.is_underspecified_generic
             and isclass(type_endpoint)
+            and not self.is_stored_as_a_value(type_endpoint)
             and not any(
                 [
                     am

--- a/test/krrood_test/conftest.py
+++ b/test/krrood_test/conftest.py
@@ -38,11 +38,14 @@ from .dataset.example_classes import (
     ChildNotMapped,
     ConceptType,
     JSONSerializableClass,
+    GenericJSONSerializableClass,
+    TextJSONSerializableClass,
 )
 from .dataset.role_and_ontology import (
     university_ontology_like_classes_without_descriptors,
     role_takers_in_another_module,
     classes_for_testing_role_recursion_error,
+    roles_over_a_value_stored_as_json,
 )
 from .dataset.semantic_world_like_classes import *
 from .test_eql.conf.world.doors_and_drawers import DoorsAndDrawersWorld
@@ -77,6 +80,7 @@ def generate_sqlalchemy_interface():
     )
     all_classes |= set(classes_of_module(role_takers_in_another_module))
     all_classes |= set(classes_of_module(classes_for_testing_role_recursion_error))
+    all_classes |= set(classes_of_module(roles_over_a_value_stored_as_json))
     all_classes |= set(classes_of_module(alternative_mappings_construction_order))
     all_classes |= set(classes_of_module(clashing_field_names))
     all_classes |= {Symbol, Role}
@@ -84,6 +88,7 @@ def generate_sqlalchemy_interface():
     # remove classes that don't need persistence
     all_classes -= {HasType, HasTypes, ContainsType}
     all_classes -= {NotMappedParent, ChildNotMapped, JSONSerializableClass}
+    all_classes -= {GenericJSONSerializableClass, TextJSONSerializableClass}
 
     # only keep dataclasses
     all_classes = {

--- a/test/krrood_test/dataset/example_classes.py
+++ b/test/krrood_test/dataset/example_classes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from abc import ABC
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
@@ -25,6 +26,7 @@ from krrood.ormatic.data_access_objects.alternative_mappings import (
     AlternativeMapping,
     T,
 )
+from krrood.patterns.subclass_safe_generic import SubClassSafeGeneric
 from krrood.symbol_graph.symbol_graph import Symbol
 from krrood import logger
 
@@ -638,6 +640,50 @@ class JSONSerializableClass(SubclassJSONSerializer):
 class JSONWrapper:
     json_serializable_object: JSONSerializableClass
     more_objects: List[JSONSerializableClass] = field(default_factory=list)
+
+
+JSONSerializableAnswer = TypingTypeVar("JSONSerializableAnswer")
+"""
+What a :class:`GenericJSONSerializableClass` answers with.
+"""
+
+
+@dataclass
+class GenericJSONSerializableClass(
+    SubclassJSONSerializer, Generic[JSONSerializableAnswer], SubClassSafeGeneric, ABC
+):
+    """
+    A JSON-serializable base that is used as a field type without binding its parameter,
+    so the field says only that some subclass of it is stored.
+    """
+
+    label: str = ""
+    """
+    What this value stands for.
+    """
+
+    def to_json(self) -> Dict[str, Any]:
+        return {**super().to_json(), "label": to_json(self.label)}
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any], **kwargs) -> Self:
+        return cls(label=from_json(data["label"]))
+
+
+@dataclass
+class TextJSONSerializableClass(GenericJSONSerializableClass[str]): ...
+
+
+@dataclass
+class GenericJSONWrapper:
+    """
+    Holds the generic JSON value under a field that leaves the parameter free.
+    """
+
+    json_serializable_object: GenericJSONSerializableClass
+    """
+    The value, whose own JSON names which subclass it is.
+    """
 
 
 @dataclass

--- a/test/krrood_test/dataset/role_and_ontology/roles_over_a_value_stored_as_json.py
+++ b/test/krrood_test/dataset/role_and_ontology/roles_over_a_value_stored_as_json.py
@@ -1,0 +1,24 @@
+"""
+A role whose taker is kept as a value in the role's own row rather than in a table of
+its own, and whose type is a generic left unparameterized.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from krrood.patterns.role import Role
+from krrood.symbol_graph.symbol_graph import Symbol
+from test.krrood_test.dataset.example_classes import GenericJSONSerializableClass
+
+
+@dataclass(eq=False)
+class RoleOverAValueStoredAsJson(Role[GenericJSONSerializableClass], Symbol):
+    """
+    Plays a part that the value it is about cannot play by itself.
+    """
+
+    note: str = ""
+    """
+    What this role records about its taker.
+    """

--- a/test/krrood_test/test_ormatic/test_generic_json_field.py
+++ b/test/krrood_test/test_ormatic/test_generic_json_field.py
@@ -1,0 +1,33 @@
+"""
+A field whose type is a generic left unparameterized still has one thing to store where
+the ORM keeps that type as a value: the value's own JSON names which subclass it is.
+"""
+
+from sqlalchemy import select
+
+from krrood.ormatic.data_access_objects.helper import to_dao
+from ..dataset.example_classes import GenericJSONWrapper, TextJSONSerializableClass
+from ..dataset.ormatic_interface import GenericJSONWrapperDAO
+
+
+def test_a_field_typed_as_an_unparameterized_generic_is_mapped():
+    """
+    The free type parameter says nothing about how the value is stored, so the field
+    gets its column rather than being dropped as underspecified.
+    """
+    assert hasattr(GenericJSONWrapperDAO, "json_serializable_object")
+
+
+def test_a_value_stored_as_json_under_an_unparameterized_generic_field_round_trips(
+    session, database
+):
+    """
+    The subclass that was stored comes back, not only the base the field is typed with.
+    """
+    value = TextJSONSerializableClass(label="colours")
+    session.add(to_dao(GenericJSONWrapper(json_serializable_object=value)))
+    session.commit()
+
+    restored = session.scalars(select(GenericJSONWrapperDAO)).one().from_dao()
+
+    assert restored.json_serializable_object == value

--- a/test/krrood_test/test_patterns/test_role_persistence.py
+++ b/test/krrood_test/test_patterns/test_role_persistence.py
@@ -1,0 +1,46 @@
+"""
+What a role read back out of the database still is.
+"""
+
+from sqlalchemy import select
+
+from krrood.ormatic.data_access_objects.helper import to_dao
+from krrood.patterns.role import Role
+from ..dataset.example_classes import TextJSONSerializableClass
+from ..dataset.ormatic_interface import RoleOverAValueStoredAsJsonDAO
+from ..dataset.role_and_ontology.roles_over_a_value_stored_as_json import (
+    RoleOverAValueStoredAsJson,
+)
+
+
+def test_a_role_read_back_from_the_database_keeps_the_taker_it_was_stored_with(
+    session, database
+):
+    """
+    A role taker kept as a value rather than in a table of its own is still what the
+    restored role is about.
+    """
+    taker = TextJSONSerializableClass(label="colours")
+    session.add(to_dao(RoleOverAValueStoredAsJson(role_taker=taker, note="asked")))
+    session.commit()
+
+    restored = session.scalars(select(RoleOverAValueStoredAsJsonDAO)).one().from_dao()
+
+    assert restored.role_taker == taker
+    assert restored.note == "asked"
+
+
+def test_a_role_read_back_from_the_database_is_registered_for_its_taker(
+    session, database
+):
+    """
+    Reconstruction runs the role's ``__post_init__``, so the restored role answers a
+    membership query from its taker just as a constructed one does.
+    """
+    taker = TextJSONSerializableClass(label="colours")
+    session.add(to_dao(RoleOverAValueStoredAsJson(role_taker=taker, note="asked")))
+    session.commit()
+
+    restored = session.scalars(select(RoleOverAValueStoredAsJsonDAO)).one().from_dao()
+
+    assert Role.roles_for(restored.role_taker) == [restored]


### PR DESCRIPTION
ORMatic skipped every field whose type is a generic class with free type parameters, on the grounds that such a field says nothing about which table holds it. That is true only of a field the ORM stores in a table; where a custom type keeps the value in its owner's own row the free parameter decides nothing, because a SubclassJSONSerializer names its own subclass in the JSON it writes. Since the skip is the first branch parse_field tries, it won over the custom-type branch that would have made the column.

So the skip now makes an exception for a type a custom type already stores by value and no table maps, which is the one case where the parameter is free and the storage is still fully decided.

Found on an in-flight branch rather than here: a recorded query there is a Role[Question], and a Question is generic in the memory it is asked of and what it answers with, so the role's required role_taker was silently dropped from its table - nothing wrote the question, nothing read it back, and reconstruction then ran Role.__post_init__ on a role with no taker at all. The registry read all_role_takers, the property read self.role_taker, and the AttributeError that raised surfaced through Role.__getattr__ as an unrelated "AttributeError: all_role_takers", on a trial's round trip rather than anywhere near the field that was missing. Neither of those classes exists on main, which is why this is reproduced here against mimics instead.

Three tests pin it, each failing without the change: test_a_field_typed_as_an_unparameterized_generic_is_mapped and its round trip name the cause in test_ormatic, and test_role_persistence names what the generator's silence broke - a role read back out of the database keeps the taker it was stored with, and registers for it, so a membership query from the taker finds it. GenericJSONSerializableClass stands in for the generic JSON value and is left out of the mapped set the same way JSONSerializableClass already is, since the point is that it is stored as a value rather than in a table of its own.

Regenerating every ORM interface in the repository with and without this adds exactly one column to the branch that has such a field and changes nothing else; on main itself no interface changes at all, since no field of that shape exists here yet.

Made with the help of Claude

Claude-Session: https://claude.ai/code/session_0155Lgy4BZ7QcZHiRuxxJJyA