### PR TITLE
[Basstler] Fix plan_item_bootstrap.py's hardcoded item-field indent

### DIFF
--- a/.claude/hooks/plan_item_bootstrap.py
+++ b/.claude/hooks/plan_item_bootstrap.py
@@ -286,7 +286,12 @@ class ManifestKey(KeySpecification, Enum):
     The manifest's top-level list of items.
     """
 
-    def render(self, value: str, opening_the_item: bool = False) -> str:
+    def render(
+        self,
+        value: str,
+        opening_the_item: bool = False,
+        field_indent: str = ITEM_FIELD_INDENT,
+    ) -> str:
         """
         The manifest line setting this key to *value*, newline included.
 
@@ -295,9 +300,13 @@ class ManifestKey(KeySpecification, Enum):
         :param value: The value to write.
         :param opening_the_item: Whether this is the item block's first line, which
             carries the list marker instead of the key indent.
+        :param field_indent: The whitespace this item's own fields are indented by,
+            read from the block being edited rather than assumed, since a manifest
+            written before this module's own convention keeps whichever indentation
+            it already has.
         :return: The rendered line.
         """
-        prefix = ITEM_MARKER if opening_the_item else ITEM_FIELD_INDENT
+        prefix = ITEM_MARKER if opening_the_item else field_indent
         written = f'"{value}"' if self.style is ValueStyle.DOUBLE_QUOTED else value
         return f"{prefix}{self.key}: {written}\n"
 
@@ -910,6 +919,28 @@ def locate_item_block(
     )
 
 
+def existing_field_indent(manifest_lines: list[str], start: int, end: int) -> str:
+    """
+    The whitespace this item's own fields are indented by, in the manifest they live in.
+
+    Read from the block itself rather than assumed: a manifest written before
+    ``/plan-create``'s own convention keeps whichever indentation it already has, and a
+    fixed indent would silently nest a patched field under whichever key happens to
+    precede it instead of beside it.
+
+    :param manifest_lines: The manifest, split into lines.
+    :param start: The block's first line (the ``- id:`` line).
+    :param end: One past the block's last line.
+    :return: The leading whitespace of the block's second populated line, or this
+        module's own default when the block holds only its opening line.
+    """
+    for index in range(start + 1, end):
+        if manifest_lines[index].strip():
+            stripped = manifest_lines[index].lstrip(" ")
+            return manifest_lines[index][: len(manifest_lines[index]) - len(stripped)]
+    return ITEM_FIELD_INDENT
+
+
 def apply_item_fields(
     manifest_text: str,
     plan_identifier: str,
@@ -933,8 +964,9 @@ def apply_item_fields(
     """
     lines = manifest_text.split("\n")
     start, end = locate_item_block(lines, plan_identifier, item_identifier)
+    field_indent = existing_field_indent(lines, start, end)
     for manifest_key, value in values_by_key.items():
-        rendered = manifest_key.render(value).rstrip("\n")
+        rendered = manifest_key.render(value, field_indent=field_indent).rstrip("\n")
         existing = next(
             (
                 index

--- a/.claude/hooks/tests/fixtures/narrowly-indented-plan.yaml
+++ b/.claude/hooks/tests/fixtures/narrowly-indented-plan.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+id: narrow-plan
+title: "A plan whose items are not indented the way /plan-create writes them"
+default_repository: an-owner/a-repository
+tracking_issue: 1
+items:
+- id: an-item
+  title: "An item indented two spaces, not four"
+  branch: null
+  pull_request_number: null
+  track: a-track
+  depends_on: []
+  status: not_started

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -40,6 +40,7 @@ from plan_item_bootstrap import (
     UnknownPlanError,
     ValueStyle,
     WorkOpenRequest,
+    apply_item_fields,
     open_work,
     record_item,
 )
@@ -554,6 +555,49 @@ def test_a_rendered_field_line_matches_how_a_real_manifest_writes_it():
         manifest_line(ManifestKey.STATUS, ItemStatus.NOT_STARTED.value) in PLAN_MANIFEST
     )
     assert manifest_line(ManifestKey.TRACK, "a-track") in PLAN_MANIFEST
+
+
+NARROWLY_INDENTED_MANIFEST = """\
+schema_version: 1
+id: narrow-plan
+title: "A plan whose items are not indented the way /plan-create writes them"
+default_repository: an-owner/a-repository
+tracking_issue: 1
+items:
+- id: an-item
+  title: "An item indented two spaces, not four"
+  branch: null
+  pull_request_number: null
+  track: a-track
+  depends_on: []
+  status: not_started
+"""
+"""
+A manifest predating this module's own formatting convention: its items list has no
+indent before the ``-`` and its fields sit two spaces in, not the four
+``ITEM_FIELD_INDENT`` assumes.
+
+``icra-mechanism/plan.yaml`` on the personal-notes branch is written exactly this way.
+"""
+
+
+def test_patching_a_field_matches_the_items_own_indentation_rather_than_a_fixed_one():
+    """
+    A fixed indentation nests a patched field under whichever key happens to precede it.
+
+    instead of beside it, the moment a manifest's own indentation differs from the
+    module's assumed one - which stops the result parsing as YAML at all.
+    """
+    patched = apply_item_fields(
+        NARROWLY_INDENTED_MANIFEST,
+        "narrow-plan",
+        "an-item",
+        {ManifestKey.STATUS: ItemStatus.IN_PROGRESS.value},
+    )
+
+    item = yaml.safe_load(patched)["items"][0]
+    assert item["status"] == ItemStatus.IN_PROGRESS.value
+    assert item["title"] == "An item indented two spaces, not four"
 
 
 def test_a_key_quotes_its_own_value_when_its_style_says_to():

--- a/.claude/hooks/tests/test_plan_item_bootstrap.py
+++ b/.claude/hooks/tests/test_plan_item_bootstrap.py
@@ -557,21 +557,9 @@ def test_a_rendered_field_line_matches_how_a_real_manifest_writes_it():
     assert manifest_line(ManifestKey.TRACK, "a-track") in PLAN_MANIFEST
 
 
-NARROWLY_INDENTED_MANIFEST = """\
-schema_version: 1
-id: narrow-plan
-title: "A plan whose items are not indented the way /plan-create writes them"
-default_repository: an-owner/a-repository
-tracking_issue: 1
-items:
-- id: an-item
-  title: "An item indented two spaces, not four"
-  branch: null
-  pull_request_number: null
-  track: a-track
-  depends_on: []
-  status: not_started
-"""
+NARROWLY_INDENTED_MANIFEST = (
+    FIXTURES_DIRECTORY / "narrowly-indented-plan.yaml"
+).read_text()
 """
 A manifest predating this module's own formatting convention: its items list has no
 indent before the ``-`` and its fields sit two spaces in, not the four
@@ -595,9 +583,9 @@ def test_patching_a_field_matches_the_items_own_indentation_rather_than_a_fixed_
         {ManifestKey.STATUS: ItemStatus.IN_PROGRESS.value},
     )
 
-    item = yaml.safe_load(patched)["items"][0]
-    assert item["status"] == ItemStatus.IN_PROGRESS.value
-    assert item["title"] == "An item indented two spaces, not four"
+    item = yaml.safe_load(patched)[ManifestKey.ITEMS.key][0]
+    assert item[ManifestKey.STATUS.key] == ItemStatus.IN_PROGRESS.value
+    assert item[ManifestKey.TITLE.key] == "An item indented two spaces, not four"
 
 
 def test_a_key_quotes_its_own_value_when_its_style_says_to():


### PR DESCRIPTION
Found while kicking off `icra-mechanism`/`snapshot-working-memory`: `apply_item_fields()` in `.claude/hooks/plan_item_bootstrap.py` wrote a patched field at a hardcoded 4-space indent (`ITEM_FIELD_INDENT`), assuming every `plan.yaml` uses `/plan-create`'s own 2-space-before-`-`/4-space-field convention.

Full detail: https://github.com/AbdelrhmanBassiouny/cognitive_robot_abstract_machine/pull/302